### PR TITLE
Release info added from the features repo

### DIFF
--- a/releases/release-1.3/features-1.3.md
+++ b/releases/release-1.3/features-1.3.md
@@ -1,0 +1,153 @@
+|  **Item** | Cluster Federation |
+|  ------ | ------ |
+|  **Stage** | Alpha |
+|  **Status** | In Progress |
+|  **SIG** | ControlPlane |
+|  **Issue/PR links** | https://github.com/kubernetes/kubernetes/labels/area%2Fcluster-federation |
+|  **Dev Lead** | https://github.com/quinton-hoole  |
+|  **Assignee** | https://github.com/nikhiljindal  |
+|  **Entity** | Google |
+|  **Docs** | In Progress |
+
+|  **Item** | Devicemapper container fs usage |
+|  ------ | ------ |
+|  **Stage** | Stable (CAdvisor) |
+|  **Status** | Merged |
+|  **SIG** | Node |
+|  **Issue/PR Links** | https://github.com/google/cadvisor/pull/1204 |
+|  **Dev Lead** | https://github.com/pmorie |
+|  **Assignee** | https://github.com/vishh |
+|  **Entity** | Red Hat |
+|  **Docs** |  |
+
+|  **Item** | Init Containers |
+|  ------ | ------ |
+|  **Stage** | Alpha |
+|  **Status** | Merged |
+|  **SIG** | Node |
+|  **Issue/PR Links** | https://github.com/kubernetes/kubernetes/pull/23666 |
+|  **Dev Lead** | https://github.com/smarterclayton |
+|  **Assignee** | https://github.com/dchen1107 |
+|  **Entity** | Red Hat |
+|  **Docs** | Waiting for LGTM |
+
+|  **Item** | Master Metrics API |
+|  ------ | ------ |
+|  **Stage** | Stable |
+|  **Status** | Merged |
+|  **SIG** | ControlPlane |
+|  **Issue/PR Links** | https://github.com/kubernetes/kubernetes/issues/23376 |
+|  **Dev Lead** | https://github.com/piosz |
+|  **Assignee** | https://github.com/piosz |
+|  **Entity** | piosz |
+|  **Docs** | N/A |
+
+|  **Item** | Node Out-of-memory handling |
+|  ------ | ------ |
+|  **Stage** | Stable |
+|  **Status** | Merged |
+|  **SIG** | Node |
+|  **Issue/PR Links** |  |
+|  **Dev Lead** | dchen1107  |
+|  **Assignee** | derekwaynecarr |
+|  **Entity** | Google / Red Hat |
+|  **Docs** | Done |
+
+|  **Item** | OIDC client AuthProvider |
+|  ------ | ------ |
+|  **Stage** | Alpha |
+|  **Status** | Merged |
+|  **SIG** | Auth |
+|  **Issue/PR Links** | https://github.com/kubernetes/kubernetes/pull/25270 |
+|  **Dev Lead** | https://github.com/bobbyrullo |
+|  **Assignee** | https://github.com/yifan-gu |
+|  **Entity** | CoreOS |
+|  **Docs** | N/A |
+
+|  **Item** | OpenStack provider |
+|  ------ | ------ |
+|  **Stage** | Stable |
+|  **Status** | Merged |
+|  **SIG** | ControlPlane |
+|  **Issue/PR Links** | https://github.com/kubernetes/kubernetes/pull/21737 |
+|  **Dev Lead** | https://github.com/zreigz  |
+|  **Assignee** | https://github.com/quinton-hoole |
+|  **Entity** | quinton-hoole |
+|  **Docs** | Done |
+
+|  **Item** | Problem API |
+|  ------ | ------ |
+|  **Stage** | Beta (Kubernetes addon) |
+|  **Status** | In Progress |
+|  **SIG** | Node |
+|  **Issue/PR Links** | https://github.com/kubernetes/kubernetes/issues/23028 |
+|  **Dev Lead** | https://github.com/ |
+|  **Assignee** | https://github.com/ |
+|  **Entity** | Google |
+|  **Docs** | In Progress |
+
+|  **Item** | Reapers (Cascading Deletion) |
+|  ------ | ------ |
+|  **Stage** | Alpha |
+|  **Status** | Merged |
+|  **SIG** | API |
+|  **Issue/PR Links** | https://github.com/kubernetes/kubernetes/pull/23656 |
+|  **Dev Lead** | https://github.com/caesarxuchao |
+|  **Assignee** | https://github.com/lavalamp |
+|  **Entity** | Google |
+|  **Docs** | Not Started |
+
+|  **Item** | Rktnetes 1.0 |
+|  ------ | ------ |
+|  **Stage** | Stable |
+|  **Status** | Merged |
+|  **SIG** | Node |
+|  **Issue/PR Links** | https://github.com/kubernetes/kubernetes/issues?q=milestone%3Arktnetes-v1.0 |
+|  **Dev Lead** | https://github.com/yifan-gu |
+|  **Assignee** | https://github.com/yifan-gu |
+|  **Entity** | CoreOS |
+|  **Docs** | In Progress |
+
+|  **Item** | Role-base access control |
+|  ------ | ------ |
+|  **Stage** | Alpha |
+|  **Status** | In Progress |
+|  **SIG** | Auth |
+|  **Issue/PR links** | https://github.com/kubernetes/kubernetes/issues/23396 |
+|  **Dev Lead** | https://github.com/ericchiang |
+|  **Assignee** | https://github.com/erictune |
+|  **Entity** | CoreOS / RedHat |
+|  **Docs** | Waiting for LGTM |
+
+|  **Item** | Self-hosted Kubelet  |
+|  ------ | ------ |
+|  **Stage** | Alpha |
+|  **Status** | Merged |
+|  **SIG** | Node |
+|  **Issue/PR links** | https://github.com/kubernetes/kubernetes/pull/23343 |
+|  **Dev Lead** | https://github.com/aaronlevy |
+|  **Assignee** | https://github.com/vishh |
+|  **Entity** | CoreOS |
+|  **Docs** | N/A |
+
+|  **Item** | Single-node DevCluster |
+|  ------ | ------ |
+|  **Stage** | Alpha (Pre-release v0.3.0 - Minikube) |
+|  **Status** | In Progress |
+|  **SIG** | Minikube |
+|  **Issue/PR links** | https://github.com/kubernetes/minikube |
+|  **Dev Lead** | https://github.com/dlorenc |
+|  **Assignee** | https://github.com/dlorenc |
+|  **Entity** | Google / CoreOS |
+|  **Docs** | https://github.com/kubernetes/minikube |
+
+|  **Item** | Stateful services (PetSet) |
+|  ------ | ------ |
+|  **Stage** | Alpha |
+|  **Status** | In Progress |
+|  **SIG** | Cluster |
+|  **Issue/PR links** | https://github.com/kubernetes/kubernetes/pull/18016 |
+|  **Dev Lead** | https://github.com/smarterclayton |
+|  **Assignee** | https://github.com/thockin |
+|  **Entity** | Red Hat / Google |
+|  **Docs** | Not started |

--- a/releases/release-1.3/release-1.3.md
+++ b/releases/release-1.3/release-1.3.md
@@ -1,0 +1,80 @@
+_(approved; last update 5/19)_
+
+#Learnings from 1.2
+The k8s 1.2 release was laid out approximately as:
+- 8w of coding, then declare "feature complete" (no major features or refactors allowed after here)
+- 2w of bug fixes and testing, then release last Alpha (head in code slush these two weeks)
+- 2w of bug fixes and testing, then declare Beta, release and branch (head in code slush these two weeks)
+- 2w of bug fixes and docs work post Beta, then release 1.2 Final
+
+None of these dates were considered "hard dates", but more of a guideline towards a 3 month release cycle.
+
+In reality, many features were not finished in time for the feature complete date, which slipped about 2w (and even then still had some features finishing up after).  The branch/beta date ended up slipping 2w in line.  The final release ended up slipping 1.5w, so was brought in by a couple of days.  We ended up slipping many docs updates past the binary release.
+
+In 1.3, we should probably make a few adjustments:
+- check back on 1.3 blocking feature status more often (and get help from others as needed)
+- minimize the list of 1.3 blocking features (nail those, and ship 1.3 with them + whatever else is done, but don't hold the release for anything not deemed blocking)
+- add a week to feature coding at the expense of one bugfix week (as we continue to improve testing and stay on top of test flakes during the milestone, this should be ok)
+
+#Proposed timeline
+Kubernetes 1.2 shipped mid-March, so to maintain our 3m minor revision trend, we should aim for 1.3 in mid to late June.
+
+That would look like:
+- 9w of coding, then declare "feature complete" (no major features or refactors allowed after here)
+- 1w of bug fixes and testing, then release last Alpha (head in code slush this week)
+- 2w of bug fixes and testing, then declare Beta, release and branch (head in code slush these two weeks)
+- 2w of bug fixes and docs work post Beta, then release 1.3 Final
+
+###Mar 21 - Mar 25
+- Feature coding week 1
+
+###Mar 28 - Apr 1
+- Feature coding week 2
+
+###Apr 4 - Apr 8
+- Feature coding week 3
+- check in on status all 1.3 blocking features in Community Meeting
+
+###Apr 11 - Apr 15 
+- Feature coding week 4
+
+###Apr 18 - Apr 22
+- Feature coding week 5
+
+###Apr 25 - Apr 29
+- Feature coding week 6
+- check in on status all 1.3 blocking features in Community Meeting, get help for some if needed
+
+###May 2 - May 6
+- Feature coding week 7
+
+###May 9 - May 13
+- Feature coding week 8
+- check in on status all 1.3 blocking features in Community Meeting, get help for some if needed
+
+###May 16 - May 20
+- Feature coding week 9
+- Feature Complete due end of day May 20 (slipped by one business day to May 23)
+
+###May 23 - May 27
+- Feature Complete due end of day May 23
+- Bugfix week 1
+- enter code slush
+- cut final Alpha end of week
+
+###May 30 - Jun 3
+- Bugfix week 2
+- US holiday on Mon May 30
+
+###Jun 6 - Jun 10
+- Bugfix week 3
+- branch, cut Beta end of week, remove code slush on head
+
+###Jun 13 - Jun 17
+- Bugfix week 4
+
+###Jun 20 - Jun 24
+- release 1.3 Final
+
+#Key features
+[Feature tracking spreadsheet](https://docs.google.com/spreadsheets/d/1rrt179VjClAfMYnh8NwC_RLJbdI5j6zcVkW1z14vPR0)

--- a/releases/release-1.4/Release-1.4.md
+++ b/releases/release-1.4/Release-1.4.md
@@ -1,0 +1,48 @@
+#A Brief History
+- Kubernetes 1.0 - July 21, 2015
+- Kubernetes 1.1 - November 9, 2015 (+3mo19d or 15w6d)
+- Kubernetes 1.2 - March 17, 2016 (+4mo8d or 18w3d - included holidays)
+- Kubernetes 1.3 - July 1, 2016 (+3mo14d or 15w1d)
+
+#Proposed timeline
+Kubernetes 1.3 ships June 24 ([schedule](https://github.com/kubernetes/kubernetes/wiki/Release-1.3)) (actual was July 1).  To land 2 more releases in 2016, we should aim for 1.5 in early December (late December is a holiday period), and work back.  December 9 is a decent choice (and allows slip without landing during the holidays, if absolutely necessary).
+
+A proposal so far has been to not immediately enter 1.4 after 1.3, and to actually build in a week for focusing on flakes and testing across our dev community.
+
+To fit these milestones in, the best format appears to be 7w of coding, 4w of stabilization/release.  1.3 was 9w coding and 5w of stabilization.
+
+Going from 14w to 11w per release seems feasible if we hold feature complete strongly (as we did for the first time in 1.3) and we make significant test/flake/queue investments (which we plan to do/are doing).  It also means if a given feature misses feature complete for 1.4, 1.5 isn't quite as far away, so it's a bit less painful.
+
+###1.4 Overview
+- June 27 flake week (1w)
+- July 3 coding start (7w)
+- Aug 19 feature complete, move to bugfix (4w) (Aug 17 update, FC moved one business day to Aug 22)
+- Sept 20 release
+
+###1.5 Overview
+- Sept 19 coding start (7w)
+- Nov 7 feature complete, move to bugfix (5w, includes US Thanksgiving holiday)
+- Dec 8 release
+
+##1.4 Details
+
+###June 27 - July 1
+- Flake and test fix-it week
+
+###July 3 - Aug 19
+- 7 week coding period
+- Release 1.4 alphas every 2 weeks
+
+###Aug 22 - Sept 2
+- Enter code slush on head, no more features or major refactors
+- Fix bugs and run tests
+- Start Milestone Burndown meetings
+- Branch and cut Beta release on Sept 2
+
+###Sept 5 - Sept 20
+- Open head for 1.5 work on Sept 5, after branch
+- Fix bugs and run tests, update docs
+- Release 1.4 on Sept 20
+
+#Key features
+[Feature tracking spreadsheet](https://docs.google.com/spreadsheets/d/1MeTQbtSiTCoQ74zjEGRI1rXRSP0Tzmo9-kMJSK_HGoA/edit?usp=sharing)

--- a/releases/release-1.5/release-1.5.md
+++ b/releases/release-1.5/release-1.5.md
@@ -1,0 +1,59 @@
+# 1.5 Tenative Timeline
+*Approved at Aug 25 community meeting*
+
+### September 19 - Monday, November 7, 2016
+- [x] **Monday, September 19, 2016**
+  - 7 week coding period begins
+  - 1.5 alpha releases are cut every 2 weeks during this period.
+- [x] **Monday, October 10, 2016**
+  - *Feature freeze* begins
+    - All features that planned for v1.5 must be defined in the [features repository with the 1.5 milestone label](https://github.com/kubernetes/features/issues?q=is%3Aopen+is%3Aissue+milestone%3Av1.5) by this date.
+- [x] **Monday, November 7, 2016**
+  - Feature Complete Date
+    - Final day to merge non-bug related code changes for the v1.5 release.
+    - All feature code must be LGTMed with tests written and in the submit queue by 6 PM PST.
+
+### November 8 - November 28, 2016
+- [x] **Tuesday, November 8, 2016**
+  - *Code freeze* begins
+    - Only bug fixes with the `v1.5` milestone will be merged to `master` branch after this date.
+    - All other changes must go through the [exceptions process](https://github.com/kubernetes/features/blob/master/EXCEPTIONS.md)
+      - All requests for exception must be submitted by Nov 8, 6 PM PST.
+- [x] **Wednesday, November 9, 2016**
+  - [Milestone Burndown](https://groups.google.com/forum/#!forum/kubernetes-milestone-burndown) meetings begin
+    - All requests for exception will be reviewed and either approved or rejected during the first meeting.
+    - Requesters will be notified within 24 hours.
+- [x] **Monday, November 28, 2016**
+  - 1.5 release branch fast-forwarded to match `master` branch (picking up all changes merged since code freeze).
+
+### November 28, 2016 - December 12, 2016
+- [x] **Monday, November 28, 2016**
+  - `master` branch is opened for 1.6 work after 1.5 release branch has been fast-forwarded.
+  - All bug fixes for 1.5, after this point, must be manually cherry-picked to the 1.5 release branch.
+- [x] **Tuesday, November 29, 2016**
+  - Docs for all [1.5 features](https://github.com/kubernetes/features/issues?q=is%3Aopen+is%3Aissue+milestone%3Av1.5) should have PRs out for review.
+    - Include a link to the relevant 1.5 feature in the docs PR.
+    - Add a link to the docs PR in the [1.5 Feature Tracking Spreadsheet](https://docs.google.com/spreadsheets/d/1g9JU-67ncE4MHMeKnmslm-JO_aKeltv2kg_Dd6VFmKs/edit#gid=0).
+  - Release Notes for all [1.5 features](https://github.com/kubernetes/features/issues?q=is%3Aopen+is%3Aissue+milestone%3Av1.5) should have a "One Line Release Note Description" in the [1.5 Feature Tracking Spreadsheet](https://docs.google.com/spreadsheets/d/1g9JU-67ncE4MHMeKnmslm-JO_aKeltv2kg_Dd6VFmKs/edit#gid=0).
+- [x] **Friday, December 2, 2016**
+  - Docs PRs for all [1.5 features](https://github.com/kubernetes/features/issues?q=is%3Aopen+is%3Aissue+milestone%3Av1.5) must be merged.
+- **Monday, December 12, 2016**
+  - Release 1.5
+
+# 1.5 Release Czar
+**Github:** [saad-ali](https://github.com/saad-ali)
+
+**Email:** saadali@google.com
+
+# Key features
+[Feature tracking spreadsheet](https://docs.google.com/spreadsheets/d/1g9JU-67ncE4MHMeKnmslm-JO_aKeltv2kg_Dd6VFmKs/edit?usp=sharing)
+
+# Why?
+Kubernetes 1.4 is set to release on Sept 20.  We want to have another release of Kubernetes in the 2016 calendar year, so that means in December.
+
+December tends to have a lot of vacation time towards the end, and we want to have a little buffer time in case of slips.  Late November also has the US Thanksgiving holiday, when many people will be on vacation.
+
+The proposal below is identical in layout to the 1.4 plan, with the exceptions of:
+- key days aren't Fridays, since it can be hard to end milestones right up against weekends
+- a week is added for the bugfix period due to the Thanksgiving holiday
+- KubeCon is Nov 8-9, Kubernetes Dev Summit - Nov 10.

--- a/releases/release-1.5/release-notes-draft.md
+++ b/releases/release-1.5/release-notes-draft.md
@@ -1,0 +1,143 @@
+## Major Themes
+
+- StatefulSets (ex-PetSets)
+  - StatefulSets are beta now (fixes and stabilization)
+- Improved Federation Support
+  - New command: `kubefed`
+  - DaemonSets
+  - Deployments
+  - ConfigMaps
+- Simplified Cluster Deployment
+  - Improvements to `kubeadm`
+  - HA Setup for Master
+- Node Robustness and Extensibility
+  - Windows Server Container support
+  - CRI for pluggable container runtimes
+  - `kubelet` API supports authentication and authorization
+
+## Features
+
+Features for this release were tracked via the use of the [kubernetes/features](https://github.com/kubernetes/features) issues repo.  Each Feature issue is owned by a Special Interest Group from [kubernetes/community](https://github.com/kubernetes/community)
+
+- **API Machinery**
+  - [beta] `kube-apiserver` support for the OpenAPI spec is moving from alpha to beta. The first [non-go client](https://github.com/kubernetes-incubator/client-python) is based on it ([kubernetes/features#53](https://github.com/kubernetes/features/issues/53))
+- **Apps**
+  - [stable] When replica sets cannot create pods, they will now report detail via the API about the underlying reason ([kubernetes/features#120](https://github.com/kubernetes/features/issues/120))
+  - [stable] `kubectl apply` is now able to delete resources you no longer need with `--prune` ([kubernetes/features#128](https://github.com/kubernetes/features/issues/128))
+  - [beta] Deployments that cannot make progress in rolling out the newest version will now indicate via the API they are blocked ([docs](http://kubernetes.io/docs/user-guide/deployments/#failed-deployment)) ([kubernetes/features#122](https://github.com/kubernetes/features/issues/122))
+  - [beta] StatefulSets allow workloads that require persistent identity or per-instance storage to be created and managed on Kubernetes. ([docs](http://kubernetes.io/docs/concepts/abstractions/controllers/statefulsets/)) ([kubernetes/features#137](https://github.com/kubernetes/features/issues/137))
+  - [beta] In order to preserve safety guarantees the cluster no longer force deletes pods on un-responsive nodes and users are now warned if they try to force delete pods via the CLI. ([docs](http://kubernetes.io/docs/tasks/manage-stateful-set/scale-stateful-set/)) ([kubernetes/features#119](https://github.com/kubernetes/features/issues/119))
+- **Auth**
+  - [alpha] Further polishing of the Role-based access control alpha API including a default set of cluster roles. ([docs](http://kubernetes.io/docs/admin/authorization/)) ([kubernetes/features#2](https://github.com/kubernetes/features/issues/2))
+  - [beta] Added ability to authenticate/authorize access to the Kubelet API ([docs](http://kubernetes.io/docs/admin/kubelet-authentication-authorization/)) ([kubernetes/features#89](https://github.com/kubernetes/features/issues/89))
+- **AWS**
+  - [stable] Roles should appear in kubectl get nodes ([kubernetes/features#113](https://github.com/kubernetes/features/issues/113))
+- **Cluster Lifecycle**
+  - [alpha] Improved UX and usability for the kubeadm binary that makes it easy to get a new cluster running. ([docs](http://kubernetes.io/docs/getting-started-guides/kubeadm/)) ([kubernetes/features#11](https://github.com/kubernetes/features/issues/11))
+- **Cluster Ops**
+  - [alpha] Added ability to create/remove clusters w/highly available (replicated) masters on GCE using kube-up/kube-down scripts. ([docs](http://kubernetes.io/docs/admin/ha-master-gce/)) ([kubernetes/features#48](https://github.com/kubernetes/features/issues/48)) 
+- **Federation**
+  - [alpha] Support for ConfigMaps in federation. ([docs](http://kubernetes.io/docs/user-guide/federation/configmap/)) ([kubernetes/features#105](https://github.com/kubernetes/features/issues/105))
+  - [alpha] Alpha level support for DaemonSets in federation. ([docs](http://kubernetes.io/docs/user-guide/federation/daemonsets/)) ([kubernetes/features#101](https://github.com/kubernetes/features/issues/101))
+  - [alpha] Alpha level support for Deployments in federation. ([docs](http://kubernetes.io/docs/user-guide/federation/deployment/)) ([kubernetes/features#100](https://github.com/kubernetes/features/issues/100))
+  - [alpha] Cluster federation: Added support for DeleteOptions.OrphanDependents for federation resources. ([docs](http://kubernetes.io/docs/user-guide/federation/#cascading-deletion)) ([kubernetes/features#99](https://github.com/kubernetes/features/issues/99))
+  - [alpha] Introducing `kubefed`, a new command line tool to simplify federation control plane kubernetes.io/docs/admin/federation/kubefed/)) ([kubernetes/features#97](https://github.com/kubernetes/features/issues/97))
+- **Network**
+  - [stable] Services can reference another service by DNS name, rather than being hosted in pods ([kubernetes/features#33](https://github.com/kubernetes/features/issues/33))
+  - [beta] Opt in source ip preservation for Services with Type NodePort or LoadBalancer ([docs](http://kubernetes.io/docs/tutorials/services/source-ip/)) ([kubernetes/features#27](https://github.com/kubernetes/features/issues/27))
+  - [stable] Enable DNS Horizontal Autoscaling with beta ConfigMap parameters support ([docs](http://kubernetes.io/docs/tasks/administer-cluster/dns-horizontal-autoscaling/))
+- **Node**
+  - [alpha] Added ability to preserve access to host userns when userns remapping is enabled in container runtime ([kubernetes/features#127](https://github.com/kubernetes/features/issues/127))
+  - [alpha] Introducing the v1alpha1 CRI API to allow pluggable container runtimes; an experimental docker-CRI integration is ready for testing and feedback. ([docs](https://github.com/kubernetes/community/blob/master/contributors/devel/container-runtime-interface.md)) ([kubernetes/features#54](https://github.com/kubernetes/features/issues/54))
+  - [alpha] Kubelet launches container in a per pod cgroup hiearchy based on quality of service tier ([kubernetes/features#126](https://github.com/kubernetes/features/issues/126))
+  - [beta] Kubelet integrates with memcg notification API to detect when a hard eviction threshold is crossed ([kubernetes/features#125](https://github.com/kubernetes/features/issues/125))
+  - [beta] Introducing the beta version containerized node conformance test gcr.io/google_containers/node-test:0.2 for users to verify node setup. ([docs](http://kubernetes.io/docs/admin/node-conformance/)) ([kubernetes/features#84](https://github.com/kubernetes/features/issues/84))
+- **Scheduling**
+  - [alpha] Added support for accounting opaque integer resources. ([docs](http://kubernetes.io/docs/user-guide/compute-resources/#opaque-integer-resources-alpha-feature)) ([kubernetes/features#76](https://github.com/kubernetes/features/issues/76))
+  - [beta] PodDisruptionBudget has been promoted to beta, can be used to safely drain nodes while respecting application SLO's ([docs](http://kubernetes.io/docs/tasks/administer-cluster/safely-drain-node/)) ([kubernetes/features#85](https://github.com/kubernetes/features/issues/85))
+- **UI**
+  - [stable] Dashboard UI now shows all user facing objects and their resource usage. ([docs](http://kubernetes.io/docs/user-guide/ui/)) ([kubernetes/features#136](https://github.com/kubernetes/features/issues/136))
+- **Windows**
+  - [alpha] Added support for Windows Server 2016 nodes and scheduling Windows Server Containers ([docs](http://kubernetes.io/docs/getting-started-guides/windows/)) ([kubernetes/features#116](https://github.com/kubernetes/features/issues/116))
+
+## Known Issues
+
+Populated via [v1.5.0 known issues / FAQ accumulator](https://github.com/kubernetes/kubernetes/issues/37134)
+
+* CRI [known issues and
+  limitations](https://github.com/kubernetes/community/blob/master/contributors/devel/container-runtime-interface.md#kubernetes-v15-release-cri-v1alpha1)
+* getDeviceNameFromMount() function doesn't return the volume path correctly when the volume path contains spaces [#37712](https://github.com/kubernetes/kubernetes/issues/37712)
+* Federation alpha features do not have feature gates defined and
+are hence enabled by default. This will be fixed in a future release.
+[#38593](https://github.com/kubernetes/kubernetes/issues/38593)
+* Federation control plane can be upgraded by updating the image
+fields in the `Deployment` specs of the control plane components.
+However, federation control plane upgrades were not tested in this
+release [38537](https://github.com/kubernetes/kubernetes/issues/38537)
+
+## Notable Changes to Existing Behavior
+
+* Node controller no longer force-deletes pods from the api-server. ([#35235](https://github.com/kubernetes/kubernetes/pull/35235), [@foxish](https://github.com/foxish))
+  * For StatefulSet (previously PetSet), this change means creation of
+    replacement pods is blocked until old pods are definitely not running
+    (indicated either by the kubelet returning from partitioned state,
+    deletion of the Node object, deletion of the instance in the cloud provider,
+    or force deletion of the pod from the api-server).
+    This helps prevent "split brain" scenarios in clustered applications by
+    ensuring that unreachable pods will not be presumed dead unless some
+    "fencing" operation has provided one of the above indications.
+  * For all other existing controllers except StatefulSet, this has no effect on
+    the ability of the controller to replace pods because the controllers do not
+    reuse pod names (they use generate-name).
+  * User-written controllers that reuse names of pod objects should evaluate this change.
+  * When deleting an object with `kubectl delete ... --grace-period=0`, the client will 
+    begin a graceful deletion and wait until the resource is fully deleted.  To force 
+    deletion immediately, use the `--force` flag. This prevents users from accidentally 
+    allowing two Stateful Set pods to share the same persistent volume which could lead to data 
+    corruption [#37263](https://github.com/kubernetes/kubernetes/pull/37263)
+
+
+* Allow anonymous API server access, decorate authenticated users with system:authenticated group ([#32386](https://github.com/kubernetes/kubernetes/pull/32386), [@liggitt](https://github.com/liggitt))
+  * kube-apiserver learned the '--anonymous-auth' flag, which defaults to true. When enabled, requests to the secure port that are not rejected by other configured authentication methods are treated as anonymous requests, and given a username of 'system:anonymous' and a group of 'system:unauthenticated'. 
+  * Authenticated users are decorated with a 'system:authenticated' group.
+  * NOTE: anonymous access is enabled by default. If you rely on authentication alone to authorize access, change to use an authorization mode other than AlwaysAllow, or or set '--anonymous-auth=false'.
+
+* kubectl get -o jsonpath=... will now throw an error if the path is to a field not present in the json, even if the path is for a field valid for the type.  This is a change from the pre-1.5 behavior, which would return the default value for some fields even if they were not present in the json. ([#37991](https://github.com/kubernetes/kubernetes/issues/37991), [@pwittrock](http://github.com/pwittrock))
+
+* The strategicmerge patchMergeKey for VolumeMounts was changed from "name" to "mountPath".  This was necessary because the name field refers to the name of the Volume, and is not a unique key for the VolumeMount.  Multiple VolumeMounts will have the same Volume name if mounting the same volume more than once.  The "mountPath" is verified to be unique and can act as the mergekey.  ([#35071](https://github.coma/kubernetes/kubernetes/pull/35071), [@pwittrock](http://github.com/pwittrock))
+
+## Deprecations
+
+* extensions/v1beta1.Jobs is deprecated, use batch/v1.Job instead ([#36355](https://github.com/kubernetes/kubernetes/pull/36355), [@soltysh](https://github.com/soltysh))
+* The kubelet --reconcile-cdir flag is deprecated because it has no function anymore. ([#35523](https://github.com/kubernetes/kubernetes/pull/35523), [@luxas](https://github.com/luxas))
+* Notice of deprecation for recycler [#36760](https://github.com/kubernetes/kubernetes/pull/36760)
+
+## Action Required Before Upgrading
+
+* batch/v2alpha1.ScheduledJob has been renamed, use batch/v2alpha1.CronJob instead ([#36021](https://github.com/kubernetes/kubernetes/pull/36021), [@soltysh](https://github.com/soltysh))
+* PetSet has been renamed to StatefulSet.
+  If you have existing PetSets, **you must perform extra migration steps** both
+  before and after upgrading to convert them to StatefulSets. ([docs](http://kubernetes.io/docs/tasks/manage-stateful-set/upgrade-pet-set-to-stateful-set/)) ([#35663](https://github.com/kubernetes/kubernetes/pull/35663), [@janetkuo](https://github.com/janetkuo))
+* If you are upgrading your Cluster Federation components from v1.4.x, please update your `federation-apiserver` and `federation-controller-manager` manifests to the new version ([#30601](https://github.com/kubernetes/kubernetes/pull/30601), [@madhusudancs](https://github.com/madhusudancs))
+* The deprecated kubelet --configure-cbr0 flag has been removed, and with that the "classic" networking mode as well.  If you depend on this mode, please investigate whether the other network plugins `kubenet` or `cni` meet your needs. ([#34906](https://github.com/kubernetes/kubernetes/pull/34906), [@luxas](https://github.com/luxas))
+* New client-go structure, refer to kubernetes/client-go for versioning policy ([#34989](https://github.com/kubernetes/kubernetes/pull/34989), [@caesarxuchao](https://github.com/caesarxuchao))
+* The deprecated kube-scheduler --bind-pods-qps and --bind-pods burst flags have been removed, use --kube-api-qps and --kube-api-burst instead ([#34471](https://github.com/kubernetes/kubernetes/pull/34471), [@timothysc](https://github.com/timothysc))
+* If you used the [PodDisruptionBudget](http://kubernetes.io/docs/admin/disruptions/) feature in 1.4 (i.e. created `PodDisruptionBudget` objects), then **BEFORE**  upgrading from 1.4 to 1.5, you must delete all `PodDisruptionBudget` objects (`policy/v1alpha1/PodDisruptionBudget`) that you have created. It is not possible to delete these objects after you upgrade, and their presence will prevent you from using the beta PodDisruptionBudget feature in 1.5 (which uses `policy/v1beta1/PodDisruptionBudget`). If you have already upgraded, you will need to downgrade the master to 1.4 to delete the `policy/v1alpha1/PodDisruptionBudget` objects.
+
+## External Dependency Version Information
+
+Continuous integration builds have used the following versions of external dependencies, however, this is not a strong recommendation and users should consult an appropriate installation or upgrade guide before deciding what versions of etcd, docker or rkt to use. 
+
+* Docker versions 1.10.3 - 1.12.3
+  * Docker version 1.11.2 known issues
+    - Kernel crash with Aufs storage driver on Debian Jessie ([#27885](https://github.com/kubernetes/kubernetes/issues/27885))
+      which can be identified by the [node problem detector](http://kubernetes.io/docs/admin/node-problem/)
+    - Leaked File descriptors ([#275](https://github.com/docker/containerd/issues/275))
+    - Additional memory overhead per container ([#21737](https://github.com/docker/docker/issues/21737))
+  * Docker version 1.12.1 [has been validated](https://github.com/kubernetes/kubernetes/issues/28698) through the Kubernetes docker automated validation framework as has Docker version 1.12.3 
+ *  Docker 1.10.3 contains [backports provided by RedHat](https://github.com/docker/docker/compare/v1.10.3...runcom:docker-1.10.3-stable) for known issues
+  * Docker versions as old as may 1.9.1 work with [known issues](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG.md#191) but this is not guaranteed 
+* rkt version 1.21.0
+  * known issues with the rkt runtime are [listed here](http://kubernetes.io/docs/getting-started-guides/rkt/notes/)
+* etcd version 2.2.1
+  * etcd version 3.0.14 [has also been validated](https://k8s-gubernator.appspot.com/builds/kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-etcd3/) but does require [specific configuration steps](https://coreos.com/blog/migrating-applications-etcd-v3.html)

--- a/releases/release-1.6/flake-reports/2017-03-03.md
+++ b/releases/release-1.6/flake-reports/2017-03-03.md
@@ -1,0 +1,54 @@
+### Summary
+
+- [Total Flakes](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake): 456 (-53 from last report)
+- [No SIG](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20-label%3Asig%2Fapi-machinery%20-label%3Asig%2Fapps%20-label%3Asig%2Fauth%20-label%3Asig%2Fautoscaling%20-label%3Asig%2Faws%20-label%3Asig%2Fcli%20-label%3Asig%2Fcluster-lifecycle%20-label%3Asig%2Fcluster-ops%20-label%3Asig%2Fcontributor-experience%20-label%3Asig%2Fdocs%20-label%3Asig%2Ffederation%20-label%3Asig%2Finstrumentation%20-label%3Asig%2Fnetwork%20-label%3Asig%2Fnode%20-label%3Asig%2Fonprem%20-label%3Asig%2Fopenstack%20-label%3Asig%2Frktnetes%20-label%3Asig%2Fscalability%20-label%3Asig%2Fscheduling%20-label%3Asig%2Fservice-catalog%20-label%3Asig%2Fstorage%20-label%3Asig%2Ftesting%20-label%3Asig%2Fwindows%20milestone%3Av1.6): 168 (-8 from last report)
+
+#### Doing Better
+- AWS (-100%)
+- CLI (−96.774)
+- Autoscaling (-29.4117%)
+- Node (−11.765%)
+- Network (−10.714)
+- Scheduling (−6.667%)
+- Apps (−2.325%)
+
+  
+#### Doing Worse
+- Federation (+50.000%)
+- Storage (+40%)
+- Auth (+NaN%)
+
+#### No Progress
+- API Machinery
+- Big Data
+- Cluster Lifecycle
+- Instrumentation
+- Scalability
+  
+  
+### Flakes by SIG
+- [API Machinery](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20label%3Asig%2Fapi-machinery%20milestone%3Av1.6): 17 (unchanged from last report)
+- [AWS](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20label%3Asig%2Faws%20%20milestone%3Av1.6): 0 (-2 from last report)
+- [Apps](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20label%3Asig%2Fapps%20milestone%3Av1.6): 42 (-1 from last report)
+- [Auth](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20label%3Asig%2Fauth%20%20milestone%3Av1.6): 2 (**+2 from last report**)
+- [Autoscaling](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20label%3Asig%2Fautoscaling%20milestone%3Av1.6): 10 (-7 from last report)
+- [Big Data](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20label%3Asig%2Fbig-data%20milestone%3Av1.6): 1 (unchanged from last report)
+- [CLI](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20label%3Asig%2Fcli%20%20milestone%3Av1.6): 1 (-30 from last report)
+- [Cluster Lifecycle](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20label%3Asig%2Fcluster-lifecycle%20milestone%3Av1.6): 5 (unchanged from last report)
+- [Cluster Ops](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20label%3Asig%2Fcluster-ops%20milestone%3Av1.6): 0 (unchanged from last report)
+- [Contributor Experience](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20label%3Asig%2Fcontributor-experience%20milestone%3Av1.6): 0 (unchanged from last report)
+- [Docs](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20label%3Asig%2Fdocs%20milestone%3Av1.6): 0 (unchanged from last report)
+- [Federation](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20label%3Asig%2Ffederation%20milestone%3Av1.6): 9 (**+3 from last report**)
+- [Instrumentation](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20label%3Asig%2Finstrumentation%20%20milestone%3Av1.6): 4 (unchanged from last report)
+- [Network](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20label%3Asig%2Fnetwork%20milestone%3Av1.6): 50 (-6 from last report)
+- [Node](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20label%3Asig%2Fnode%20milestone%3Av1.6%20): 75 (-10 from last report)
+- [On Prem](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20label%3Asig%2Fon-prem%20milestone%3Av1.6): 0 (unchanged from last report)
+- [OpenStack](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20label%3Asig%2Fopenstack%20milestone%3Av1.6): 0 (unchanged from last report)
+- [PM](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20label%3Asig%2Fpm%20milestone%3Av1.6): 0 (unchange from last report)
+- [Scalability](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20label%3Asig%2Fscalability%20milestone%3Av1.6): 3 (unchanged from last report)
+- [Scheduling](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20label%3Asig%2Fscheduling%20milestone%3Av1.6): 14 (-1 from last report)
+- [Service Catalog](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20label%3Asig%2Fservice-catalog%20milestone%3Av1.6): 0 (unchanged from last report)
+- [Storage](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20label%3Asig%2Fstorage%20milestone%3Av1.6): 14 (**+4 from last report**)
+- [Testing](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20label%3Asig%2Ftesting%20milestone%3Av1.6): 0 (unchanged from last report)
+- [UI](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20label%3Asig%2Fui%20milestone%3Av1.6): 0 (unchanged from last report)
+- [Windows](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20label%3Asig%2Fwindows%20milestone%3Av1.6): 0 (unchanged from last report)

--- a/releases/release-1.6/go-signal-reports/2017-03-06.md
+++ b/releases/release-1.6/go-signal-reports/2017-03-06.md
@@ -1,0 +1,136 @@
+## Status: *NO GO*
+### Reasons
+- Bugs exist in 1.6 milestone
+- Flakes exist in 1.6 milestone
+- Tests unstable
+- Skew tests not running
+
+## Table Of Contents
+- [Flakes](#flakes)
+  - [By SIG](#by-sig)
+  - [Action Required](#action-required)
+- [Bugs](#bugs)
+  - [Action Required](#action-required-1)
+- [Test Failures](#test-failures)
+  - [Action Required](#action-required-2)
+- [Suite Failures](#suite-failures)
+  - [Action Required](#action-required-3)
+- [Incomplete Features](#incomplete-features)
+  - [Action Required](#action-required-4)
+- [Release Machinery](#release-machinery)
+  - [Action Required](#action-required-5)
+
+## Flakes
+- [Total](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6): 337 (-119 from last report)
+- [No SIG](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20-label%3Asig%2Fapi-machinery%20-label%3Asig%2Fapps%20-label%3Asig%2Fauth%20-label%3Asig%2Fautoscaling%20-label%3Asig%2Faws%20-label%3Asig%2Fcli%20-label%3Asig%2Fcluster-lifecycle%20-label%3Asig%2Fcluster-ops%20-label%3Asig%2Fcontributor-experience%20-label%3Asig%2Fdocs%20-label%3Asig%2Ffederation%20-label%3Asig%2Finstrumentation%20-label%3Asig%2Fnetwork%20-label%3Asig%2Fnode%20-label%3Asig%2Fonprem%20-label%3Asig%2Fopenstack%20-label%3Asig%2Frktnetes%20-label%3Asig%2Fscalability%20-label%3Asig%2Fscheduling%20-label%3Asig%2Fservice-catalog%20-label%3Asig%2Fstorage%20-label%3Asig%2Ftesting%20-label%3Asig%2Fwindows): 162 (-6 from last report)
+
+### By SIG
+- [API Machinery](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fapi-machinery%20): 2 (-15 from last report)
+- [AWS](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Faws): 0 (unchanged from last report)
+- [Apps](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fapps): 39 (-3 from last report)
+- [Auth](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fauth): 0 (-2 from last report)
+- [Autoscaling](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fautoscaling): 10 (unchanged from last report)
+- [Big Data](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fbig-data): 1 (unchanged from last report)
+- [CLI](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fcli): 1 (unchanged from last report)
+- [Cluster Lifecycle](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fcluster-lifecycle): 5 (unchanged from last report)
+- [Cluster Ops](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fcluster-ops): 0 (unchanged from last report)
+- [Contributor Experience](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fcontributor-experience): 0 (unchanged from last report)
+- [Docs](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fdocs): 0 (unchanged from last report)
+- [Federation](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Ffederation): 10 (**+1 from last report**)
+- [Instrumentation](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Finstrumentation): 3 (-1 from last report)
+- [Network](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fnetwork): 49 (-1 from last report)
+- [Node](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fnode): 25 (-50 from last report)
+- [On Prem](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fon-prem): 0 (unchanged from last report)
+- [OpenStack](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fopenstack): 0 (unchanged from last report)
+- [PM](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fpm): 0 (unchanged from last report)
+- [Scalability](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fscalability): 3 (unchanged from last report)
+- [Scheduling](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fscheduling): 6 (-8 from last report)
+- [Service Catalog](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fservice-catalog): 0 (unchanged from last report)
+- [Storage](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fstorage): 12 (-2 from last report)
+- [Testing](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Ftesting): 0 (unchanged from last report)
+- [UI](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fui): 0 (unchanged from last report)
+- [Windows](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fwindows): 0 (unchanged from last report)
+
+
+### Action Required
+- Help route all flakes into SIGs
+- Move all non release blocking issues into the 1.6.1 or 1.7 milestones by 2017-03-10
+- Assign owners for each blocking issue from each SIG for all remaining release blocking issues
+- Provide status updates within 24hrs for all flakes assigned to your SIG
+
+## Bugs
+- [Total in Milestone](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fbug%20milestone%3Av1.6): 17
+
+### Action Required
+- Bug owners please provide regular status updates for all bugs with fix or triage in progress
+- SIGs please close fixed bug issues or move non release blocking bugs into the 1.6.1 or 1.7 milestone
+
+## Test Failures
+### gce-es-logging
+- [k8s.io] Cluster level logging using Elasticsearch [Feature:Elasticsearch] should check that logs from containers are ingested into Elasticsearch
+
+### gce-examples
+- [k8s.io] [Feature:Example] [k8s.io] Cassandra should create and scale cassandraChanges (TG: https://github.com/kubernetes/kubernetes/compare/ac05be7...50943d1)
+- [k8s.io] [Feature:Example] [k8s.io] CassandraStatefulSet should create statefulsetChanges (TG: https://github.com/kubernetes/kubernetes/compare/9cbaff9...c36eee2)
+- [k8s.io] [Feature:Example] [k8s.io] Hazelcast should create and scale hazelcast
+
+### gce-statefulset
+- [k8s.io] StatefulSet [k8s.io] Deploy clustered applications [Feature:StatefulSet] [Slow] should creating a working CockroachDB cluster
+- [k8s.io] StatefulSet [k8s.io] Deploy clustered applications [Feature:StatefulSet] [Slow] should creating a working mysql cluster
+- [k8s.io] StatefulSet [k8s.io] Deploy clustered applications [Feature:StatefulSet] [Slow] should creating a working redis cluster
+- [k8s.io] StatefulSet [k8s.io] Deploy clustered applications [Feature:StatefulSet] [Slow] should creating a working zookeeper cluster
+
+### gce-serial
+#### gci-gce-serial
+- [k8s.io] Kubelet [Serial] [Slow] [k8s.io] regular resource usage tracking resource tracking for 100 pods per node (TG: https://github.com/kubernetes/kubernetes/compare/815b340...f7c07a1)
+- [k8s.io] Network Partition [Disruptive] [Slow] [k8s.io] [ReplicationController] should eagerly create replacement pod during network partition when termination grace is non-zero (TG: https://github.com/kubernetes/kubernetes/compare/8cc7475...102f267)
+- [k8s.io] Rescheduler [Serial] should ensure that critical pod is scheduled in case there is no resources available (TG: https://github.com/kubernetes/kubernetes/compare/93a3efd...2ebf6ed)
+- [k8s.io] Services should work after restarting apiserver [Disruptive]
+
+
+### kubelet-serial-gce-e2e
+- [k8s.io] GarbageCollect [Serial] Garbage Collection Test: Many Pods with Many Restarting Containers Should eventually garbage collect containers when we exceed the number of dead containers per container[k8s.io] GarbageCollect [Serial] Garbage Collection Test: Many Pods with Many Restarting Containers Should eventually garbage collect containers when we exceed the number of dead containers per container [2]
+- [k8s.io] GarbageCollect [Serial] Garbage Collection Test: Many Pods with Many Restarting Containers Should eventually garbage collect containers when we exceed the number of dead containers per container [3]
+- [k8s.io] GarbageCollect [Serial] Garbage Collection Test: Many Pods with Many Restarting Containers Should eventually garbage collect containers when we exceed the number of dead containers per container [4]
+- [k8s.io] GarbageCollect [Serial] Garbage Collection Test: Many Pods with Many Restarting Containers Should eventually garbage collect containers when we exceed the number of dead containers per container [5]
+- [k8s.io] GarbageCollect [Serial] Garbage Collection Test: Many Restarting Containers Should eventually garbage collect containers when we exceed the number of dead containers per container
+- [k8s.io] GarbageCollect [Serial] Garbage Collection Test: Many Restarting Containers Should eventually garbage collect containers when we exceed the number of dead containers per container [2]
+- [k8s.io] GarbageCollect [Serial] Garbage Collection Test: Many Restarting Containers Should eventually garbage collect containers when we exceed the number of dead containers per container [3]
+- [k8s.io] GarbageCollect [Serial] Garbage Collection Test: Many Restarting Containers Should eventually garbage collect containers when we exceed the number of dead containers per container [4]
+- [k8s.io] GarbageCollect [Serial] Garbage Collection Test: Many Restarting Containers Should eventually garbage collect containers when we exceed the number of dead containers per container [5]
+- [k8s.io] GarbageCollect [Serial] Garbage Collection Test: One Non-restarting Container Should eventually garbage collect containers when we exceed the number of dead containers per container
+- [k8s.io] GarbageCollect [Serial] Garbage Collection Test: One Non-restarting Container Should eventually garbage collect containers when we exceed the number of dead containers per container [2]
+- [k8s.io] GarbageCollect [Serial] Garbage Collection Test: One Non-restarting Container Should eventually garbage collect containers when we exceed the number of dead containers per container [3]
+- [k8s.io] GarbageCollect [Serial] Garbage Collection Test: One Non-restarting Container Should eventually garbage collect containers when we exceed the number of dead containers per container [4]
+- [k8s.io] GarbageCollect [Serial] Garbage Collection Test: One Non-restarting Container Should eventually garbage collect containers when we exceed the number of dead containers per container [5]
+
+### Action Required
+- SIG Node address Garbage Collection Test Regression
+- StatefulSet regression addressed
+
+## Suite Failures
+- [GKE Serial](https://k8s-testgrid.appspot.com/google-gke#gke-serial)
+- [GCE Examples](https://k8s-testgrid.appspot.com/google-gce#gce-examples)
+- [GCE HA Master](https://k8s-testgrid.appspot.com/google-gce#gce-ha-master)
+- [etcd Upgrades](https://k8s-testgrid.appspot.com/etcd-upgrades)
+
+### Action Required
+- GKE Suite Owner must be identified
+- GCE Suite Owner must be identified
+
+## Incomplete Features
+- Open issues filed against [`kubernetes/features` in 1.6 milestone](https://github.com/kubernetes/features/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20milestone%3Av1.6): 33
+
+### Action Required
+- Feature owners fill out feature template by 10 March 2017
+- Feature owners submit docs PR which references issue in features repo by 13 March 2017
+- Feature owners prepare release notes by 13 March 2017
+- Address etcd upgrade test failures
+
+## Release Machinery
+- Version skew tests are still not up. This presents a major threat to the release schedule as it is impossible
+  to verify regressions between minor release versions and mixed version clusters (as would exist during a rolling
+  upgrade)
+
+### Action Required
+- Finish release infrastructure setup

--- a/releases/release-1.6/go-signal-reports/2017-03-08.md
+++ b/releases/release-1.6/go-signal-reports/2017-03-08.md
@@ -1,0 +1,151 @@
+## Status: *NO GO*
+### Reasons
+- Bugs exist in 1.6 milestone
+- Flakes exist in 1.6 milestone
+- Open issues in 1.6 milestone
+- Tests unstable
+- Skew test failures
+- Upgrade test failures
+
+## Table Of Contents
+- [Issues](#issues)
+  - [Action Required](#action-required)
+  - [Flakes](#flakes)
+    - [By SIG](#by-sig)
+    - [Action Required](#action-required-1)
+  - [Bugs](#bugs)
+    - [Action Required](#action-required-2)
+- [Test Failures](#test-failures)
+  - [Action Required](#action-required-3)
+- [Suite Failures](#suite-failures)
+  - [Action Required](#action-required-4)
+- [Incomplete Features](#incomplete-features)
+  - [Action Required](#action-required-5)
+- [Release Machinery](#release-machinery)
+  - [Action Required](#action-required-6)
+
+## Issues
+- [Total in milestone](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20milestone%3Av1.6): 617
+
+### Action required
+- Ensure all issues in milestone are release blocking
+- Ensure all issues in milestone have SIG routing label
+- Ensure all issues opened by a human have an assignee. It's now possible to [assign people using prow](https://groups.google.com/forum/#!topic/kubernetes-wg-contribex/t6aceRk03Ag); thanks contribx! 
+- Move all non blocking issues into the 1.6.1 or 1.7 milestones **do not remove the milestone of the issue**
+- Close issues which have been addressed  
+
+### Flakes
+- [Total in milestone](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6): 321 (-16 from last report)
+- [No SIG](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20-label%3Asig%2Fapi-machinery%20-label%3Asig%2Fapps%20-label%3Asig%2Fauth%20-label%3Asig%2Fautoscaling%20-label%3Asig%2Faws%20-label%3Asig%2Fcli%20-label%3Asig%2Fcluster-lifecycle%20-label%3Asig%2Fcluster-ops%20-label%3Asig%2Fcontributor-experience%20-label%3Asig%2Fdocs%20-label%3Asig%2Ffederation%20-label%3Asig%2Finstrumentation%20-label%3Asig%2Fnetwork%20-label%3Asig%2Fnode%20-label%3Asig%2Fonprem%20-label%3Asig%2Fopenstack%20-label%3Asig%2Frktnetes%20-label%3Asig%2Fscalability%20-label%3Asig%2Fscheduling%20-label%3Asig%2Fservice-catalog%20-label%3Asig%2Fstorage%20-label%3Asig%2Ftesting%20-label%3Asig%2Fwindows): 166 (**+4 from last report**)
+
+### By SIG
+- [API Machinery](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fapi-machinery%20): 6 (**+4 from last report**)
+- [AWS](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Faws): 0 (unchanged from last report)
+- [Apps](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fapps): 33 (-6 from last report)
+- [Auth](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fauth): 1 (**+1 from last report**)
+- [Autoscaling](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fautoscaling): 4 (-6 from last report)
+- [Big Data](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fbig-data): 1 (**unchanged from last report**)
+- [CLI](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fcli): 1 (**unchanged from last report**)
+- [Cluster Lifecycle](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fcluster-lifecycle): 5 (**unchanged from last report**)
+- [Cluster Ops](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fcluster-ops): 0 (unchanged from last report)
+- [Contributor Experience](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fcontributor-experience): 0 (unchanged from last report)
+- [Docs](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fdocs): 0 (unchanged from last report)
+- [Federation](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Ffederation): 10 (**unchanged from last report**)
+- [Instrumentation](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Finstrumentation): 3 (**unchanged from last report**)
+- [Network](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fnetwork): 48 (-1 from last report)
+- [Node](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fnode): 26 (**+1 from last report**)
+- [On Prem](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fon-prem): 0 (unchanged from last report)
+- [OpenStack](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fopenstack): 0 (unchanged from last report)
+- [PM](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fpm): 0 (unchanged from last report)
+- [Scalability](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fscalability): 1 (-2 from last report)
+- [Scheduling](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fscheduling): 7 (**+1 from last report**)
+- [Service Catalog](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fservice-catalog): 0 (unchanged from last report)
+- [Storage](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fstorage): 11 (-1 from last report)
+- [Testing](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Ftesting): 0 (unchanged from last report)
+- [UI](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fui): 0 (unchanged from last report)
+- [Windows](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fwindows): 0 (unchanged from last report)
+
+#### Action Required
+- Help route all flakes into SIGs
+- **Do not open a flake issue without assigning a SIG to that issue**
+- Move all non release blocking issues into the 1.6.1 or 1.7 milestones by 2017-03-10
+- Assign owners for each blocking issue from each SIG for all remaining release blocking issues
+- Provide status updates within 24hrs for all flakes assigned to your SIG
+
+### Bugs
+- [Total in milestone](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fbug%20milestone%3Av1.6): 144 (**+127 from last report due to moving all issues of `kind/bug` into the 1.6 milestone**)
+
+#### Action Required
+- Bug assignees please label all bugs with the appropriate SIG(s)
+- BUg assignees please move all non release blocking bugs into either the 1.6.1 or 1.7 milestones **do not simply remove the milestone**
+- Bug assignees please provide regular status updates for all bugs with fix or triage in progress
+- Bug assignees and SIGs please close fixed bugs
+
+## Test Failures
+- [k8s.io] Federation apiserver [Feature:Federation] Cluster objects [Serial] should be created and deleted successfully
+- [k8s.io] Cluster level logging using Elasticsearch [Feature:Elasticsearch] should check that logs from containers are ingested into Elasticsearch
+- [k8s.io] [Feature:Example] [k8s.io] Cassandra should create and scale cassandra
+- [k8s.io] [Feature:Example] [k8s.io] CassandraStatefulSet should create statefulset
+- [k8s.io] [Feature:Example] [k8s.io] Hazelcast should create and scale hazelcast
+- [k8s.io] kubelet [k8s.io] host cleanup with volume mounts [HostCleanup][Flaky] Host cleanup after pod using NFS mount is deleted [Volume][NFS] after deleting the nfs-server, the host should be cleaned-up when deleting a pod accessing the NFS vol 
+- [k8s.io] Cluster level logging using GCL [Slow] [Flaky] should create a constant load with short-living pods and ensure logs delivery
+- [k8s.io] PersistentVolumes [Volume][Disruptive][Flaky] when kubelet restarts Should test that a file written to the mount before kubelet restart is stat-able after restart.
+- [k8s.io] PersistentVolumes [Volume][Disruptive][Flaky] when kubelet restarts Should test that a volume mounted to a pod that is deleted while the kubelet is down unmounts when the kubelet returns.
+- [k8s.io] InodeEviction [Slow] [Serial] [Disruptive] [Flaky] when we run containers that should cause Disk Pressure due to Inodes should eventually see Disk Pressure due to Inodes, and then evict all of the correct pods [5]
+- [k8s.io] Garbage collector [Feature:GarbageCollector] should keep the rc around until all its pods are deleted if the deleteOptions says soChanges
+- [k8s.io] Kubectl client [k8s.io] Simple pod should handle in-cluster config
+- [k8s.io] Services should work after restarting apiserver [Disruptive]
+- [k8s.io] Rescheduler [Serial] should ensure that critical pod is scheduled in case there is no resources available
+- [k8s.io] Kubelet [Serial] [Slow] [k8s.io] regular resource usage tracking resource tracking for 100 pods per node
+- [k8s.io] StatefulSet [k8s.io] Deploy clustered applications [Feature:StatefulSet] [Slow] should creating a working CockroachDB cluster
+- [k8s.io] StatefulSet [k8s.io] Deploy clustered applications [Feature:StatefulSet] [Slow] should creating a working mysql cluster
+- [k8s.io] StatefulSet [k8s.io] Deploy clustered applications [Feature:StatefulSet] [Slow] should creating a working redis cluster
+- [k8s.io] StatefulSet [k8s.io] Deploy clustered applications [Feature:StatefulSet] [Slow] should creating a working zookeeper cluster
+
+
+
+### Action Required
+- Please address all failing tests
+- Please add SIG routing labels to issued opened due to test failure
+
+## Suite Failures
+- [Federation, GCE](https://k8s-testgrid.appspot.com/google-federation#gce)
+- [Federation, GCI-GKE](https://k8s-testgrid.appspot.com/google-federation#gci-gce)
+- [Node, heapster push](https://k8s-testgrid.appspot.com/google-node#heapster-push)
+- [1.5 -> 1.6 GCI kubectl skew](https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gce-1.5-1.6-gci-kubectl-skew)
+- [1.5 -> 1.6 Container VM kubectl skew](https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gce-1.5-1.6-cvm-kubectl-skew)
+- [GKE 1.5 -> 1.6 Container VM kubectl skew](https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-1.5-1.6-cvm-kubectl-skew)
+- [GKE 1.5 -> 1.6 GCI kubectl skew](https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-1.5-1.6-gci-kubectl-skew)
+- [GCE 1.5 -> 1.6 upgrade cluster](https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gce-1.5-1.6-upgrade-cluster)
+- [GCE 1.5 -> 1.6 upgrade cluster new](https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gce-1.5-1.6-upgrade-cluster-new)
+- [GCE 1.5 -> 1.6 upgrade master](https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gce-1.5-1.6-upgrade-master)
+- [GKE 1.5 -> 1.6 upgrade cluster](https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-container_vm-1.4-container_vm-1.6-upgrade-cluster)
+- [GKE 1.5 -> 1.6 GCI upgrade cluster](https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-gci-1.5-gci-1.6-upgrade-cluster)
+- [GKE Serial 1.6](https://k8s-testgrid.appspot.com/release-1.6-blocking#gke-serial-1.6)
+- [GKE GCI Serial 1.6](https://k8s-testgrid.appspot.com/release-1.6-blocking#gci-gke-serial-1.6)
+- [GCE Federation 1.6](https://k8s-testgrid.appspot.com/release-1.6-blocking#gce-federation-1.6)
+
+### Action Required
+- GKE Suite Owner must be identified
+- GCE Suite Owner must be identified
+- Fix GCE skew testing
+- Fix GKE skew testing
+- Fix Federation suites
+
+## Incomplete Features
+- Open issues filed against [`kubernetes/features` in 1.6 milestone](https://github.com/kubernetes/features/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20milestone%3Av1.6): 31 (-2 from last report)
+
+### Action Required
+- Feature owners fill out feature template by 10 March 2017
+- Feature owners submit docs PR which references issue in features repo by 13 March 2017
+- Feature owners prepare release notes by 13 March 2017
+- Address etcd upgrade test failures
+
+## Release Machinery
+- Large cluster testing is not running yet
+- Skew tests are running; thanks @ixdy!
+- Automated upgrade tests are running
+- Manual upgrade testing in progress
+
+### Action Required
+- Start running large scale cluster testing ASAP 

--- a/releases/release-1.6/go-signal-reports/2017-03-10.md
+++ b/releases/release-1.6/go-signal-reports/2017-03-10.md
@@ -1,0 +1,128 @@
+## Status: *NO GO*
+### Reasons
+- Bugs exist in 1.6 milestone
+- Flakes exist in 1.6 milestone
+- Open issues in 1.6 milestone
+- Tests unstable
+- Skew test failures
+- Upgrade test failures
+
+## Table Of Contents
+- [Issues](#issues)
+  - [Action Required](#action-required)
+  - [Flakes](#flakes)
+    - [By SIG](#by-sig)
+    - [Action Required](#action-required-1)
+  - [Bugs](#bugs)
+    - [Action Required](#action-required-2)
+- [Test Failures](#test-failures)
+  - [Action Required](#action-required-3)
+- [Suite Failures](#suite-failures)
+  - [Action Required](#action-required-4)
+- [Incomplete Features](#incomplete-features)
+  - [Action Required](#action-required-5)
+- [Release Machinery](#release-machinery)
+  - [Action Required](#action-required-6)
+
+## Issues
+- [Total in milestone](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20milestone%3Av1.6): 411 (-206 from last report)
+
+### Action required
+- Ensure all issues in milestone are release blocking
+- Ensure all issues in milestone have SIG routing label
+- Ensure all issues opened by a human have an assignee. It's now possible to [assign people using prow](https://groups.google.com/forum/#!topic/kubernetes-wg-contribex/t6aceRk03Ag); thanks contribx!
+- Move all non blocking issues out of `v1.6` milestone
+- Close issues which have been addressed
+
+### Flakes
+- [Total in milestone](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6): 253 (-68 from last report)
+- [No SIG](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20-label%3Asig%2Fapi-machinery%20-label%3Asig%2Fapps%20-label%3Asig%2Fauth%20-label%3Asig%2Fautoscaling%20-label%3Asig%2Faws%20-label%3Asig%2Fcli%20-label%3Asig%2Fcluster-lifecycle%20-label%3Asig%2Fcluster-ops%20-label%3Asig%2Fcontributor-experience%20-label%3Asig%2Fdocs%20-label%3Asig%2Ffederation%20-label%3Asig%2Finstrumentation%20-label%3Asig%2Fnetwork%20-label%3Asig%2Fnode%20-label%3Asig%2Fonprem%20-label%3Asig%2Fopenstack%20-label%3Asig%2Frktnetes%20-label%3Asig%2Fscalability%20-label%3Asig%2Fscheduling%20-label%3Asig%2Fservice-catalog%20-label%3Asig%2Fstorage%20-label%3Asig%2Ftesting%20-label%3Asig%2Fwindows): 139 (-27 from last report)
+
+### By SIG
+- [API Machinery](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fapi-machinery%20): 6 (**unchanged from last report**)
+- [AWS](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Faws): 1 (**+1 from last report**)
+- [Apps](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fapps): 12 (-21 from last report)
+- [Auth](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fauth): 0 (-1 from last report)
+- [Autoscaling](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fautoscaling): 1 (-3 from last report)
+- [Big Data](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fbig-data): 1 (**unchanged from last report**)
+- [CLI](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fcli): 0 (-1 from last report)
+- [Cluster Lifecycle](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fcluster-lifecycle): 1 (-4 from last report)
+- [Cluster Ops](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fcluster-ops): 1 (**+1 from last report**)
+- [Contributor Experience](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fcontributor-experience): 0 (unchanged from last report)
+- [Docs](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fdocs): 0 (unchanged from last report)
+- [Federation](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Ffederation): 11 (**+1 from last report**)
+- [Instrumentation](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Finstrumentation): 3 (**unchanged from last report**)
+- [Network](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fnetwork): 49 (**+1 from last report**)
+- [Node](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fnode): 8 (-18 from last report)
+- [On Prem](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fon-prem): 0 (unchanged from last report)
+- [OpenStack](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fopenstack): 0 (unchanged from last report)
+- [PM](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fpm): 0 (unchanged from last report)
+- [Scalability](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fscalability): 2 (**+1 from last report**)
+- [Scheduling](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fscheduling): 5 (-2 from last report)
+- [Service Catalog](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fservice-catalog): 0 (unchanged from last report)
+- [Storage](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fstorage): 7 (-4 from last report)
+- [Testing](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Ftesting): 0 (unchanged from last report)
+- [UI](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fui): 0 (unchanged from last report)
+- [Windows](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fwindows): 0 (unchanged from last report)
+
+#### Action Required
+- Help route all flakes into SIGs
+- **Do not open a flake issue without assigning a SIG to that issue**
+- Move all non release blocking issues out of `v1.6` milestone
+- Assign owners for each blocking issue from each SIG for all remaining release blocking issues
+- Provide status updates within 24hrs for all flakes assigned to your SIG
+
+### Bugs
+- [Total in milestone](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fbug%20milestone%3Av1.6): 20 (-76 from last report)
+
+#### Action Required
+- Bug assignees please label all bugs with the appropriate SIG(s)
+- BUg assignees please move all non release blocking bugs out of the `v1.6` milestone**
+- Bug assignees please provide regular status updates for all bugs with fix or triage in progress
+- Bug assignees and SIGs please close fixed bugs
+
+## Test Failures
+
+
+### Action Required
+- Please address all failing tests
+- Please add SIG routing labels to issued opened due to test failure
+
+## Suite Failures
+- [Federation, GCE](https://k8s-testgrid.appspot.com/google-federation#gce)
+- [Federation, GCI-GKE](https://k8s-testgrid.appspot.com/google-federation#gci-gce)
+- [Node, heapster push](https://k8s-testgrid.appspot.com/google-node#heapster-push)
+- [1.5 -> 1.6 GCI kubectl skew](https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gce-1.5-1.6-gci-kubectl-skew)
+- [1.5 -> 1.6 Container VM kubectl skew](https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gce-1.5-1.6-cvm-kubectl-skew)
+- [GKE 1.5 -> 1.6 Container VM kubectl skew](https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-1.5-1.6-cvm-kubectl-skew)
+- [GKE 1.5 -> 1.6 GCI kubectl skew](https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-1.5-1.6-gci-kubectl-skew)
+- [GCE 1.5 -> 1.6 upgrade cluster](https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gce-1.5-1.6-upgrade-cluster)
+- [GCE 1.5 -> 1.6 upgrade cluster new](https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gce-1.5-1.6-upgrade-cluster-new)
+- [GCE 1.5 -> 1.6 upgrade master](https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gce-1.5-1.6-upgrade-master)
+- [GKE 1.5 -> 1.6 upgrade cluster](https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-container_vm-1.4-container_vm-1.6-upgrade-cluster)
+- [GKE 1.5 -> 1.6 GCI upgrade cluster](https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-gci-1.5-gci-1.6-upgrade-cluster)
+- [GKE Serial 1.6](https://k8s-testgrid.appspot.com/release-1.6-blocking#gke-serial-1.6)
+- [GKE GCI Serial 1.6](https://k8s-testgrid.appspot.com/release-1.6-blocking#gci-gke-serial-1.6)
+- [GCE Federation 1.6](https://k8s-testgrid.appspot.com/release-1.6-blocking#gce-federation-1.6)
+
+### Action Required
+- GKE Suite Owner must be identified
+- GCE Suite Owner must be identified
+- Fix GCE skew testing
+- Fix GKE skew testing
+- Fix Federation suites
+
+## Incomplete Features
+- Open issues filed against [`kubernetes/features` in 1.6 milestone](https://github.com/kubernetes/features/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20milestone%3Av1.6): 31 (**unchanged from last report**)
+
+### Action Required
+- Feature owners fill out feature template by **TODAY!**
+- Feature owners submit docs PR which references issue in features repo by 13 March 2017
+- Feature owners prepare release notes by 13 March 2017
+- Address etcd upgrade test failures
+
+## Release Machinery
+- Large cluster testing is not running yet
+
+### Action Required
+- Start running large scale cluster testing ASAP 

--- a/releases/release-1.6/go-signal-reports/2017-03-13.md
+++ b/releases/release-1.6/go-signal-reports/2017-03-13.md
@@ -1,0 +1,205 @@
+## Status: *NO GO*
+### Reasons
+- Bugs exist in 1.6 milestone
+- Flakes exist in 1.6 milestone
+- Open issues in 1.6 milestone
+- Tests unstable (missing three successful runs in a row)
+- Skew test failures
+- Upgrade test failures
+
+## Table Of Contents
+- [Issues](#issues)
+  - [Action Required](#action-required)
+  - [Flakes](#flakes)
+    - [By SIG](#by-sig)
+    - [Action Required](#action-required-1)
+  - [Bugs](#bugs)
+    - [Action Required](#action-required-2)
+- [Test Failures](#test-failures)
+  - [Action Required](#action-required-3)
+- [Suite Failures](#suite-failures)
+  - [Action Required](#action-required-4)
+- [Incomplete Features](#incomplete-features)
+  - [Action Required](#action-required-5)
+- [Release Machinery](#release-machinery)
+  - [Action Required](#action-required-6)
+- [Actions Taken by Release Team](#actions-taken-by-release-team)
+
+
+## Issues
+- [Total in milestone](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20milestone%3Av1.6): 172 (-239 from last report)
+- ["broken test run" issues in 1.6 milestone](https://github.com/kubernetes/kubernetes/issues?page=1&q=is%3Aissue+is%3Aopen+label%3Akind%2Fflake+%22broken+test+run%22++milestone%3Av1.6&utf8=%E2%9C%93): 24
+
+### Action required
+- Ensure all issues in milestone are release blocking
+- Ensure all issues in milestone have SIG routing label
+- Ensure all issues opened by a human have an assignee. It's now possible to [assign people using prow](https://groups.google.com/forum/#!topic/kubernetes-wg-contribex/t6aceRk03Ag); thanks contribx!
+- Move all non blocking issues out of `v1.6` milestone **and into** *either* the `v1.6.1` or `v1.7` milestones 
+- Close "broken test run" issues for transient test infrastructure failures 
+- Close issues which have been addressed
+
+### Flakes
+- [Total in milestone](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6): 84 (-169 from last report)
+- [No SIG](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20-label%3Asig%2Fapi-machinery%20-label%3Asig%2Fapps%20-label%3Asig%2Fauth%20-label%3Asig%2Fautoscaling%20-label%3Asig%2Faws%20-label%3Asig%2Fcli%20-label%3Asig%2Fcluster-lifecycle%20-label%3Asig%2Fcluster-ops%20-label%3Asig%2Fcontributor-experience%20-label%3Asig%2Fdocs%20-label%3Asig%2Ffederation%20-label%3Asig%2Finstrumentation%20-label%3Asig%2Fnetwork%20-label%3Asig%2Fnode%20-label%3Asig%2Fonprem%20-label%3Asig%2Fopenstack%20-label%3Asig%2Frktnetes%20-label%3Asig%2Fscalability%20-label%3Asig%2Fscheduling%20-label%3Asig%2Fservice-catalog%20-label%3Asig%2Fstorage%20-label%3Asig%2Ftesting%20-label%3Asig%2Fwindows): 4 (-135 from last report)
+
+### By SIG
+- [API Machinery](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fapi-machinery%20): 5 (-1 from last report)
+- [AWS](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Faws): 5 (**+4 from last report**)
+- [Apps](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fapps): 1 (-11 from last report)
+- [Auth](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fauth): 1 (**+1 from last report**)
+- [Autoscaling](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fautoscaling): 4 (**+3 from last report**)
+- [Big Data](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fbig-data): 0 (-1 from last report)
+- [CLI](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fcli): 4 (**+4 from last report**)
+- [Cluster Lifecycle](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fcluster-lifecycle): 6 (**+5 from last report**)
+- [Cluster Ops](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fcluster-ops): 0 (-1 from last report)
+- [Contributor Experience](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fcontributor-experience): 0 (unchanged from last report)
+- [Docs](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fdocs): 0 (unchanged from last report)
+- [Federation](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Ffederation): 6 (-5 from last report)
+- [Instrumentation](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Finstrumentation): 4 (**+1 from last report**)
+- [Network](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fnetwork): 17 (-32 from last report)
+- [Node](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fnode): 16 (**+8 from last report**)
+- [On Prem](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fon-prem): 0 (unchanged from last report)
+- [OpenStack](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fopenstack): 0 (unchanged from last report)
+- [PM](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fpm): 0 (unchanged from last report)
+- [Scalability](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fscalability): 2 (**unchanged from last report**)
+- [Scheduling](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fscheduling): 5 (**unchanged from last report**)
+- [Service Catalog](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fservice-catalog): 0 (unchanged from last report)
+- [Storage](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fstorage): 11 (**+4 from last report**)
+- [Testing](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Ftesting): 7 (**+7 from last report**)
+- [UI](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fui): 0 (unchanged from last report)
+- [Windows](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fwindows): 0 (unchanged from last report)
+
+#### Action Required
+- Help route all flakes into SIGs
+- **Do not open a flake issue without assigning a SIG to that issue**
+- **Do not remove a milestone without assigning a new milestone**
+- Move all non release blocking issues out of `v1.6` milestone and into _either_ the `v1.6.1` or `v1.7` milestones
+- Assign owners for each blocking issue from each SIG for all remaining release blocking issues
+- Provide status updates within 24hrs for all flakes assigned to your SIG
+
+### Bugs
+- [Total in milestone](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fbug%20milestone%3Av1.6): 17 (-3 from last report)
+
+#### Action Required
+- Bug assignees please label all bugs with the appropriate SIG(s)
+- **Bug assignees please move all non release blocking bugs out of the `v1.6` milestone** and into the `v1.6.1` or `v1.7` milestones
+- Bug assignees please provide regular status updates for all bugs with fix or triage in progress
+- Bug assignees and SIGs please close fixed bugs
+
+## Test Failures
+- [k8s.io] ConfigMap should be consumable from pods in volume with mappings as non-root [Conformance] [Volume]
+- [k8s.io] EmptyDir volumes should support (root,0777,tmpfs) [Conformance] [Volume]
+- [k8s.io] Cluster size autoscaling [Slow] shouldn't increase cluster size if pending pod is too large [Feature:ClusterSizeAutoscalingScaleUp]
+- [k8s.io] [Feature:Example] [k8s.io] Cassandra should create and scale cassandra
+- [k8s.io] [Feature:Example] [k8s.io] CassandraStatefulSet should create statefulset
+- [k8s.io] [Feature:Example] [k8s.io] Hazelcast should create and scale hazelcast
+- [k8s.io] StatefulSet [k8s.io] Deploy clustered applications [Feature:StatefulSet] [Slow] should creating a working CockroachDB cluster
+- [k8s.io] StatefulSet [k8s.io] Deploy clustered applications [Feature:StatefulSet] [Slow] should creating a working mysql cluster
+- [k8s.io] StatefulSet [k8s.io] Deploy clustered applications [Feature:StatefulSet] [Slow] should creating a working redis cluster
+- [k8s.io] StatefulSet [k8s.io] Deploy clustered applications [Feature:StatefulSet] [Slow] should creating a working zookeeper cluster
+- [k8s.io] Cluster size autoscaling [Slow] shouldn't increase cluster size if pending pod is too large [Feature:ClusterSizeAutoscalingScaleUp]
+- [k8s.io] Cluster level logging using Elasticsearch [Feature:Elasticsearch] should check that logs from containers are ingested into Elasticsearch
+- [k8s.io] Daemon set [Serial] Should adopt or recreate existing pods when creating a RollingUpdate DaemonSet with matching or mismatching templateGeneration
+- [k8s.io] Kubelet [Serial] [Slow] [k8s.io] regular resource usage tracking resource tracking for 100 pods per node
+- [k8s.io] Cluster size autoscaling [Slow] should correctly scale down after a node is not needed when there is non autoscaled pool[Feature:ClusterSizeAutoscalingScaleDown]
+- [k8s.io] Cluster size autoscaling [Slow] shouldn't increase cluster size if pending pod is too large [Feature:ClusterSizeAutoscalingScaleUp]
+- [k8s.io] Network Partition [Disruptive] [Slow] [k8s.io] [ReplicationController] should recreate pods scheduled on the unreachable node AND allow scheduling of pods on a node after it rejoins the cluster
+- [k8s.io] Rescheduler [Serial] should ensure that critical pod is scheduled in case there is no resources availableChanges
+- [k8s.io] Kubelet [Serial] [Slow] [k8s.io] regular resource usage tracking resource tracking for 0 pods per node
+- [k8s.io] Network Partition [Disruptive] [Slow] [k8s.io] [Job] should create new pods when node is partitioned
+- [k8s.io] Network Partition [Disruptive] [Slow] [k8s.io] [ReplicationController] should eagerly create replacement pod during network partition when termination grace is non-zero 
+- [k8s.io] Services should be able to change the type and ports of a service [Slow]
+- [k8s.io] Services should only allow access from service loadbalancer source ranges [Slow]
+- [k8s.io] Generated release_1_5 clientset should create pods, delete pods, watch pods
+- [k8s.io] Namespaces [Serial] should ensure that all pods are removed when a namespace is deleted.
+- [k8s.io] NoExecuteTaintManager [Serial] eventually evict pod with finite tolerations from tainted nodes
+
+### Action Required
+- Please address all failing tests
+- Please add SIG routing labels to issued opened due to test failure
+
+## Suite Failures
+- [Federation, GCE](https://k8s-testgrid.appspot.com/google-federation#gce)
+- [Federation, GCI-GKE](https://k8s-testgrid.appspot.com/google-federation#gci-gce)
+- [Node, heapster push](https://k8s-testgrid.appspot.com/google-node#heapster-push)
+- [1.5 -> 1.6 GCI kubectl skew](https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gce-1.5-1.6-gci-kubectl-skew)
+- [1.5 -> 1.6 Container VM kubectl skew](https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gce-1.5-1.6-cvm-kubectl-skew)
+- [GKE 1.5 -> 1.6 Container VM kubectl skew](https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-1.5-1.6-cvm-kubectl-skew)
+- [GKE 1.5 -> 1.6 GCI kubectl skew](https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-1.5-1.6-gci-kubectl-skew)
+- [GCE 1.5 -> 1.6 upgrade cluster](https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gce-1.5-1.6-upgrade-cluster)
+- [GCE 1.5 -> 1.6 upgrade cluster new](https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gce-1.5-1.6-upgrade-cluster-new)
+- [GCE 1.5 -> 1.6 upgrade master](https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gce-1.5-1.6-upgrade-master)
+- [GKE 1.5 -> 1.6 upgrade cluster](https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-container_vm-1.4-container_vm-1.6-upgrade-cluster)
+- [GKE 1.5 -> 1.6 GCI upgrade cluster](https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-gci-1.5-gci-1.6-upgrade-cluster)
+- [GKE Serial 1.6](https://k8s-testgrid.appspot.com/release-1.6-blocking#gke-serial-1.6)
+- [GKE GCI Serial 1.6](https://k8s-testgrid.appspot.com/release-1.6-blocking#gci-gke-serial-1.6)
+- [GCE Federation 1.6](https://k8s-testgrid.appspot.com/release-1.6-blocking#gce-federation-1.6)
+- [GCE Multizone](https://k8s-testgrid.appspot.com/google-gce#gce-multizone)
+
+### Action Required
+- GKE Suite Owner must be identified
+- GCE Suite Owner must be identified
+- Fix GCE skew testing
+- Fix GKE skew testing
+- Fix Federation suites
+
+## Incomplete Features
+- Open issues filed against [`kubernetes/features` in 1.6 milestone](https://github.com/kubernetes/features/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20milestone%3Av1.6): 31 (**unchanged from last report**)
+
+### Action Required
+- Feature owners fill out feature template by **TODAY!**
+- Feature owners submit docs PR which references issue in features repo by **TODAY!**
+- Feature owners prepare release notes by **TODAY!**
+- Address etcd upgrade test failures
+
+## Release Machinery
+- Large cluster testing is not running yet
+
+### Action Required
+- Start running large scale cluster testing ASAP
+
+## Actions Taken by Release Team
+- Issues optimistically moved into the 1.5 milestone
+  - https://github.com/kubernetes/kubernetes/issues/37882
+  - https://github.com/kubernetes/kubernetes/issues/37892
+  - https://github.com/kubernetes/kubernetes/issues/40679
+  - https://github.com/kubernetes/kubernetes/issues/40391
+  - https://github.com/kubernetes/kubernetes/issues/40133
+  - https://github.com/kubernetes/kubernetes/issues/40681
+  - https://github.com/kubernetes/kubernetes/issues/40960
+  - https://github.com/kubernetes/kubernetes/issues/40966
+  - https://github.com/kubernetes/kubernetes/issues/40986
+  - https://github.com/kubernetes/kubernetes/issues/40599
+  - https://github.com/kubernetes/kubernetes/issues/39292
+  - https://github.com/kubernetes/kubernetes/issues/39177
+  - https://github.com/kubernetes/kubernetes/issues/39174
+  - https://github.com/kubernetes/kubernetes/issues/39167
+  - https://github.com/kubernetes/kubernetes/issues/38530
+  - https://github.com/kubernetes/kubernetes/issues/38513
+  - https://github.com/kubernetes/kubernetes/issues/38491
+  - https://github.com/kubernetes/kubernetes/issues/38490
+  - https://github.com/kubernetes/kubernetes/issues/38489
+  - https://github.com/kubernetes/kubernetes/issues/38482
+  - https://github.com/kubernetes/kubernetes/issues/38483
+  - https://github.com/kubernetes/kubernetes/issues/38484
+  - https://github.com/kubernetes/kubernetes/issues/38485
+  - https://github.com/kubernetes/kubernetes/issues/38487
+  - https://github.com/kubernetes/kubernetes/issues/38480
+  - https://github.com/kubernetes/kubernetes/issues/38477
+  - https://github.com/kubernetes/kubernetes/issues/38472
+  - https://github.com/kubernetes/kubernetes/issues/38471
+  - https://github.com/kubernetes/kubernetes/issues/38470
+  - https://github.com/kubernetes/kubernetes/issues/38465
+  - https://github.com/kubernetes/kubernetes/issues/38307
+  - https://github.com/kubernetes/kubernetes/issues/38162
+  - https://github.com/kubernetes/kubernetes/issues/38467
+  - https://github.com/kubernetes/kubernetes/issues/38042
+  - https://github.com/kubernetes/kubernetes/issues/37940
+  - https://github.com/kubernetes/kubernetes/issues/37896
+
+- Issues optimistically moved into 1.4 milestone
+  - https://github.com/kubernetes/kubernetes/issues/39704
+  - https://github.com/kubernetes/kubernetes/issues/38055
+  - https://github.com/kubernetes/kubernetes/issues/38022
+  - https://github.com/kubernetes/kubernetes/issues/37947
+  - https://github.com/kubernetes/kubernetes/issues/37916

--- a/releases/release-1.6/go-signal-reports/2017-03-14.md
+++ b/releases/release-1.6/go-signal-reports/2017-03-14.md
@@ -1,0 +1,122 @@
+## Status: *NO GO*
+### Reasons
+- Bugs exist in 1.6 milestone
+- Flakes exist in 1.6 milestone
+- Open issues in 1.6 milestone
+- Tests unstable (missing three successful runs in a row)
+- Skew test failures
+- Upgrade test failures
+
+## Table Of Contents
+- [Issues](#issues)
+  - [Action Required](#action-required)
+  - [Flakes](#flakes)
+    - [By SIG](#by-sig)
+    - [Action Required](#action-required-1)
+  - [Bugs](#bugs)
+    - [Action Required](#action-required-2)
+- [Test Failures](#test-failures)
+  - [Action Required](#action-required-3)
+- [Suite Failures](#suite-failures)
+  - [Action Required](#action-required-4)
+- [Incomplete Features](#incomplete-features)
+  - [Action Required](#action-required-5)
+- [Release Machinery](#release-machinery)
+  - [Action Required](#action-required-6)
+- [Actions Taken by Release Team](#actions-taken-by-release-team)
+
+
+## Issues
+- [Total in milestone](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20milestone%3Av1.6): 100 (-72 from last report)
+- ["broken test run" issues in 1.6 milestone](https://github.com/kubernetes/kubernetes/issues?page=1&q=is%3Aissue+is%3Aopen+label%3Akind%2Fflake+%22broken+test+run%22++milestone%3Av1.6&utf8=%E2%9C%93): 19 (-5 from last report)
+
+### Action required
+- Ensure all issues in milestone are release blocking
+- Ensure all issues in milestone have SIG routing label
+- Ensure all issues opened by a human have an assignee. It's now possible to [assign people using prow](https://groups.google.com/forum/#!topic/kubernetes-wg-contribex/t6aceRk03Ag); thanks contribx!
+- Move all non blocking issues out of `v1.6` milestone **and into** *either* the `v1.6.1` or `v1.7` milestones 
+- Close "broken test run" issues for transient test infrastructure failures 
+- Close issues which have been addressed
+
+### Flakes
+- [Total in milestone](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6): 64 (-20 from last report)
+- [No SIG](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20-label%3Asig%2Fapi-machinery%20-label%3Asig%2Fapps%20-label%3Asig%2Fauth%20-label%3Asig%2Fautoscaling%20-label%3Asig%2Faws%20-label%3Asig%2Fcli%20-label%3Asig%2Fcluster-lifecycle%20-label%3Asig%2Fcluster-ops%20-label%3Asig%2Fcontributor-experience%20-label%3Asig%2Fdocs%20-label%3Asig%2Ffederation%20-label%3Asig%2Finstrumentation%20-label%3Asig%2Fnetwork%20-label%3Asig%2Fnode%20-label%3Asig%2Fonprem%20-label%3Asig%2Fopenstack%20-label%3Asig%2Frktnetes%20-label%3Asig%2Fscalability%20-label%3Asig%2Fscheduling%20-label%3Asig%2Fservice-catalog%20-label%3Asig%2Fstorage%20-label%3Asig%2Ftesting%20-label%3Asig%2Fwindows): 1 (-3 from last report)
+
+### By SIG
+- [API Machinery](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fapi-machinery%20): 1 (-4 from last report)
+- [AWS](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Faws): 4 (-1 from last report)
+- [Apps](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fapps): 6 (**+5 from last report**)
+- [Auth](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fauth): 0 (-1 from last report)
+- [Autoscaling](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fautoscaling): 1 (-3 from last report)
+- [Big Data](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fbig-data): 0 (-1 from last report)
+- [CLI](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fcli): 5 (**+1 from last report**)
+- [Cluster Lifecycle](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fcluster-lifecycle): 8 (**+2 from last report**)
+- [Cluster Ops](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fcluster-ops): 0 (unchanged from last report)
+- [Contributor Experience](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fcontributor-experience): 0 (unchanged from last report)
+- [Docs](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fdocs): 0 (unchanged from last report)
+- [Federation](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Ffederation): 8 (**+2 from last report**)
+- [Instrumentation](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Finstrumentation): 4 (**unchanged from last report**)
+- [Network](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fnetwork): 12 (-5 from last report)
+- [Node](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fnode): 11 (-5 from last report)
+- [On Prem](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fon-prem): 0 (unchanged from last report)
+- [OpenStack](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fopenstack): 0 (unchanged from last report)
+- [PM](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fpm): 0 (unchanged from last report)
+- [Scalability](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fscalability): 2 (**unchanged from last report**)
+- [Scheduling](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fscheduling): 5 (**unchanged from last report**)
+- [Service Catalog](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fservice-catalog): 0 (unchanged from last report)
+- [Storage](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fstorage): 8 (-3 from last report)
+- [Testing](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Ftesting): 0 (-7 from last report)
+- [UI](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fui): 0 (unchanged from last report)
+- [Windows](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fwindows): 0 (unchanged from last report)
+
+#### Action Required
+- Help route all flakes into SIGs
+- **Do not open a flake issue without assigning a SIG to that issue**
+- **Do not remove a milestone without assigning a new milestone**
+- Move all non release blocking issues out of `v1.6` milestone and into _either_ the `v1.6.1` or `v1.7` milestones
+- Assign owners for each blocking issue from each SIG for all remaining release blocking issues
+- Provide status updates within 24hrs for all flakes assigned to your SIG
+
+### Bugs
+- [Total in milestone](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fbug%20milestone%3Av1.6): 12 (-5 from last report)
+
+#### Action Required
+- Bug assignees please label all bugs with the appropriate SIG(s)
+- **Bug assignees please move all non release blocking bugs out of the `v1.6` milestone** and into the `v1.6.1` or `v1.7` milestones
+- Bug assignees please provide regular status updates for all bugs with fix or triage in progress
+- Bug assignees and SIGs please close fixed bugs
+
+## Test Failures
+
+[ not updated for this report ]
+
+### Action Required
+
+[ not updated for this report ]
+
+## Suite Failures
+
+[ not updated for this report ]
+
+### Action Required
+
+[ not updated for this report ]
+
+## Incomplete Features
+- Open issues filed against [`kubernetes/features` in 1.6 milestone](https://github.com/kubernetes/features/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20milestone%3Av1.6): 29 (-2 from last report)
+
+### Action Required
+- Feature owners fill out feature template by **TODAY!**
+- Feature owners submit docs PR which references issue in features repo by **TODAY!**
+- Feature owners prepare release notes by **TODAY!**
+- Address etcd upgrade test failures
+
+## Release Machinery
+- Large cluster testing is not running yet
+
+### Action Required
+- Start running large scale cluster testing ASAP
+
+## Actions Taken by Release Team
+
+[ not updated for this report ]

--- a/releases/release-1.6/go-signal-reports/2017-03-15.md
+++ b/releases/release-1.6/go-signal-reports/2017-03-15.md
@@ -1,0 +1,167 @@
+## Status: *NO GO*
+### Reasons
+- Bugs exist in 1.6 milestone
+- Flakes exist in 1.6 milestone
+- Open issues in 1.6 milestone
+- Tests unstable (missing three successful runs in a row)
+- Skew test failures
+- Upgrade test failures
+
+## Table Of Contents
+- [Issues](#issues)
+  - [Action Required](#action-required)
+  - [Flakes](#flakes)
+    - [By SIG](#by-sig)
+    - [Action Required](#action-required-1)
+  - [Bugs](#bugs)
+    - [Action Required](#action-required-2)
+- [Test Failures](#test-failures)
+  - [Action Required](#action-required-3)
+- [Suite Failures](#suite-failures)
+  - [Action Required](#action-required-4)
+- [Incomplete Features](#incomplete-features)
+  - [Action Required](#action-required-5)
+- [Release Machinery](#release-machinery)
+  - [Action Required](#action-required-6)
+- [Actions Taken by Release Team](#actions-taken-by-release-team)
+
+
+## Issues
+- [Total in milestone](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20milestone%3Av1.6): 29 (-71 from last report)
+- ["broken test run" issues in 1.6 milestone](https://github.com/kubernetes/kubernetes/issues?page=1&q=is%3Aissue+is%3Aopen+label%3Akind%2Fflake+%22broken+test+run%22++milestone%3Av1.6&utf8=%E2%9C%93): 6 (-13 from last report)
+
+### Action required
+- Ensure all issues in milestone are release blocking
+- Ensure all issues in milestone have SIG routing label
+- Ensure all issues opened by a human have an assignee. It's now possible to [assign people using prow](https://groups.google.com/forum/#!topic/kubernetes-wg-contribex/t6aceRk03Ag); thanks contribx!
+- Move all non blocking issues out of `v1.6` milestone **and into** *either* the `v1.6.1` or `v1.7` milestones 
+- Close "broken test run" issues for transient test infrastructure failures 
+- Close issues which have been addressed
+
+### Flakes
+- [Total in milestone](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6): 17 (-47 from last report)
+- [No SIG](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20-label%3Asig%2Fapi-machinery%20-label%3Asig%2Fapps%20-label%3Asig%2Fauth%20-label%3Asig%2Fautoscaling%20-label%3Asig%2Faws%20-label%3Asig%2Fcli%20-label%3Asig%2Fcluster-lifecycle%20-label%3Asig%2Fcluster-ops%20-label%3Asig%2Fcontributor-experience%20-label%3Asig%2Fdocs%20-label%3Asig%2Ffederation%20-label%3Asig%2Finstrumentation%20-label%3Asig%2Fnetwork%20-label%3Asig%2Fnode%20-label%3Asig%2Fonprem%20-label%3Asig%2Fopenstack%20-label%3Asig%2Frktnetes%20-label%3Asig%2Fscalability%20-label%3Asig%2Fscheduling%20-label%3Asig%2Fservice-catalog%20-label%3Asig%2Fstorage%20-label%3Asig%2Ftesting%20-label%3Asig%2Fwindows): 0 (-1 from last report). **this is awesome!**
+
+### By SIG
+- [API Machinery](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fapi-machinery%20): 2 (**+1 from last report**)
+- [AWS](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Faws): 3 (-1 from last report)
+- [Apps](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fapps): 3 (-3 from last report)
+- [Auth](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fauth): 0 (unchanged from last report)
+- [Autoscaling](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fautoscaling): 0 (-1 from last report)
+- [Big Data](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fbig-data): 0 (unchanged from last report)
+- [CLI](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fcli): 0 (-5 from last report)
+- [Cluster Lifecycle](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fcluster-lifecycle): 1 (-7 from last report)
+- [Cluster Ops](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fcluster-ops): 0 (unchanged from last report)
+- [Contributor Experience](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fcontributor-experience): 0 (unchanged from last report)
+- [Docs](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fdocs): 0 (unchanged from last report)
+- [Federation](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Ffederation): 2 (-6 from last report)
+- [Instrumentation](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Finstrumentation): 1 (-3 from last report)
+- [Network](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fnetwork): 1 (-11 from last report)
+- [Node](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fnode): 3 (-8 from last report)
+- [On Prem](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fon-prem): 0 (unchanged from last report)
+- [OpenStack](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fopenstack): 0 (unchanged from last report)
+- [PM](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fpm): 0 (unchanged from last report)
+- [Scalability](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fscalability): 0 (-2 from last report)
+- [Scheduling](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fscheduling): 1 (-4 from last report)
+- [Service Catalog](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fservice-catalog): 0 (unchanged from last report)
+- [Storage](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fstorage): 1 (-7 from last report)
+- [Testing](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Ftesting): 0 (unchanged from last report)
+- [UI](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fui): 0 (unchanged from last report)
+- [Windows](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fwindows): 0 (unchanged from last report)
+
+#### Action Required
+- Help route all flakes into SIGs
+- **Do not open a flake issue without assigning a SIG to that issue**
+- **Do not remove a milestone without assigning a new milestone**
+- Move all non release blocking issues out of `v1.6` milestone and into _either_ the `v1.6.1` or `v1.7` milestones
+- Assign owners for each blocking issue from each SIG for all remaining release blocking issues
+- Provide status updates within 24hrs for all flakes assigned to your SIG
+
+### Bugs
+- [Total in milestone](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fbug%20milestone%3Av1.6): 5 (-7 from last report)
+- [Without Milestone](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fbug%20no%3Amilestone): 103
+
+#### Action Required
+- Bug assignees please label all bugs with the appropriate SIG(s)
+- **Bug assignees please move all non release blocking bugs out of the `v1.6` milestone** and into the `v1.6.1` or `v1.7` milestones
+- Bug assignees please provide regular status updates for all bugs with fix or triage in progress
+- Bug assignees and SIGs please close fixed bugs
+- As spare time allows *please* help to begin addressing bugs without a milestone. Some of these bugs can probably be closed but we should be kind to the community and address these issues.
+
+## Test Failures
+- [k8s.io] Kubelet [Serial] [Slow] [k8s.io] regular resource usage tracking resource tracking for 100 pods per node
+- [k8s.io] Network Partition [Disruptive] [Slow] [k8s.io] Pods should be evicted from unready Node [Feature:TaintEviction] All pods on the unreachable node should be marked as NotReady upon the node turn NotReady AND all pods should be evicted after eviction timeout passes
+- [k8s.io] PersistentVolumes [Volume][Disruptive][Flaky] when kubelet restarts Should test that a file written to the mount before kubelet restart is stat-able after restart.
+- [k8s.io] PersistentVolumes [Volume][Disruptive][Flaky] when kubelet restarts Should test that a volume mounted to a pod that is deleted while the kubelet is down unmounts when the kubelet returns.
+- [k8s.io] kubelet [k8s.io] host cleanup with volume mounts [HostCleanup][Flaky] Host cleanup after pod using NFS mount is deleted [Volume][NFS] after deleting the nfs-server, the host should be cleaned-up when deleting a pod accessing the NFS vol [Serial]
+- [k8s.io] kubelet [k8s.io] host cleanup with volume mounts [HostCleanup][Flaky] Host cleanup after pod using NFS mount is deleted [Volume][NFS] after deleting the nfs-server, the host should be cleaned-up when deleting sleeping pod which mounts an NFS vol [Serial]
+- [k8s.io] Dynamic provisioning [k8s.io] DynamicProvisioner Default should be disabled by changing the default annotation[Slow] [Serial] [Disruptive] [Volume]
+- [k8s.io] Dynamic provisioning [k8s.io] DynamicProvisioner Default should be disabled by removing the default annotation[Slow] [Serial] [Disruptive] [Volume]
+- [k8s.io] Kubelet [Serial] [Slow] [k8s.io] regular resource usage tracking resource tracking for 100 pods per node
+- [k8s.io] Federated ingresses [Feature:Federation] Federated Ingresses should create and update matching ingresses in underlying clusters
+- [k8s.io] Federated ingresses [Feature:Federation] Federated Ingresses should not be deleted from underlying clusters when OrphanDependents is nil
+- [k8s.io] Federated ingresses [Feature:Federation] Federated Ingresses should not be deleted from underlying clusters when OrphanDependents is true
+- [k8s.io] Federation replicasets [Feature:Federation] Federated ReplicaSet should create and update matching replicasets in underling clusters
+- [k8s.io] Federation apiserver [Feature:Federation] Cluster objects [Serial] should be created and deleted successfully
+- [k8s.io] Kubectl client [k8s.io] Kubectl taint should remove all the taints with the same key off a node
+- [k8s.io] Kubectl client [k8s.io] Kubectl taint should update the taint on a node
+- [k8s.io] Cluster size autoscaling [Slow] shouldn't increase cluster size if pending pod is too large [Feature:ClusterSizeAutoscalingScaleUp]
+- [k8s.io] [Feature:Example] [k8s.io] Cassandra should create and scale cassandra
+- [k8s.io] [Feature:Example] [k8s.io] CassandraStatefulSet should create statefulset
+- [k8s.io] [Feature:Example] [k8s.io] Hazelcast should create and scale hazelcast
+- [k8s.io] Cluster level logging using GCL [Slow] [Flaky] should create a constant load with short-living pods and ensure logs delivery
+- [k8s.io] Addon update should propagate add-on file changes [Slow]
+- [k8s.io] Network Partition [Disruptive] [Slow] [k8s.io] [StatefulSet] should not reschedule stateful pods if there is a network partition [Slow] [Disruptive]
+- [k8s.io] Upgrade [Feature:Upgrade] [k8s.io] cluster upgrade should maintain a functioning cluster [Feature:ClusterUpgrade]
+- [k8s.io] DNS horizontal autoscaling kube-dns-autoscaler should scale kube-dns pods in both nonfaulty and faulty scenarios
+- [k8s.io] Rescheduler [Serial] should ensure that critical pod is scheduled in case there is no resources available 
+- [k8s.io] Daemon set [Serial] Should adopt or recreate existing pods when creating a RollingUpdate DaemonSet with matching or mismatching templateGeneration
+
+
+### Action Required
+- Address all test failures *immediately*
+- Fix or delete Cassandra, Hazelcast tests
+
+## Suite Failures
+- https://k8s-testgrid.appspot.com/google-aws#kops-aws-serial
+- https://k8s-testgrid.appspot.com/google-gke#gci-gke-autoscaling
+- https://k8s-testgrid.appspot.com/google-gke#gke-autoscaling
+- https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-container_vm-1.5-container_vm-1.6-upgrade-master
+- https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-gci-1.4-gci-1.6-upgrade-cluster
+- https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-gci-1.5-container_vm-1.6-upgrade-cluster
+- https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-gci-1.5-gci-1.6-upgrade-cluster
+- https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gce-1.5-1.6-upgrade-cluster
+- https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-container_vm-1.4-gci-1.6-upgrade-cluster
+- https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-container_vm-1.5-container_vm-1.6-upgrade-cluster
+- https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-container_vm-1.4-container_vm-1.6-upgrade-master
+- https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gce-1.5-1.6-upgrade-cluster
+- https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gce-1.5-1.6-upgrade-master
+- https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-container_vm-1.4-container_vm-1.6-upgrade-cluster
+- https://k8s-testgrid.appspot.com/etcd-upgrades#gce-latest
+- https://k8s-testgrid.appspot.com/google-kubectl-skew#gke-latest-1.4-cvm
+- https://k8s-testgrid.appspot.com/google-kubectl-skew#gke-latest-1.4-gci
+- https://k8s-testgrid.appspot.com/google-kubectl-skew#gce-latest-1.4-cvm
+- https://k8s-testgrid.appspot.com/google-kubectl-skew#gce-latest-1.4-gci
+- https://k8s-testgrid.appspot.com/kubernetes-apps#charts-gce
+
+### Action Required
+- Address all suite failures *immediately*
+
+## Incomplete Features
+- Open issues filed against [`kubernetes/features` in 1.6 milestone](https://github.com/kubernetes/features/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20milestone%3Av1.6): 29 (**unchanged from last report**)
+
+### Action Required
+- Feature owners fill out feature template by **TODAY!**
+- Feature owners submit docs PR which references issue in features repo by **TODAY!**
+- Feature owners prepare release notes by **TODAY!**
+- Address etcd upgrade test failures
+- Begin adding human curated release notes to [the release notes draft](https://github.com/kubernetes/features/blob/release-notes-draft-1.6/release-1.6/release-notes-draft.md) by Friday, 17 March 2017 **please commit directly to the `release-notes-draft-1.6` branch so we can comment on the [associated PR](https://github.com/kubernetes/features/pull/203) collectively** 
+
+## Release Machinery
+- Large cluster testing is not running yet
+
+### Action Required
+- Start running large scale cluster testing ASAP
+
+## Actions Taken by Release Team
+- Plan to send out request for human curation of release notes by EOD 2017-03-15

--- a/releases/release-1.6/go-signal-reports/2017-03-16.md
+++ b/releases/release-1.6/go-signal-reports/2017-03-16.md
@@ -1,0 +1,151 @@
+## Status: *NO GO*
+### Reasons
+- Bugs exist in 1.6 milestone
+- Flakes exist in 1.6 milestone
+- Open issues in 1.6 milestone
+- Tests unstable (missing three successful runs in a row)
+- Skew test failures
+- Upgrade test failures
+
+## Table Of Contents
+- [Issues](#issues)
+  - [Action Required](#action-required)
+  - [Flakes](#flakes)
+    - [By SIG](#by-sig)
+    - [Action Required](#action-required-1)
+  - [Bugs](#bugs)
+    - [Action Required](#action-required-2)
+- [Test Failures](#test-failures)
+  - [Action Required](#action-required-3)
+- [Suite Failures](#suite-failures)
+  - [Action Required](#action-required-4)
+- [Incomplete Features](#incomplete-features)
+  - [Action Required](#action-required-5)
+- [Release Machinery](#release-machinery)
+  - [Action Required](#action-required-6)
+- [Actions Taken by Release Team](#actions-taken-by-release-team)
+
+
+## Issues
+- [Total in milestone](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20milestone%3Av1.6): 29 (**unchanged from last report**)
+- ["broken test run" issues in 1.6 milestone](https://github.com/kubernetes/kubernetes/issues?page=1&q=is%3Aissue+is%3Aopen+label%3Akind%2Fflake+%22broken+test+run%22++milestone%3Av1.6&utf8=%E2%9C%93): 7 (**+1 from last report**)
+
+### Action required
+- Ensure all issues in milestone are release blocking
+- Ensure all issues in milestone have SIG routing label
+- Ensure all issues opened by a human have an assignee. It's now possible to [assign people using prow](https://groups.google.com/forum/#!topic/kubernetes-wg-contribex/t6aceRk03Ag); thanks contribx!
+- Move all non blocking issues out of `v1.6` milestone **and into** *either* the `v1.6.1` or `v1.7` milestones 
+- Close "broken test run" issues for transient test infrastructure failures 
+- Close issues which have been addressed
+- Close issues opened by GCP infrastructure failures on 15 March 2017 
+
+### Flakes
+- [Total in milestone](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6): 16 (-1 from last report)
+- [No SIG](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20-label%3Asig%2Fapi-machinery%20-label%3Asig%2Fapps%20-label%3Asig%2Fauth%20-label%3Asig%2Fautoscaling%20-label%3Asig%2Faws%20-label%3Asig%2Fcli%20-label%3Asig%2Fcluster-lifecycle%20-label%3Asig%2Fcluster-ops%20-label%3Asig%2Fcontributor-experience%20-label%3Asig%2Fdocs%20-label%3Asig%2Ffederation%20-label%3Asig%2Finstrumentation%20-label%3Asig%2Fnetwork%20-label%3Asig%2Fnode%20-label%3Asig%2Fonprem%20-label%3Asig%2Fopenstack%20-label%3Asig%2Frktnetes%20-label%3Asig%2Fscalability%20-label%3Asig%2Fscheduling%20-label%3Asig%2Fservice-catalog%20-label%3Asig%2Fstorage%20-label%3Asig%2Ftesting%20-label%3Asig%2Fwindows): 5 (**+5 from last report**)
+
+### By SIG
+- [API Machinery](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fapi-machinery%20): 1 (**unchanged from last report**)
+- [AWS](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Faws): 0 (-3 from last report)
+- [Apps](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fapps): 1 (-2 from last report)
+- [Auth](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fauth): 0 (unchanged from last report)
+- [Autoscaling](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fautoscaling): 0 (unchanged from last report)
+- [Big Data](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fbig-data): 0 (unchanged from last report)
+- [CLI](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fcli): 0 (unchanged from last report)
+- [Cluster Lifecycle](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fcluster-lifecycle): 1 (**unchanged from last report**)
+- [Cluster Ops](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fcluster-ops): 0 (unchanged from last report)
+- [Contributor Experience](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fcontributor-experience): 0 (unchanged from last report)
+- [Docs](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fdocs): 0 (unchanged from last report)
+- [Federation](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Ffederation): 3 (**+1 from last report**)
+- [Instrumentation](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Finstrumentation): 1 (**unchanged from last report**)
+- [Network](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fnetwork): 1 (**unchanged from last report**)
+- [Node](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fnode): 0 (-3 from last report)
+- [On Prem](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fon-prem): 0 (unchanged from last report)
+- [OpenStack](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fopenstack): 0 (unchanged from last report)
+- [PM](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fpm): 0 (unchanged from last report)
+- [Scalability](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fscalability): 0 (unchanged from last report)
+- [Scheduling](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fscheduling): 0 (-1 from last report)
+- [Service Catalog](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fservice-catalog): 0 (unchanged from last report)
+- [Storage](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fstorage): 1 (**unchanged from last report**)
+- [Testing](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Ftesting): 0 (unchanged from last report)
+- [UI](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fui): 0 (unchanged from last report)
+- [Windows](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fwindows): 0 (unchanged from last report)
+
+#### Action Required
+- Help route all flakes into SIGs
+- **Do not open a flake issue without assigning a SIG to that issue**
+- **Do not remove a milestone without assigning a new milestone**
+- Move all non release blocking issues out of `v1.6` milestone and into _either_ the `v1.6.1` or `v1.7` milestones
+- Assign owners for each blocking issue from each SIG for all remaining release blocking issues
+- Provide status updates within 24hrs for all flakes assigned to your SIG
+
+### Bugs
+- [Total in milestone](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fbug%20milestone%3Av1.6): 6 (**+1 from last report**)
+- [Without Milestone](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fbug%20no%3Amilestone): 104 (**+1 from last report**)
+
+#### Action Required
+- Bug assignees please label all bugs with the appropriate SIG(s)
+- **Bug assignees please move all non release blocking bugs out of the `v1.6` milestone** and into the `v1.6.1` or `v1.7` milestones
+- Bug assignees please provide regular status updates for all bugs with fix or triage in progress
+- Bug assignees and SIGs please close fixed bugs
+- As spare time allows *please* help to begin addressing bugs without a milestone. Some of these bugs can probably be closed but we should be kind to the community and address these issues.
+
+## Test Failures
+- [k8s.io] Services should be able to change the type and ports of a service [Slow]
+- [k8s.io] Services should only allow access from service loadbalancer source ranges [Slow]
+- [k8s.io] Kubelet [Serial] [Slow] [k8s.io] regular resource usage tracking resource tracking for 0 pods per node
+- [k8s.io] Kubelet [Serial] [Slow] [k8s.io] regular resource usage tracking resource tracking for 100 pods per node
+- [k8s.io] Network Partition [Disruptive] [Slow] [k8s.io] [Job] should create new pods when node is partitioned
+- [k8s.io] Network Partition [Disruptive] [Slow] [k8s.io] [ReplicationController] should eagerly create replacement pod during network partition when termination grace is non-zero
+- [k8s.io] Network Partition [Disruptive] [Slow] [k8s.io] [ReplicationController] should recreate pods scheduled on the unreachable node AND allow scheduling of pods on a node after it rejoins the cluster
+- [k8s.io] kubelet [k8s.io] host cleanup with volume mounts [HostCleanup][Flaky] Host cleanup after pod using NFS mount is deleted [Volume][NFS] after deleting the nfs-server, the host should be cleaned-up when deleting a pod accessing the NFS vol [Serial]
+- [k8s.io] kubelet [k8s.io] host cleanup with volume mounts [HostCleanup][Flaky] Host cleanup after pod using NFS mount is deleted [Volume][NFS] after deleting the nfs-server, the host should be cleaned-up when deleting sleeping pod which mounts an NFS vol [Serial]
+- [k8s.io] PersistentVolumes [Volume][Disruptive][Flaky] when kubelet restarts Should test that a file written to the mount before kubelet restart is stat-able after restart.
+- [k8s.io] PersistentVolumes [Volume][Disruptive][Flaky] when kubelet restarts Should test that a volume mounted to a pod that is deleted while the kubelet is down unmounts when the kubelet returns.
+- [k8s.io] Dynamic provisioning [k8s.io] DynamicProvisioner Default should be disabled by changing the default annotation[Slow] [Serial] [Disruptive] [Volume]
+- [k8s.io] Dynamic provisioning [k8s.io] DynamicProvisioner Default should be disabled by removing the default annotation[Slow] [Serial] [Disruptive] [Volume]
+- [k8s.io] Federated ingresses [Feature:Federation] Federated Ingresses should create and update matching ingresses in underlying cluster
+- [k8s.io] Federated ingresses [Feature:Federation] Federated Ingresses should not be deleted from underlying clusters when OrphanDependents is nil
+- [k8s.io] Federated ingresses [Feature:Federation] Federated Ingresses should not be deleted from underlying clusters when OrphanDependents is true
+- [k8s.io] Federation deployments [Feature:Federation] Federated Deployment should create and update matching deployments in underlying clusters
+- [k8s.io] Federation replicasets [Feature:Federation] Federated ReplicaSet should create and update matching replicasets in underling clusters
+- [k8s.io] Federation apiserver [Feature:Federation] Cluster objects [Serial] should be created and deleted successfully
+- [k8s.io] Network Partition [Disruptive] [Slow] [k8s.io] [StatefulSet] should not reschedule stateful pods if there is a network partition [Slow] [Disruptive]
+
+### Action Required
+- Address all test failures *immediately*
+- Fix or delete Cassandra, Hazelcast tests
+
+## Suite Failures
+- https://k8s-testgrid.appspot.com/google-gke#gci-gke-autoscaling
+- https://k8s-testgrid.appspot.com/etcd-upgrades#gce-rollback-latest
+- https://k8s-testgrid.appspot.com/release-1.6-all#gci-gke-serial-1.6
+- https://k8s-testgrid.appspot.com/release-1.6-all#gke-serial-1.6
+- https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#Summary
+  - https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gce-1.5-1.6-upgrade-cluster
+  - https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gce-1.5-1.6-upgrade-master
+  - https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-container_vm-1.5-container_vm-1.6-upgrade-master
+  - https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-gci-1.5-container_vm-1.6-upgrade-master
+- https://k8s-testgrid.appspot.com/kubernetes-apps#charts-gce
+
+### Action Required
+- Address all suite failures *immediately*
+- Pay particular attention to skew test failures
+
+## Incomplete Features
+- Open issues filed against [`kubernetes/features` in 1.6 milestone](https://github.com/kubernetes/features/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20milestone%3Av1.6): 29 (**unchanged from last report**)
+
+### Action Required
+- Feature owners fill out feature template by **TODAY!**
+- Feature owners submit docs PR which references issue in features repo by **TODAY!**
+- Feature owners prepare release notes by **TODAY!**
+- Address etcd upgrade test failures
+- Begin adding human curated release notes to [the release notes draft](https://github.com/kubernetes/features/blob/release-notes-draft-1.6/release-1.6/release-notes-draft.md) by Friday, 17 March 2017 **please commit directly to the `release-notes-draft-1.6` branch so we can comment on the [associated PR](https://github.com/kubernetes/features/pull/203) collectively** 
+
+## Release Machinery
+- Timeouts during upgrade tests
+
+### Action Required
+- Fix upgrade tests, ensure large scale testing is not impacted
+
+## Actions Taken by Release Team
+[ not updated for this report]

--- a/releases/release-1.6/go-signal-reports/2017-03-16.md
+++ b/releases/release-1.6/go-signal-reports/2017-03-16.md
@@ -139,7 +139,7 @@
 - Feature owners submit docs PR which references issue in features repo by **TODAY!**
 - Feature owners prepare release notes by **TODAY!**
 - Address etcd upgrade test failures
-- Begin adding human curated release notes to [the release notes draft](https://github.com/kubernetes/features/blob/release-notes-draft-1.6/release-1.6/release-notes-draft.md) by Friday, 17 March 2017 **please commit directly to the `release-notes-draft-1.6` branch so we can comment on the [associated PR](https://github.com/kubernetes/features/pull/203) collectively** 
+- Begin adding human curated release notes to [the release notes draft](https://github.com/kubernetes/sig-release/blob/release-notes-draft-1.6/release-1.6/release-notes-draft.md) by Friday, 17 March 2017 **please commit directly to the `release-notes-draft-1.6` branch so we can comment on the [associated PR](https://github.com/kubernetes/features/pull/203) collectively** 
 
 ## Release Machinery
 - Timeouts during upgrade tests

--- a/releases/release-1.6/go-signal-reports/2017-03-17.md
+++ b/releases/release-1.6/go-signal-reports/2017-03-17.md
@@ -1,0 +1,178 @@
+## Status: *NO GO*
+### Reasons
+- Bugs exist in 1.6 milestone
+- Flakes exist in 1.6 milestone
+- Open issues in 1.6 milestone
+- Tests unstable (missing three successful runs in a row)
+- Skew test failures
+- Upgrade test failures
+
+## Table Of Contents
+- [Issues](#issues)
+  - [Action Required](#action-required)
+  - [Flakes](#flakes)
+    - [By SIG](#by-sig)
+    - [Action Required](#action-required-1)
+  - [Bugs](#bugs)
+    - [Action Required](#action-required-2)
+- [Test Failures](#test-failures)
+  - [Action Required](#action-required-3)
+- [Suite Failures](#suite-failures)
+  - [Action Required](#action-required-4)
+- [Incomplete Features](#incomplete-features)
+  - [Action Required](#action-required-5)
+- [Release Machinery](#release-machinery)
+  - [Action Required](#action-required-6)
+- [Actions Taken by Release Team](#actions-taken-by-release-team)
+
+
+## Issues
+- [Total in milestone](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20milestone%3Av1.6): 15 (-4 from last report)
+- ["broken test run" issues in 1.6 milestone](https://github.com/kubernetes/kubernetes/issues?page=1&q=is%3Aissue+is%3Aopen+label%3Akind%2Fflake+%22broken+test+run%22++milestone%3Av1.6&utf8=%E2%9C%93): 2 (-5 from last report)
+
+### Action required
+- Ensure all issues in milestone are release blocking
+- Ensure all issues in milestone have SIG routing label
+- Ensure all issues opened by a human have an assignee. It's now possible to [assign people using prow](https://groups.google.com/forum/#!topic/kubernetes-wg-contribex/t6aceRk03Ag); thanks contribx!
+- Move all non blocking issues out of `v1.6` milestone **and into** *either* the `v1.6.1` or `v1.7` milestones 
+- Close "broken test run" issues for transient test infrastructure failures 
+- Close issues which have been addressed
+- Close issues opened by GCP infrastructure failures on 15 March 2017 
+
+### Flakes
+- [Total in milestone](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6): 5 (-11 from last report)
+- [No SIG](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20-label%3Asig%2Fapi-machinery%20-label%3Asig%2Fapps%20-label%3Asig%2Fauth%20-label%3Asig%2Fautoscaling%20-label%3Asig%2Faws%20-label%3Asig%2Fcli%20-label%3Asig%2Fcluster-lifecycle%20-label%3Asig%2Fcluster-ops%20-label%3Asig%2Fcontributor-experience%20-label%3Asig%2Fdocs%20-label%3Asig%2Ffederation%20-label%3Asig%2Finstrumentation%20-label%3Asig%2Fnetwork%20-label%3Asig%2Fnode%20-label%3Asig%2Fonprem%20-label%3Asig%2Fopenstack%20-label%3Asig%2Frktnetes%20-label%3Asig%2Fscalability%20-label%3Asig%2Fscheduling%20-label%3Asig%2Fservice-catalog%20-label%3Asig%2Fstorage%20-label%3Asig%2Ftesting%20-label%3Asig%2Fwindows): 0 (-5 from last report)
+- [Flakes without milestone](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20no%3Amilestone): 0
+
+### By SIG
+- [API Machinery](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fapi-machinery%20): 0 (-1 from last report)
+- [AWS](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Faws): 0 (unchanged from last report)
+- [Apps](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fapps): 1 (**unchanged from last report**)
+- [Auth](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fauth): 0 (unchanged from last report)
+- [Autoscaling](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fautoscaling): 0 (unchanged from last report)
+- [Big Data](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fbig-data): 0 (unchanged from last report)
+- [CLI](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fcli): 0 (unchanged from last report)
+- [Cluster Lifecycle](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fcluster-lifecycle): 1 (**unchanged from last report**)
+- [Cluster Ops](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fcluster-ops): 0 (unchanged from last report)
+- [Contributor Experience](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fcontributor-experience): 0 (unchanged from last report)
+- [Docs](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fdocs): 0 (unchanged from last report)
+- [Federation](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Ffederation): 2 (-1 from last report)
+- [Instrumentation](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Finstrumentation): 0 (-1 from last report)
+- [Network](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fnetwork): 0 (-1 from last report)
+- [Node](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fnode): 0 (unchanged from last report)
+- [On Prem](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fon-prem): 0 (unchanged from last report)
+- [OpenStack](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fopenstack): 0 (unchanged from last report)
+- [PM](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fpm): 0 (unchanged from last report)
+- [Scalability](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fscalability): 0 (unchanged from last report)
+- [Scheduling](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fscheduling): 0 (-1 from last report)
+- [Service Catalog](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fservice-catalog): 0 (unchanged from last report)
+- [Storage](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fstorage): 0 (-1 from last report)
+- [Testing](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Ftesting): 1 (**+1 from last report**)
+- [UI](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fui): 0 (unchanged from last report)
+- [Windows](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fwindows): 0 (unchanged from last report)
+
+#### Action Required
+- **Do not open a flake issue without assigning a SIG to that issue**
+- **Do not remove a milestone without assigning a new milestone**
+- Move all non release blocking issues out of `v1.6` milestone and into _either_ the `v1.6.1` or `v1.7` milestones
+- Assign owners for each blocking issue from each SIG for all remaining release blocking issues
+- Provide status updates within 24hrs for all flakes assigned to your SIG
+- Continue to ensure flakes are moved into the correct milestone
+  - 1.6 *for blocking issues*
+  - 1.6.1 *for important but not blocking issues*
+  - 1.7 *for non critical issues to address later*
+
+### Bugs
+- [Total in milestone](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fbug%20milestone%3Av1.6): 4 (-2 from last report)
+- [Without Milestone](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fbug%20no%3Amilestone): 104 (**unchanged from last report**)
+
+#### Action Required
+- Bug assignees please label all bugs with the appropriate SIG(s)
+- **Bug assignees please move all non release blocking bugs out of the `v1.6` milestone** and into the `v1.6.1` or `v1.7` milestones
+- Bug assignees please provide regular status updates for all bugs with fix or triage in progress
+- Bug assignees and SIGs please close fixed bugs
+- As spare time allows *please* help to begin addressing bugs without a milestone. Some of these bugs can probably be closed but we should be kind to the community and address these issues.
+
+## Test Failures
+- [k8s.io] Services should be able to change the type and ports of a service [Slow]
+- [k8s.io] Services should only allow access from service loadbalancer source ranges [Slow]
+- [k8s.io] Services should work after restarting apiserver [Disruptive]	
+- [k8s.io] Kubelet [Serial] [Slow] [k8s.io] regular resource usage tracking resource tracking for 0 pods per node
+- [k8s.io] Kubelet [Serial] [Slow] [k8s.io] regular resource usage tracking resource tracking for 100 pods per node
+- [k8s.io] Network Partition [Disruptive] [Slow] [k8s.io] [Job] should create new pods when node is partitioned
+- [k8s.io] Network Partition [Disruptive] [Slow] [k8s.io] [ReplicationController] should eagerly create replacement pod during network partition when termination grace is non-zero
+- [k8s.io] Network Partition [Disruptive] [Slow] [k8s.io] [ReplicationController] should recreate pods scheduled on the unreachable node AND allow scheduling of pods on a node after it rejoins the cluster
+- [k8s.io] Cluster level logging using GCL [Flaky] should check that logs from containers are ingested in GCL
+- [k8s.io] Cluster level logging using GCL [Slow] [Flaky] should create a constant load with long-living pods and ensure logs delivery
+- [k8s.io] Cluster level logging using GCL [Slow] [Flaky] should create a constant load with short-living pods and ensure logs delivery	
+- [k8s.io] kubelet [k8s.io] host cleanup with volume mounts [HostCleanup][Flaky] Host cleanup after pod using NFS mount is deleted [Volume][NFS] after deleting the nfs-server, the host should be cleaned-up when deleting a pod accessing the NFS vol [Serial]
+- [k8s.io] kubelet [k8s.io] host cleanup with volume mounts [HostCleanup][Flaky] Host cleanup after pod using NFS mount is deleted [Volume][NFS] after deleting the nfs-server, the host should be cleaned-up when deleting sleeping pod which mounts an NFS vol [Serial]
+- [k8s.io] PersistentVolumes [Volume][Disruptive][Flaky] when kubelet restarts Should test that a file written to the mount before kubelet restart is stat-able after restart.
+- [k8s.io] PersistentVolumes [Volume][Disruptive][Flaky] when kubelet restarts Should test that a volume mounted to a pod that is deleted while the kubelet is down unmounts when the kubelet returns.
+- [k8s.io] Dynamic provisioning [k8s.io] DynamicProvisioner Default should be disabled by changing the default annotation[Slow] [Serial] [Disruptive] [Volume]
+- [k8s.io] Dynamic provisioning [k8s.io] DynamicProvisioner Default should be disabled by removing the default annotation[Slow] [Serial] [Disruptive] [Volume]
+- [k8s.io] Federated ingresses [Feature:Federation] Federated Ingresses Ingress connectivity and DNS should be able to connect to a federated ingress via its load balancer
+- [k8s.io] Federated ingresses [Feature:Federation] Federated Ingresses should be deleted from underlying clusters when OrphanDependents is false
+- [k8s.io] Federated ingresses [Feature:Federation] Federated Ingresses should create and update matching ingresses in underlying clusters
+- [k8s.io] Federated ingresses [Feature:Federation] Federated Ingresses should not be deleted from underlying clusters when OrphanDependents is nilChanges
+- [k8s.io] Federated ingresses [Feature:Federation] Federated Ingresses should not be deleted from underlying clusters when OrphanDependents is trueChanges
+- [k8s.io] Federation deployments [Feature:Federation] Federated Deployment should create and update matching deployments in underlying clusters
+- [k8s.io] Federation replicasets [Feature:Federation] Federated ReplicaSet should create and update matching replicasets in underling clusters
+- [k8s.io] Network Partition [Disruptive] [Slow] [k8s.io] [StatefulSet] should not reschedule stateful pods if there is a network partition [Slow] [Disruptive]
+- [k8s.io] Rescheduler [Serial] should ensure that critical pod is scheduled in case there is no resources available
+
+### Action Required
+- Address all test failures *immediately*
+- Fix or delete Cassandra, Hazelcast tests
+- Address DynamicProvisioner regression **has not been fixed**
+- Use the new [triage tool](https://storage.googleapis.com/k8s-gubernator/triage/index.html?test=Simple%20pod%20should%20handle%20in-cluster%20config%7CNginx%20should%20conform%20to%20Ingress%20spec%7CPreStop%20should%20call%20prestop%20when%20killing%20a%20pod), thanks SIG Testing and Team/Test-Infra!
+
+## Suite Failures
+- https://k8s-testgrid.appspot.com/latest-upgrades#gce-cluster
+- https://k8s-testgrid.appspot.com/etcd-upgrades#gce-latest
+- https://k8s-testgrid.appspot.com/google-gke-latest-upgrade#gci-1.4-gci-latest-upgrade-master
+- https://k8s-testgrid.appspot.com/google-gke-latest-upgrade#gci-1.4-gci-latest-upgrade-cluster
+- https://k8s-testgrid.appspot.com/google-gke-latest-upgrade#gci-1.4-container_vm-latest-upgrade-cluster
+- https://k8s-testgrid.appspot.com/google-gke-latest-upgrade#container_vm-1.4-gci-latest-upgrade-master
+- https://k8s-testgrid.appspot.com/google-gke-latest-upgrade#container_vm-1.4-gci-latest-upgrade-cluster
+- https://k8s-testgrid.appspot.com/google-gke-latest-upgrade#container_vm-1.4-container_vm-latest-upgrade-cluster
+- https://k8s-testgrid.appspot.com/release-1.6-all#gce-federation-1.6
+- https://k8s-testgrid.appspot.com/etcd-upgrades#gce-rollback-latest (signal unclear due to flake period)
+- https://k8s-testgrid.appspot.com/release-1.6-all#gci-gke-serial-1.6
+- https://k8s-testgrid.appspot.com/release-1.6-all#gke-serial-1.6
+- https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#Summary
+  - https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gce-1.5-1.6-upgrade-cluster
+  - https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gce-1.5-1.6-upgrade-master
+  - https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-gci-1.5-container_vm-1.6-upgrade-cluster
+  - https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-container_vm-1.5-container_vm-1.6-upgrade-master
+  - https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-gci-1.5-container_vm-1.6-upgrade-master
+  - https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-gci-1.5-gci-1.6-upgrade-cluster
+- https://k8s-testgrid.appspot.com/kubernetes-apps#charts-gce
+
+### Action Required
+- Address all suite failures *immediately*
+- Pay particular attention to skew test failures
+
+## Incomplete Features
+- Open issues filed against [`kubernetes/features` in 1.6 milestone](https://github.com/kubernetes/features/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20milestone%3Av1.6): 29 (**unchanged from last report**)
+- PRs still needing docs
+  - https://github.com/kubernetes/features/issues/93
+  - https://github.com/kubernetes/features/issues/54
+  - https://github.com/kubernetes/features/issues/97
+  - https://github.com/kubernetes/features/issues/88 
+
+### Action Required
+- Feature owners fill out feature template by **TODAY!**
+- Feature owners submit docs PR which references issue in features repo by **TODAY!**
+- Feature owners prepare release notes by **TODAY!**
+- Address etcd upgrade test failures
+- Begin adding human curated release notes to [the release notes draft](https://github.com/kubernetes/features/blob/release-notes-draft-1.6/release-1.6/release-notes-draft.md) by **TODAY** **please commit directly to the `release-notes-draft-1.6` branch so we can comment on the [associated PR](https://github.com/kubernetes/features/pull/203) collectively** 
+
+## Release Machinery
+- Timeouts during upgrade tests
+
+### Action Required
+- Fix upgrade tests, ensure large scale testing is not impacted
+
+## Actions Taken by Release Team
+[ not updated for this report]

--- a/releases/release-1.6/go-signal-reports/2017-03-20.md
+++ b/releases/release-1.6/go-signal-reports/2017-03-20.md
@@ -1,0 +1,163 @@
+## Status: *NO GO*
+### Reasons
+- Bugs exist in 1.6 milestone
+- Flakes exist in 1.6 milestone
+- Open issues in 1.6 milestone
+- Tests unstable (missing three successful runs in a row)
+- Skew test failures
+- Upgrade test failures
+
+## Table Of Contents
+- [Issues](#issues)
+  - [Action Required](#action-required)
+  - [Flakes](#flakes)
+    - [By SIG](#by-sig)
+    - [Action Required](#action-required-1)
+  - [Bugs](#bugs)
+    - [Action Required](#action-required-2)
+- [Test Failures](#test-failures)
+  - [Action Required](#action-required-3)
+- [Suite Failures](#suite-failures)
+  - [Action Required](#action-required-4)
+- [Incomplete Features](#incomplete-features)
+  - [Action Required](#action-required-5)
+- [Release Machinery](#release-machinery)
+  - [Action Required](#action-required-6)
+- [Actions Taken by Release Team](#actions-taken-by-release-team)
+
+
+## Issues
+- [Total in milestone](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20milestone%3Av1.6): 16 (**+1 from last report**)
+- ["broken test run" issues in 1.6 milestone](https://github.com/kubernetes/kubernetes/issues?page=1&q=is%3Aissue+is%3Aopen+label%3Akind%2Fflake+%22broken+test+run%22++milestone%3Av1.6&utf8=%E2%9C%93): 2 (**unchanged from last report**)
+
+### Action required
+- Ensure all issues in milestone are release blocking
+- Ensure all issues in milestone have SIG routing label
+- Ensure all issues opened by a human have an assignee. It's now possible to [assign people using prow](https://groups.google.com/forum/#!topic/kubernetes-wg-contribex/t6aceRk03Ag); thanks contribx!
+- Move all non blocking issues out of `v1.6` milestone **and into** *either* the `v1.6.1` or `v1.7` milestones 
+- Close "broken test run" issues for transient test infrastructure failures 
+- Close issues which have been addressed
+- Close issues opened by GCP infrastructure failures on 15 March 2017 
+
+### Flakes
+- [Total in milestone](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6): 6 (**+1 from last report**)
+- [No SIG](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20-label%3Asig%2Fapi-machinery%20-label%3Asig%2Fapps%20-label%3Asig%2Fauth%20-label%3Asig%2Fautoscaling%20-label%3Asig%2Faws%20-label%3Asig%2Fcli%20-label%3Asig%2Fcluster-lifecycle%20-label%3Asig%2Fcluster-ops%20-label%3Asig%2Fcontributor-experience%20-label%3Asig%2Fdocs%20-label%3Asig%2Ffederation%20-label%3Asig%2Finstrumentation%20-label%3Asig%2Fnetwork%20-label%3Asig%2Fnode%20-label%3Asig%2Fonprem%20-label%3Asig%2Fopenstack%20-label%3Asig%2Frktnetes%20-label%3Asig%2Fscalability%20-label%3Asig%2Fscheduling%20-label%3Asig%2Fservice-catalog%20-label%3Asig%2Fstorage%20-label%3Asig%2Ftesting%20-label%3Asig%2Fwindows): 3 (**+3 from last report**)
+- [Flakes without milestone](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20no%3Amilestone): 0
+
+### By SIG
+- [API Machinery](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fapi-machinery%20): 0 (unchanged from last report)
+- [AWS](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Faws): 0 (unchanged from last report)
+- [Apps](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fapps): 0 (-1 from last report)
+- [Auth](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fauth): 0 (unchanged from last report)
+- [Autoscaling](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fautoscaling): 0 (unchanged from last report)
+- [Big Data](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fbig-data): 0 (unchanged from last report)
+- [CLI](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fcli): 0 (unchanged from last report)
+- [Cluster Lifecycle](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fcluster-lifecycle): 0 (-1 from last report)
+- [Cluster Ops](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fcluster-ops): 0 (unchanged from last report)
+- [Contributor Experience](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fcontributor-experience): 0 (unchanged from last report)
+- [Docs](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fdocs): 0 (unchanged from last report)
+- [Federation](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Ffederation): 2 (**unchanged from last report**)
+- [Instrumentation](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Finstrumentation): 0 (unchanged from last report)
+- [Network](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fnetwork): 0 (unchanged from last report)
+- [Node](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fnode): 0 (unchanged from last report)
+- [On Prem](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fon-prem): 0 (unchanged from last report)
+- [OpenStack](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fopenstack): 0 (unchanged from last report)
+- [PM](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fpm): 0 (unchanged from last report)
+- [Scalability](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fscalability): 0 (unchanged from last report)
+- [Scheduling](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fscheduling): 0 (unchanged from last report)
+- [Service Catalog](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fservice-catalog): 0 (unchanged from last report)
+- [Storage](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fstorage): 0 (unchanged from last report)
+- [Testing](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Ftesting): 1 (**unchanged from last report**)
+- [UI](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fui): 0 (unchanged from last report)
+- [Windows](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fwindows): 0 (unchanged from last report)
+
+#### Action Required
+- **Do not open a flake issue without assigning a SIG to that issue**
+- **Do not remove a milestone without assigning a new milestone**
+- Move all non release blocking issues out of `v1.6` milestone and into _either_ the `v1.6.1` or `v1.7` milestones
+- Assign owners for each blocking issue from each SIG for all remaining release blocking issues
+- Provide status updates within 24hrs for all flakes assigned to your SIG
+- Continue to ensure flakes are moved into the correct milestone
+  - 1.6 *for blocking issues*
+  - 1.6.1 *for important but not blocking issues*
+  - 1.7 *for non critical issues to address later*
+
+### Bugs
+- [Total in 1.6 milestone](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fbug%20milestone%3Av1.6): 5 (**+1 from last report**)
+- [Without Milestone](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fbug%20no%3Amilestone): 105 (**+1 from last report**)
+
+#### Action Required
+- Bug assignees please label all bugs with the appropriate SIG(s)
+- **Bug assignees please move all non release blocking bugs out of the `v1.6` milestone** and into the `v1.6.1` or `v1.7` milestones
+- Bug assignees please provide regular status updates for all bugs with fix or triage in progress
+- Bug assignees and SIGs please close fixed bugs
+- As spare time allows *please* help to begin addressing bugs without a milestone. Some of these bugs can probably be closed but we should be kind to the community and address these issues.
+
+## Test Failures
+- [k8s.io] [Feature:Example] [k8s.io] Cassandra should create and scale cassandra
+- [k8s.io] [Feature:Example] [k8s.io] CassandraStatefulSet should create statefulset
+- [k8s.io] [Feature:Example] [k8s.io] Hazelcast should create and scale hazelcast
+
+### Action Required
+- Please remove Cassandra and Hazelcast example tests which seem to be misconfigured
+
+## Suite Failures
+- https://k8s-testgrid.appspot.com/latest-upgrades#gce-cluster
+- https://k8s-testgrid.appspot.com/etcd-upgrades#gce-latest
+- https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#Summary
+  - https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gce-1.5-1.6-upgrade-cluster
+  - https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gce-1.5-1.6-upgrade-master
+  - https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-gci-1.5-container_vm-1.6-upgrade-cluster
+  - https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-gci-1.5-container_vm-1.6-upgrade-master
+  - https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-gci-1.5-gci-1.6-upgrade-cluster
+  - https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-container_vm-1.4-container_vm-1.6-upgrade-cluster
+  - https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-container_vm-1.4-gci-1.6-upgrade-cluster
+  - https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-container_vm-1.5-container_vm-1.6-upgrade-cluster
+  - https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-container_vm-1.5-container_vm-1.6-upgrade-master
+  - https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-container_vm-1.5-gci-1.6-upgrade-cluster
+  - https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-container_vm-1.5-gci-1.6-upgrade-master
+  - https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-gci-1.4-container_vm-1.6-upgrade-cluster
+  - https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-gci-1.4-gci-1.6-upgrade-cluster
+  - https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-gci-1.5-container_vm-1.6-upgrade-cluster
+  - https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-gci-1.5-container_vm-1.6-upgrade-master
+  - https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-gci-1.5-gci-1.6-upgrade-cluster
+  - https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-gci-1.5-gci-1.6-upgrade-master
+- https://k8s-testgrid.appspot.com/kubernetes-apps#charts-gce
+- https://k8s-testgrid.appspot.com/google-federation#soak-gce-test
+- https://k8s-testgrid.appspot.com/release-1.6-all#gce-federation-1.6
+- https://k8s-testgrid.appspot.com/release-1.6-all#gci-gke-ingress-1.6
+- https://k8s-testgrid.appspot.com/release-1.6-all#gci-gke-reboot-1.6
+- https://k8s-testgrid.appspot.com/google-aws#kops-aws-slow
+
+### Action Required
+- Address all suite failures *immediately*
+- Pay particular attention to skew test failures
+- Use the new [triage tool](https://storage.googleapis.com/k8s-gubernator/triage/index.html?test=Simple%20pod%20should%20handle%20in-cluster%20config%7CNginx%20should%20conform%20to%20Ingress%20spec%7CPreStop%20should%20call%20prestop%20when%20killing%20a%20pod), thanks SIG Testing and Team/Test-Infra!
+
+## Incomplete Features
+- Open issues filed against [`kubernetes/features` in 1.6 milestone](https://github.com/kubernetes/features/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20milestone%3Av1.6): 29 (**unchanged from last report**)
+- PRs still needing docs
+  - https://github.com/kubernetes/features/issues/93
+  - https://github.com/kubernetes/features/issues/88
+  - https://github.com/kubernetes/features/issues/43
+
+### Action Required
+- Feature owners fill out feature template by **TODAY!**
+- Feature owners submit docs PR which references issue in features repo by **TODAY!**
+- Feature owners prepare release notes by **TODAY!**
+- Address etcd upgrade test failures
+- Begin adding human curated release notes to [the release notes draft](https://github.com/kubernetes/features/blob/release-notes-draft-1.6/release-1.6/release-notes-draft.md) by **TODAY** **please commit directly to the `release-notes-draft-1.6` branch so we can comment on the [associated PR](https://github.com/kubernetes/features/pull/203) collectively** 
+
+## Release Machinery
+[ not updated for this report ]
+
+### Action Required
+[ not updated for this report ]
+
+## Actions Taken by Release Team
+- These issues will be closed by the release team if testgrid looks stable
+  - https://github.com/kubernetes/kubernetes/issues/43380
+  - https://github.com/kubernetes/kubernetes/issues/43394
+  - https://github.com/kubernetes/kubernetes/issues/43351
+  - https://github.com/kubernetes/kubernetes/issues/43348
+  - https://github.com/kubernetes/kubernetes/issues/43283

--- a/releases/release-1.6/go-signal-reports/2017-03-20.md
+++ b/releases/release-1.6/go-signal-reports/2017-03-20.md
@@ -146,7 +146,7 @@
 - Feature owners submit docs PR which references issue in features repo by **TODAY!**
 - Feature owners prepare release notes by **TODAY!**
 - Address etcd upgrade test failures
-- Begin adding human curated release notes to [the release notes draft](https://github.com/kubernetes/features/blob/release-notes-draft-1.6/release-1.6/release-notes-draft.md) by **TODAY** **please commit directly to the `release-notes-draft-1.6` branch so we can comment on the [associated PR](https://github.com/kubernetes/features/pull/203) collectively** 
+- Begin adding human curated release notes to [the release notes draft](https://github.com/kubernetes/sig-release/blob/release-notes-draft-1.6/release-1.6/release-notes-draft.md) by **TODAY** **please commit directly to the `release-notes-draft-1.6` branch so we can comment on the [associated PR](https://github.com/kubernetes/features/pull/203) collectively** 
 
 ## Release Machinery
 [ not updated for this report ]

--- a/releases/release-1.6/go-signal-reports/2017-03-21.md
+++ b/releases/release-1.6/go-signal-reports/2017-03-21.md
@@ -1,0 +1,165 @@
+## Status: *NO GO*
+### Reasons
+- Bugs exist in 1.6 milestone
+- Flakes exist in 1.6 milestone
+- Open issues in 1.6 milestone
+- Tests unstable (missing three successful runs in a row)
+- Skew tests very noisy
+- Upgrade test failures
+- Release notes incomplete
+
+## Table Of Contents
+- [Issues](#issues)
+  - [Action Required](#action-required)
+  - [Flakes](#flakes)
+    - [By SIG](#by-sig)
+    - [Action Required](#action-required-1)
+  - [Bugs](#bugs)
+    - [Action Required](#action-required-2)
+- [Test Failures](#test-failures)
+  - [Action Required](#action-required-3)
+- [Suite Failures](#suite-failures)
+  - [Action Required](#action-required-4)
+- [Incomplete Features](#incomplete-features)
+  - [Action Required](#action-required-5)
+- [Release Machinery](#release-machinery)
+  - [Action Required](#action-required-6)
+- [Actions Taken by Release Team](#actions-taken-by-release-team)
+
+
+## Issues
+- [Total in 1.6 milestone](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20milestone%3Av1.6): 8 (-8 from last report)
+- ["broken test run" issues in 1.6 milestone](https://github.com/kubernetes/kubernetes/issues?page=1&q=is%3Aissue+is%3Aopen+label%3Akind%2Fflake+%22broken+test+run%22++milestone%3Av1.6&utf8=%E2%9C%93): 0 (-2 from last report)
+
+### Action required
+- Ensure all issues in milestone are release blocking
+- Ensure all issues in milestone have SIG routing label
+- Ensure all issues opened by a human have an assignee. It's now possible to [assign people using prow](https://groups.google.com/forum/#!topic/kubernetes-wg-contribex/t6aceRk03Ag); thanks contribx!
+- Move all non blocking issues out of `v1.6` milestone **and into** *either* the `v1.6.1` or `v1.7` milestones 
+- Close "broken test run" issues for transient test infrastructure failures 
+- Close issues which have been addressed
+- Close issues opened by GCP infrastructure failures on 15 March 2017 
+
+### Flakes
+- [Total in milestone](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6): 1 (-5 from last report)
+- [No SIG](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20-label%3Asig%2Fapi-machinery%20-label%3Asig%2Fapps%20-label%3Asig%2Fauth%20-label%3Asig%2Fautoscaling%20-label%3Asig%2Faws%20-label%3Asig%2Fcli%20-label%3Asig%2Fcluster-lifecycle%20-label%3Asig%2Fcluster-ops%20-label%3Asig%2Fcontributor-experience%20-label%3Asig%2Fdocs%20-label%3Asig%2Ffederation%20-label%3Asig%2Finstrumentation%20-label%3Asig%2Fnetwork%20-label%3Asig%2Fnode%20-label%3Asig%2Fonprem%20-label%3Asig%2Fopenstack%20-label%3Asig%2Frktnetes%20-label%3Asig%2Fscalability%20-label%3Asig%2Fscheduling%20-label%3Asig%2Fservice-catalog%20-label%3Asig%2Fstorage%20-label%3Asig%2Ftesting%20-label%3Asig%2Fwindows): 0 (-3 from last report)
+- [Flakes without milestone](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20no%3Amilestone): 0
+
+### By SIG
+- [API Machinery](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fapi-machinery%20): 0 (unchanged from last report)
+- [AWS](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Faws): 0 (unchanged from last report)
+- [Apps](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fapps): 0 (-1 from last report)
+- [Auth](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fauth): 0 (unchanged from last report)
+- [Autoscaling](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fautoscaling): 0 (unchanged from last report)
+- [Big Data](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fbig-data): 0 (unchanged from last report)
+- [CLI](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fcli): 0 (unchanged from last report)
+- [Cluster Lifecycle](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fcluster-lifecycle): 0 (unchanged from last report)
+- [Cluster Ops](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fcluster-ops): 0 (unchanged from last report)
+- [Contributor Experience](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fcontributor-experience): 0 (unchanged from last report)
+- [Docs](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fdocs): 0 (unchanged from last report)
+- [Federation](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Ffederation): 0 (-2 from last report), great job closing those last stubborn issues out!
+- [Instrumentation](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Finstrumentation): 0 (unchanged from last report)
+- [Network](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fnetwork): 1 (**+1 from last report**)
+- [Node](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fnode): 0 (unchanged from last report)
+- [On Prem](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fon-prem): 0 (unchanged from last report)
+- [OpenStack](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fopenstack): 0 (unchanged from last report)
+- [PM](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fpm): 0 (unchanged from last report)
+- [Scalability](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fscalability): 0 (unchanged from last report)
+- [Scheduling](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fscheduling): 0 (unchanged from last report)
+- [Service Catalog](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fservice-catalog): 0 (unchanged from last report)
+- [Storage](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fstorage): 0 (unchanged from last report)
+- [Testing](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Ftesting): 0 (-1 from last report)
+- [UI](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fui): 0 (unchanged from last report)
+- [Windows](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fwindows): 0 (unchanged from last report)
+
+#### Action Required
+- **Do not open a flake issue without assigning a SIG to that issue**
+- **Do not remove a milestone without assigning a new milestone**
+- Move all non release blocking issues out of `v1.6` milestone and into _either_ the `v1.6.1` or `v1.7` milestones
+- Assign owners for each blocking issue from each SIG for all remaining release blocking issues
+- Provide status updates within 24hrs for all flakes assigned to your SIG
+- Continue to ensure flakes are moved into the correct milestone
+  - 1.6 *for blocking issues*
+  - 1.6.1 *for important but not blocking issues*
+  - 1.7 *for non critical issues to address later*
+
+### Bugs
+- [Total in 1.6 milestone](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fbug%20milestone%3Av1.6): 2 (-3 from last report)
+- [Without Milestone](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fbug%20no%3Amilestone): 104 (-1 from last report)
+
+#### Action Required
+- Bug assignees please label all bugs with the appropriate SIG(s)
+- **Bug assignees please move all non release blocking bugs out of the `v1.6` milestone** and into the `v1.6.1` or `v1.7` milestones
+- Bug assignees please provide regular status updates for all bugs with fix or triage in progress
+- Bug assignees and SIGs please close fixed bugs
+- As spare time allows *please* help to begin addressing bugs without a milestone. Some of these bugs can probably be closed but we should be kind to the community and address these issues.
+
+## Test Failures
+- [k8s.io] [Feature:Example] [k8s.io] Cassandra should create and scale cassandra
+- [k8s.io] [Feature:Example] [k8s.io] CassandraStatefulSet should create statefulset
+- [k8s.io] [Feature:Example] [k8s.io] Hazelcast should create and scale hazelcast
+- [k8s.io] Loadbalancing: L7 [k8s.io] GCE [Slow] [Feature:Ingress] should conform to Ingress spec
+- [k8s.io] Cluster level logging using GCL should check that logs from containers are ingested in GCL
+- [k8s.io] Kubelet [Serial] [Slow] [k8s.io] regular resource usage tracking resource tracking for 100 pods per node
+- [k8s.io] Services should be able to change the type and ports of a service [Slow]
+- [k8s.io] Services should only allow access from service loadbalancer source ranges [Slow]
+
+### Action Required
+- Please remove Cassandra and Hazelcast example tests which seem to be misconfigured
+
+## Suite Failures
+- https://k8s-testgrid.appspot.com/latest-upgrades#gce-cluster
+- https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gce-1.5-1.6-upgrade-cluster
+- https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gce-1.5-1.6-upgrade-cluster-new
+- https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gce-1.5-1.6-upgrade-master
+- https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-container_vm-1.4-container_vm-1.6-upgrade-cluster
+- https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-container_vm-1.4-container_vm-1.6-upgrade-master
+- https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-container_vm-1.4-gci-1.6-upgrade-cluster
+- https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-container_vm-1.4-gci-1.6-upgrade-master
+- https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-container_vm-1.5-container_vm-1.6-upgrade-cluster
+- https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-container_vm-1.5-container_vm-1.6-upgrade-cluster-new
+- https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-container_vm-1.5-container_vm-1.6-upgrade-master
+- https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-container_vm-1.5-gci-1.6-upgrade-cluster
+- https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-container_vm-1.5-gci-1.6-upgrade-master
+- https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-gci-1.4-container_vm-1.6-upgrade-cluster
+- https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-gci-1.4-container_vm-1.6-upgrade-master
+- https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-gci-1.4-gci-1.6-upgrade-cluster
+- https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-gci-1.4-gci-1.6-upgrade-master
+- https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-gci-1.5-container_vm-1.6-upgrade-cluster
+- https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-gci-1.5-container_vm-1.6-upgrade-master
+- https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-gci-1.5-gci-1.6-upgrade-cluster
+- https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-gci-1.5-gci-1.6-upgrade-master
+- https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gce-1.6-1.5-downgrade-cluster
+- https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-gci-1.6-gci-1.5-downgrade-cluster
+- https://k8s-testgrid.appspot.com/kubernetes-apps#charts-gce
+- https://k8s-testgrid.appspot.com/google-federation#soak-gce-test
+- https://k8s-testgrid.appspot.com/release-1.6-all#gce-federation-1.6
+- https://k8s-testgrid.appspot.com/release-1.6-all#gci-gke-ingress-1.6
+- https://k8s-testgrid.appspot.com/google-aws#kops-aws-slow
+
+### Action Required
+- Address all suite failures *immediately*
+- Pay particular attention to skew test failures
+- Use the new [triage tool](https://storage.googleapis.com/k8s-gubernator/triage/index.html?test=Simple%20pod%20should%20handle%20in-cluster%20config%7CNginx%20should%20conform%20to%20Ingress%20spec%7CPreStop%20should%20call%20prestop%20when%20killing%20a%20pod), thanks SIG Testing and Team/Test-Infra!
+
+## Incomplete Features
+- Open issues filed against [`kubernetes/features` in 1.6 milestone](https://github.com/kubernetes/features/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20milestone%3Av1.6): 29 (**unchanged from last report**)
+- PRs still needing docs
+  - https://github.com/kubernetes/features/issues/43
+- Human curated release notes still incomplete. Specifically very litte curation of [automatically generated release notes](https://github.com/kubernetes/features/blob/release-notes-draft-1.6/release-1.6/release-notes-draft.md#auto-generated-release-notes)
+
+### Action Required
+- Feature owners fill out feature template by **TODAY!**
+- Feature owners submit docs PR which references issue in features repo by **TODAY!**
+- Feature owners prepare release notes by **TODAY!**
+- Address etcd upgrade test failures
+- Finish adding human curated release notes to [the release notes draft](https://github.com/kubernetes/features/blob/release-notes-draft-1.6/release-1.6/release-notes-draft.md) by **TODAY** **please commit directly to the `release-notes-draft-1.6` branch so we can comment on the [associated PR](https://github.com/kubernetes/features/pull/203) collectively** 
+
+## Release Machinery
+[ not updated for this report ]
+
+### Action Required
+[ not updated for this report ]
+
+## Actions Taken by Release Team
+[ not updated for this report ]

--- a/releases/release-1.6/go-signal-reports/2017-03-21.md
+++ b/releases/release-1.6/go-signal-reports/2017-03-21.md
@@ -146,14 +146,14 @@
 - Open issues filed against [`kubernetes/features` in 1.6 milestone](https://github.com/kubernetes/features/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20milestone%3Av1.6): 29 (**unchanged from last report**)
 - PRs still needing docs
   - https://github.com/kubernetes/features/issues/43
-- Human curated release notes still incomplete. Specifically very litte curation of [automatically generated release notes](https://github.com/kubernetes/features/blob/release-notes-draft-1.6/release-1.6/release-notes-draft.md#auto-generated-release-notes)
+- Human curated release notes still incomplete. Specifically very litte curation of [automatically generated release notes](https://github.com/kubernetes/sig-release/blob/release-notes-draft-1.6/release-1.6/release-notes-draft.md#auto-generated-release-notes)
 
 ### Action Required
 - Feature owners fill out feature template by **TODAY!**
 - Feature owners submit docs PR which references issue in features repo by **TODAY!**
 - Feature owners prepare release notes by **TODAY!**
 - Address etcd upgrade test failures
-- Finish adding human curated release notes to [the release notes draft](https://github.com/kubernetes/features/blob/release-notes-draft-1.6/release-1.6/release-notes-draft.md) by **TODAY** **please commit directly to the `release-notes-draft-1.6` branch so we can comment on the [associated PR](https://github.com/kubernetes/features/pull/203) collectively** 
+- Finish adding human curated release notes to [the release notes draft](https://github.com/kubernetes/sig-release/blob/release-notes-draft-1.6/release-1.6/release-notes-draft.md) by **TODAY** **please commit directly to the `release-notes-draft-1.6` branch so we can comment on the [associated PR](https://github.com/kubernetes/features/pull/203) collectively** 
 
 ## Release Machinery
 [ not updated for this report ]

--- a/releases/release-1.6/go-signal-reports/2017-03-22.md
+++ b/releases/release-1.6/go-signal-reports/2017-03-22.md
@@ -1,0 +1,171 @@
+## Status: *NO GO*
+### Reasons
+- Bugs exist in 1.6 milestone
+- Flakes exist in 1.6 milestone
+- Open issues in 1.6 milestone
+- Tests unstable (missing three successful runs in a row)
+- Upgrade test noisy
+- Release notes incomplete
+
+## Table Of Contents
+- [Issues](#issues)
+  - [Action Required](#action-required)
+  - [Flakes](#flakes)
+    - [By SIG](#by-sig)
+    - [Action Required](#action-required-1)
+  - [Bugs](#bugs)
+    - [Action Required](#action-required-2)
+- [Test Failures](#test-failures)
+  - [Action Required](#action-required-3)
+- [Suite Failures](#suite-failures)
+  - [Action Required](#action-required-4)
+- [Incomplete Features](#incomplete-features)
+  - [Action Required](#action-required-5)
+- [Release Machinery](#release-machinery)
+  - [Action Required](#action-required-6)
+- [Actions Taken by Release Team](#actions-taken-by-release-team)
+
+
+## Issues
+- [Total in 1.6 milestone](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20milestone%3Av1.6): 10 (**+2 from last report**)
+- ["broken test run" issues in 1.6 milestone](https://github.com/kubernetes/kubernetes/issues?page=1&q=is%3Aissue+is%3Aopen+label%3Akind%2Fflake+%22broken+test+run%22++milestone%3Av1.6&utf8=%E2%9C%93): 0 (unchanged from last report)
+
+### Action required
+- Ensure all issues in milestone are release blocking
+- Ensure all issues in milestone have SIG routing label
+- Ensure all issues opened by a human have an assignee. It's now possible to [assign people using prow](https://groups.google.com/forum/#!topic/kubernetes-wg-contribex/t6aceRk03Ag); thanks contribx!
+- Move all non blocking issues out of `v1.6` milestone **and into** *either* the `v1.6.1` or `v1.7` milestones 
+- Close "broken test run" issues for transient test infrastructure failures 
+- Close issues which have been addressed
+- Close issues opened by GCP infrastructure failures on 15 March 2017 
+
+### Flakes
+- [Total in milestone](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6): 0 (-1 from last report)
+- [No SIG](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20-label%3Asig%2Fapi-machinery%20-label%3Asig%2Fapps%20-label%3Asig%2Fauth%20-label%3Asig%2Fautoscaling%20-label%3Asig%2Faws%20-label%3Asig%2Fcli%20-label%3Asig%2Fcluster-lifecycle%20-label%3Asig%2Fcluster-ops%20-label%3Asig%2Fcontributor-experience%20-label%3Asig%2Fdocs%20-label%3Asig%2Ffederation%20-label%3Asig%2Finstrumentation%20-label%3Asig%2Fnetwork%20-label%3Asig%2Fnode%20-label%3Asig%2Fonprem%20-label%3Asig%2Fopenstack%20-label%3Asig%2Frktnetes%20-label%3Asig%2Fscalability%20-label%3Asig%2Fscheduling%20-label%3Asig%2Fservice-catalog%20-label%3Asig%2Fstorage%20-label%3Asig%2Ftesting%20-label%3Asig%2Fwindows): 0 (unchanged from last report)
+- [Flakes without milestone](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20no%3Amilestone): 0 (unchanged from last report)
+
+### By SIG
+- [API Machinery](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fapi-machinery%20): 0 (unchanged from last report)
+- [AWS](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Faws): 0 (unchanged from last report)
+- [Apps](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fapps): 0 (unchanged from last report)
+- [Auth](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fauth): 0 (unchanged from last report)
+- [Autoscaling](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fautoscaling): 0 (unchanged from last report)
+- [Big Data](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fbig-data): 0 (unchanged from last report)
+- [CLI](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fcli): 0 (unchanged from last report)
+- [Cluster Lifecycle](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fcluster-lifecycle): 0 (unchanged from last report)
+- [Cluster Ops](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fcluster-ops): 0 (unchanged from last report)
+- [Contributor Experience](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fcontributor-experience): 0 (unchanged from last report)
+- [Docs](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fdocs): 0 (unchanged from last report)
+- [Federation](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Ffederation): 0 (unchanged from last report)
+- [Instrumentation](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Finstrumentation): 0 (unchanged from last report)
+- [Network](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fnetwork): 0 (-1 from last report)
+- [Node](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fnode): 0 (unchanged from last report)
+- [On Prem](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fon-prem): 0 (unchanged from last report)
+- [OpenStack](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fopenstack): 0 (unchanged from last report)
+- [PM](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fpm): 0 (unchanged from last report)
+- [Scalability](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fscalability): 0 (unchanged from last report)
+- [Scheduling](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fscheduling): 0 (unchanged from last report)
+- [Service Catalog](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fservice-catalog): 0 (unchanged from last report)
+- [Storage](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fstorage): 0 (unchanged from last report)
+- [Testing](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Ftesting): 0 (unchanged from last report)
+- [UI](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fui): 0 (unchanged from last report)
+- [Windows](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fwindows): 0 (unchanged from last report)
+
+#### Action Required
+- **Do not open a flake issue without assigning a SIG to that issue**
+- **Do not remove a milestone without assigning a new milestone**
+- Move all non release blocking issues out of `v1.6` milestone and into _either_ the `v1.6.1` or `v1.7` milestones
+- Assign owners for each blocking issue from each SIG for all remaining release blocking issues
+- Provide status updates within 24hrs for all flakes assigned to your SIG
+- Continue to ensure flakes are moved into the correct milestone
+  - 1.6 *for blocking issues*
+  - 1.6.1 *for important but not blocking issues*
+  - 1.7 *for non critical issues to address later*
+
+### Bugs
+- [Total in 1.6 milestone](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fbug%20milestone%3Av1.6): 2 (**unchanged from last report**)
+- [Without Milestone](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fbug%20no%3Amilestone): 104 (**unchanged from last report**)
+
+#### Action Required
+- Bug assignees please label all bugs with the appropriate SIG(s)
+- **Bug assignees please move all non release blocking bugs out of the `v1.6` milestone** and into the `v1.6.1` or `v1.7` milestones
+- Bug assignees please provide regular status updates for all bugs with fix or triage in progress
+- Bug assignees and SIGs please close fixed bugs
+- As spare time allows *please* help to begin addressing bugs without a milestone. Some of these bugs can probably be closed but we should be kind to the community and address these issues.
+
+## Test Failures
+- [k8s.io] Downward API volume should update annotations on modification [Conformance] [Volume]
+- [k8s.io] Cluster level logging using GCL should check that logs from containers are ingested in GCL
+- [k8s.io] Rescheduler [Serial] should ensure that critical pod is scheduled in case there is no resources available
+- [k8s.io] [Feature:Example] [k8s.io] Cassandra should create and scale cassandra
+- [k8s.io] [Feature:Example] [k8s.io] CassandraStatefulSet should create statefulset
+- [k8s.io] [Feature:Example] [k8s.io] Hazelcast should create and scale hazelcast
+- [k8s.io] Loadbalancing: L7 [k8s.io] GCE [Slow] [Feature:Ingress] should conform to Ingress spec
+- [k8s.io] Kubelet [Serial] [Slow] [k8s.io] regular resource usage tracking resource tracking for 100 pods per node
+- [k8s.io] Services should be able to change the type and ports of a service [Slow]
+- [k8s.io] Services should only allow access from service loadbalancer source ranges [Slow]
+
+### Action Required
+- Please remove Cassandra and Hazelcast example tests which seem to be misconfigured
+- Use the new [triage tool](https://storage.googleapis.com/k8s-gubernator/triage/index.html?test=Simple%20pod%20should%20handle%20in-cluster%20config%7CNginx%20should%20conform%20to%20Ingress%20spec%7CPreStop%20should%20call%20prestop%20when%20killing%20a%20pod), thanks SIG Testing and Team/Test-Infra!
+
+## Suite Failures
+- https://k8s-testgrid.appspot.com/release-1.6-all#gci-gce-reboot-1.6
+- https://k8s-testgrid.appspot.com/release-1.6-all#gci-gke-serial-1.6
+- https://k8s-testgrid.appspot.com/release-1.6-all#gke-reboot-1.6
+- https://k8s-testgrid.appspot.com/latest-upgrades#gce-cluster
+- https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gce-1.5-1.6-upgrade-cluster
+- https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gce-1.5-1.6-upgrade-cluster-new
+- https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gce-1.5-1.6-upgrade-master
+- https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-container_vm-1.4-container_vm-1.6-upgrade-cluster
+- https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-container_vm-1.4-container_vm-1.6-upgrade-master
+- https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-container_vm-1.4-gci-1.6-upgrade-cluster
+- https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-container_vm-1.4-gci-1.6-upgrade-master
+- https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-container_vm-1.5-container_vm-1.6-upgrade-cluster
+- https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-container_vm-1.5-container_vm-1.6-upgrade-cluster-new
+- https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-container_vm-1.5-container_vm-1.6-upgrade-master
+- https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-container_vm-1.5-gci-1.6-upgrade-cluster
+- https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-container_vm-1.5-gci-1.6-upgrade-master
+- https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-gci-1.4-container_vm-1.6-upgrade-cluster
+- https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-gci-1.4-container_vm-1.6-upgrade-master
+- https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-gci-1.4-gci-1.6-upgrade-cluster
+- https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-gci-1.4-gci-1.6-upgrade-master
+- https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-container_vm-1.5-gci-1.6-upgrade-cluster-new
+- https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-gci-1.4-container_vm-1.6-upgrade-cluster-new
+- https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-gci-1.5-container_vm-1.6-upgrade-cluster-new
+- https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-gci-1.5-container_vm-1.6-upgrade-cluster
+- https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-gci-1.5-container_vm-1.6-upgrade-master
+- https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-gci-1.5-gci-1.6-upgrade-cluster
+- https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-gci-1.5-gci-1.6-upgrade-master
+- https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gce-1.6-1.5-downgrade-cluster
+- https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-gci-1.6-gci-1.5-downgrade-cluster
+- https://k8s-testgrid.appspot.com/kubernetes-apps#charts-gce
+- https://k8s-testgrid.appspot.com/google-federation#soak-gce-test
+- https://k8s-testgrid.appspot.com/release-1.6-all#gce-federation-1.6
+- https://k8s-testgrid.appspot.com/google-aws#kops-aws-slow
+
+### Action Required
+- Address all suite failures *immediately*
+- Pay particular attention to skew test failures
+- Use the new [triage tool](https://storage.googleapis.com/k8s-gubernator/triage/index.html?test=Simple%20pod%20should%20handle%20in-cluster%20config%7CNginx%20should%20conform%20to%20Ingress%20spec%7CPreStop%20should%20call%20prestop%20when%20killing%20a%20pod), thanks SIG Testing and Team/Test-Infra!
+
+## Incomplete Features
+- Open issues filed against [`kubernetes/features` in 1.6 milestone](https://github.com/kubernetes/features/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20milestone%3Av1.6): 29 (**unchanged from last report**)
+- Human curated release notes still incomplete. Specifically very litte curation of [automatically generated release notes](https://github.com/kubernetes/features/blob/release-notes-draft-1.6/release-1.6/release-notes-draft.md#auto-generated-release-notes)
+
+### Action Required
+- Feature owners fill out feature template by **TODAY!**
+- Feature owners submit docs PR which references issue in features repo by **TODAY!**
+- Feature owners prepare release notes by **TODAY!**
+- Address etcd upgrade test failures
+- Finish adding human curated release notes to [the release notes draft](https://github.com/kubernetes/features/blob/release-notes-draft-1.6/release-1.6/release-notes-draft.md) by **TODAY** **please commit directly to the `release-notes-draft-1.6` branch so we can comment on the [associated PR](https://github.com/kubernetes/features/pull/203) collectively** 
+
+## Release Machinery
+[ not updated for this report ]
+
+### Action Required
+[ not updated for this report ]
+
+## Actions Taken by Release Team
+[ not updated for this report ]
+

--- a/releases/release-1.6/go-signal-reports/2017-03-23.md
+++ b/releases/release-1.6/go-signal-reports/2017-03-23.md
@@ -1,0 +1,178 @@
+## Status: *NO GO*
+### Reasons
+- Open issues in 1.6 milestone
+- Unclear signal from upgrade tests
+- Release notes incomplete
+
+## Table Of Contents
+- [Issues](#issues)
+  - [Action Required](#action-required)
+  - [Flakes](#flakes)
+    - [By SIG](#by-sig)
+    - [Action Required](#action-required-1)
+  - [Bugs](#bugs)
+    - [Action Required](#action-required-2)
+- [Test Failures](#test-failures)
+  - [Action Required](#action-required-3)
+- [Suite Failures](#suite-failures)
+  - [Action Required](#action-required-4)
+- [Incomplete Features](#incomplete-features)
+  - [Action Required](#action-required-5)
+- [Release Machinery](#release-machinery)
+  - [Action Required](#action-required-6)
+- [Actions Taken by Release Team](#actions-taken-by-release-team)
+
+
+## Issues
+- [Total in 1.6 milestone](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20milestone%3Av1.6): 6 (-4 from last report)
+- ["broken test run" issues in 1.6 milestone](https://github.com/kubernetes/kubernetes/issues?page=1&q=is%3Aissue+is%3Aopen+label%3Akind%2Fflake+%22broken+test+run%22++milestone%3Av1.6&utf8=%E2%9C%93): 0 (unchanged from last report)
+
+### Action required
+- Ensure all issues in milestone are release blocking
+- Ensure all issues in milestone have SIG routing label
+- Ensure all issues opened by a human have an assignee. It's now possible to [assign people using prow](https://groups.google.com/forum/#!topic/kubernetes-wg-contribex/t6aceRk03Ag); thanks contribx!
+- Move all non blocking issues out of `v1.6` milestone **and into** *either* the `v1.6.1` or `v1.7` milestones 
+- Close "broken test run" issues for transient test infrastructure failures 
+- Close issues which have been addressed
+- Close issues opened by GCP infrastructure failures on 15 March 2017 
+
+### Flakes
+- [Total in milestone](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6): 0 (unchanged from last report)
+- [No SIG](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20-label%3Asig%2Fapi-machinery%20-label%3Asig%2Fapps%20-label%3Asig%2Fauth%20-label%3Asig%2Fautoscaling%20-label%3Asig%2Faws%20-label%3Asig%2Fcli%20-label%3Asig%2Fcluster-lifecycle%20-label%3Asig%2Fcluster-ops%20-label%3Asig%2Fcontributor-experience%20-label%3Asig%2Fdocs%20-label%3Asig%2Ffederation%20-label%3Asig%2Finstrumentation%20-label%3Asig%2Fnetwork%20-label%3Asig%2Fnode%20-label%3Asig%2Fonprem%20-label%3Asig%2Fopenstack%20-label%3Asig%2Frktnetes%20-label%3Asig%2Fscalability%20-label%3Asig%2Fscheduling%20-label%3Asig%2Fservice-catalog%20-label%3Asig%2Fstorage%20-label%3Asig%2Ftesting%20-label%3Asig%2Fwindows): 0 (unchanged from last report)
+- [Flakes without milestone](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20no%3Amilestone): 0 (unchanged from last report)
+
+### By SIG
+- [API Machinery](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fapi-machinery%20): 0 (unchanged from last report)
+- [AWS](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Faws): 0 (unchanged from last report)
+- [Apps](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fapps): 0 (unchanged from last report)
+- [Auth](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fauth): 0 (unchanged from last report)
+- [Autoscaling](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fautoscaling): 0 (unchanged from last report)
+- [Big Data](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fbig-data): 0 (unchanged from last report)
+- [CLI](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fcli): 0 (unchanged from last report)
+- [Cluster Lifecycle](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fcluster-lifecycle): 0 (unchanged from last report)
+- [Cluster Ops](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fcluster-ops): 0 (unchanged from last report)
+- [Contributor Experience](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fcontributor-experience): 0 (unchanged from last report)
+- [Docs](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fdocs): 0 (unchanged from last report)
+- [Federation](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Ffederation): 0 (unchanged from last report)
+- [Instrumentation](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Finstrumentation): 0 (unchanged from last report)
+- [Network](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fnetwork): 0 (unchanged from last report)
+- [Node](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fnode): 0 (unchanged from last report)
+- [On Prem](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fon-prem): 0 (unchanged from last report)
+- [OpenStack](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fopenstack): 0 (unchanged from last report)
+- [PM](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fpm): 0 (unchanged from last report)
+- [Scalability](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fscalability): 0 (unchanged from last report)
+- [Scheduling](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fscheduling): 0 (unchanged from last report)
+- [Service Catalog](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fservice-catalog): 0 (unchanged from last report)
+- [Storage](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fstorage): 0 (unchanged from last report)
+- [Testing](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Ftesting): 0 (unchanged from last report)
+- [UI](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fui): 0 (unchanged from last report)
+- [Windows](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fwindows): 0 (unchanged from last report)
+
+#### Action Required
+- **Do not open a flake issue without assigning a SIG to that issue**
+- **Do not remove a milestone without assigning a new milestone**
+- Move all non release blocking issues out of `v1.6` milestone and into _either_ the `v1.6.1` or `v1.7` milestones
+- Assign owners for each blocking issue from each SIG for all remaining release blocking issues
+- Provide status updates within 24hrs for all flakes assigned to your SIG
+- Continue to ensure flakes are moved into the correct milestone
+  - 1.6 *for blocking issues*
+  - 1.6.1 *for important but not blocking issues*
+  - 1.7 *for non critical issues to address later*
+
+### Bugs
+- [Total in 1.6 milestone](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fbug%20milestone%3Av1.6): 0 (-2 from last report)
+- [Without Milestone](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fbug%20no%3Amilestone): 105 (**+1 from last report**)
+
+#### Action Required
+- Bug assignees please label all bugs with the appropriate SIG(s)
+- **Bug assignees please move all non release blocking bugs out of the `v1.6` milestone** and into the `v1.6.1` or `v1.7` milestones
+- Bug assignees please provide regular status updates for all bugs with fix or triage in progress
+- Bug assignees and SIGs please close fixed bugs
+- As spare time allows *please* help to begin addressing bugs without a milestone. Some of these bugs can probably be closed but we should be kind to the community and address these issues.
+
+## Test Failures
+- [k8s.io] Downward API volume should update annotations on modification [Conformance] [Volume]
+- [k8s.io] Cluster level logging using GCL should check that logs from containers are ingested in GCL
+- [k8s.io] Rescheduler [Serial] should ensure that critical pod is scheduled in case there is no resources available
+- [k8s.io] [Feature:Example] [k8s.io] Cassandra should create and scale cassandra
+- [k8s.io] [Feature:Example] [k8s.io] CassandraStatefulSet should create statefulset
+- [k8s.io] [Feature:Example] [k8s.io] Hazelcast should create and scale hazelcast
+- [k8s.io] Loadbalancing: L7 [k8s.io] GCE [Slow] [Feature:Ingress] should conform to Ingress spec
+- [k8s.io] Kubelet [Serial] [Slow] [k8s.io] regular resource usage tracking resource tracking for 100 pods per node
+- [k8s.io] Services should be able to change the type and ports of a service [Slow]
+- [k8s.io] Services should only allow access from service loadbalancer source ranges [Slow]
+- [k8s.io] Kubectl client [k8s.io] Kubectl describe should check if kubectl describe prints relevant information for rc and pods [Conformance]
+- [k8s.io] Kubectl client [k8s.io] Kubectl run job should create a job from an image when restart is OnFailure [Conformance]
+- [k8s.io] Kubectl client [k8s.io] Simple pod should support inline execution and attach
+- [k8s.io] StatefulSet [k8s.io] Basic StatefulSet functionality should handle healthy pet restarts during scale
+- [k8s.io] SchedulerPredicates [Serial] validates that taints-tolerations is respected if not matching
+- [k8s.io] SchedulerPredicates [Serial] validates that InterPodAntiAffinity is respected if matching 2
+- [k8s.io] SchedulerPredicates [Serial] validates that NodeAffinity is respected if not matching
+- [k8s.io] SchedulerPredicates [Serial] validates that a pod with an invalid NodeAffinity is rejected
+- [k8s.io] SchedulerPredicates [Serial] validates that a pod with an invalid podAffinity is rejected because of the LabelSelectorRequirement is invalid
+- [k8s.io] V1Job should fail a job [Slow]
+- [k8s.io] Daemon set [Serial] should run and stop complex daemon with node affinity
+- [k8s.io] Deployment overlapping deployment should not fight with each other
+
+
+### Action Required
+- Please remove Cassandra and Hazelcast example tests which seem to be misconfigured
+- Use the new [triage tool](https://storage.googleapis.com/k8s-gubernator/triage/index.html?test=Simple%20pod%20should%20handle%20in-cluster%20config%7CNginx%20should%20conform%20to%20Ingress%20spec%7CPreStop%20should%20call%20prestop%20when%20killing%20a%20pod), thanks SIG Testing and Team/Test-Infra!
+
+## Suite Failures
+- https://k8s-testgrid.appspot.com/latest-upgrades#gce-cluster
+- https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gce-1.5-1.6-upgrade-cluster
+- https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gce-1.5-1.6-upgrade-cluster-new
+- https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gce-1.5-1.6-upgrade-master
+- https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-container_vm-1.4-container_vm-1.6-upgrade-cluster
+- https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-container_vm-1.4-container_vm-1.6-upgrade-master
+- https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-container_vm-1.4-gci-1.6-upgrade-cluster
+- https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-container_vm-1.4-gci-1.6-upgrade-master
+- https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-container_vm-1.5-container_vm-1.6-upgrade-cluster
+- https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-container_vm-1.5-container_vm-1.6-upgrade-cluster-new
+- https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-container_vm-1.5-container_vm-1.6-upgrade-master
+- https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-container_vm-1.5-gci-1.6-upgrade-cluster
+- https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-container_vm-1.5-gci-1.6-upgrade-master
+- https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-gci-1.4-container_vm-1.6-upgrade-cluster
+- https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-gci-1.4-container_vm-1.6-upgrade-master
+- https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-gci-1.4-gci-1.6-upgrade-cluster
+- https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-gci-1.4-gci-1.6-upgrade-master
+- https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-gci-1.5-container_vm-1.6-upgrade-cluster
+- https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-gci-1.5-container_vm-1.6-upgrade-master
+- https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-gci-1.5-gci-1.6-upgrade-cluster
+- https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-gci-1.5-gci-1.6-upgrade-master
+- https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gce-1.6-1.5-downgrade-cluster
+- https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-gci-1.6-gci-1.5-downgrade-cluster
+- https://k8s-testgrid.appspot.com/kubernetes-apps#charts-gce
+- https://k8s-testgrid.appspot.com/google-federation#soak-gce-test
+- https://k8s-testgrid.appspot.com/release-1.6-all#gce-federation-1.6
+- https://k8s-testgrid.appspot.com/google-aws#kops-aws-slow
+
+### Action Required
+- Address all suite failures *immediately*
+- Pay particular attention to skew test failures
+- Use the new [triage tool](https://storage.googleapis.com/k8s-gubernator/triage/index.html?test=Simple%20pod%20should%20handle%20in-cluster%20config%7CNginx%20should%20conform%20to%20Ingress%20spec%7CPreStop%20should%20call%20prestop%20when%20killing%20a%20pod), thanks SIG Testing and Team/Test-Infra!
+
+## Incomplete Features
+- Open issues filed against [`kubernetes/features` in 1.6 milestone](https://github.com/kubernetes/features/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20milestone%3Av1.6): 29 (**unchanged from last report**)
+- Human curated release notes still incomplete. Specifically very litte curation of [automatically generated release notes](https://github.com/kubernetes/features/blob/release-notes-draft-1.6/release-1.6/release-notes-draft.md#auto-generated-release-notes)
+
+### Action Required
+- Feature owners fill out feature template by **TODAY!**
+- Feature owners submit docs PR which references issue in features repo by **TODAY!**
+- Feature owners prepare release notes by **TODAY!**
+- Address etcd upgrade test failures
+- Finish adding human curated release notes to [the release notes draft](https://github.com/kubernetes/features/blob/release-notes-draft-1.6/release-1.6/release-notes-draft.md) by **TODAY** **please commit directly to the `release-notes-draft-1.6` branch so we can comment on the [associated PR](https://github.com/kubernetes/features/pull/203) collectively** 
+
+## Release Machinery
+[ not updated for this report ]
+
+### Action Required
+[ not updated for this report ]
+
+## Actions Taken by Release Team
+- Release team has moved the following issues to the `v1.6.1` milestone
+  - https://github.com/kubernetes/kubernetes/issues/43550
+  - https://github.com/kubernetes/kubernetes/issues/43549
+- Last fast forward of master to the `release-1.6` branch has been made, all further changes for 1.6.0  must be cherry picked onto the branch.
+- Submit queue opened

--- a/releases/release-1.6/go-signal-reports/2017-03-24.md
+++ b/releases/release-1.6/go-signal-reports/2017-03-24.md
@@ -1,0 +1,148 @@
+## Status: *NO GO*
+### Reasons
+- Open issues in 1.6 milestone
+- Waiting for additional signal from skew tests
+- Release notes incomplete
+
+## Table Of Contents
+- [Issues](#issues)
+  - [Action Required](#action-required)
+  - [Flakes](#flakes)
+    - [By SIG](#by-sig)
+    - [Action Required](#action-required-1)
+  - [Bugs](#bugs)
+    - [Action Required](#action-required-2)
+- [Test Failures](#test-failures)
+  - [Action Required](#action-required-3)
+- [Suite Failures](#suite-failures)
+  - [Action Required](#action-required-4)
+- [Incomplete Features](#incomplete-features)
+  - [Action Required](#action-required-5)
+- [Release Machinery](#release-machinery)
+  - [Action Required](#action-required-6)
+- [Actions Taken by Release Team](#actions-taken-by-release-team)
+
+
+## Issues
+- [Total in 1.6 milestone](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20milestone%3Av1.6): 8 (**+2 from last report**)
+- ["broken test run" issues in 1.6 milestone](https://github.com/kubernetes/kubernetes/issues?page=1&q=is%3Aissue+is%3Aopen+label%3Akind%2Fflake+%22broken+test+run%22++milestone%3Av1.6&utf8=%E2%9C%93): 0 (unchanged from last report)
+
+### Action required
+- Ensure all issues in milestone are release blocking
+- Ensure all issues in milestone have SIG routing label
+- Ensure all issues opened by a human have an assignee. It's now possible to [assign people using prow](https://groups.google.com/forum/#!topic/kubernetes-wg-contribex/t6aceRk03Ag); thanks contribx!
+- Move all non blocking issues out of `v1.6` milestone **and into** *either* the `v1.6.1` or `v1.7` milestones 
+- Close "broken test run" issues for transient test infrastructure failures 
+- Close issues which have been addressed
+- Close issues opened by GCP infrastructure failures on 15 March 2017 
+
+### Flakes
+- [Total in milestone](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6): 1 (**+1 from last report**)
+- [No SIG](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20-label%3Asig%2Fapi-machinery%20-label%3Asig%2Fapps%20-label%3Asig%2Fauth%20-label%3Asig%2Fautoscaling%20-label%3Asig%2Faws%20-label%3Asig%2Fcli%20-label%3Asig%2Fcluster-lifecycle%20-label%3Asig%2Fcluster-ops%20-label%3Asig%2Fcontributor-experience%20-label%3Asig%2Fdocs%20-label%3Asig%2Ffederation%20-label%3Asig%2Finstrumentation%20-label%3Asig%2Fnetwork%20-label%3Asig%2Fnode%20-label%3Asig%2Fonprem%20-label%3Asig%2Fopenstack%20-label%3Asig%2Frktnetes%20-label%3Asig%2Fscalability%20-label%3Asig%2Fscheduling%20-label%3Asig%2Fservice-catalog%20-label%3Asig%2Fstorage%20-label%3Asig%2Ftesting%20-label%3Asig%2Fwindows): 1 (**+1 from last report**)
+- [Flakes without milestone](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20no%3Amilestone): 0 (unchanged from last report)
+
+### By SIG
+- [API Machinery](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fapi-machinery%20): 0 (unchanged from last report)
+- [AWS](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Faws): 0 (unchanged from last report)
+- [Apps](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fapps): 0 (unchanged from last report)
+- [Auth](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fauth): 0 (unchanged from last report)
+- [Autoscaling](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fautoscaling): 0 (unchanged from last report)
+- [Big Data](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fbig-data): 0 (unchanged from last report)
+- [CLI](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fcli): 0 (unchanged from last report)
+- [Cluster Lifecycle](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fcluster-lifecycle): 0 (unchanged from last report)
+- [Cluster Ops](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fcluster-ops): 0 (unchanged from last report)
+- [Contributor Experience](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fcontributor-experience): 0 (unchanged from last report)
+- [Docs](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fdocs): 0 (unchanged from last report)
+- [Federation](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Ffederation): 0 (unchanged from last report)
+- [Instrumentation](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Finstrumentation): 0 (unchanged from last report)
+- [Network](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fnetwork): 0 (unchanged from last report)
+- [Node](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fnode): 0 (unchanged from last report)
+- [On Prem](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fon-prem): 0 (unchanged from last report)
+- [OpenStack](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fopenstack): 0 (unchanged from last report)
+- [PM](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fpm): 0 (unchanged from last report)
+- [Scalability](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fscalability): 0 (unchanged from last report)
+- [Scheduling](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fscheduling): 0 (unchanged from last report)
+- [Service Catalog](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fservice-catalog): 0 (unchanged from last report)
+- [Storage](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fstorage): 0 (unchanged from last report)
+- [Testing](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Ftesting): 0 (unchanged from last report)
+- [UI](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fui): 0 (unchanged from last report)
+- [Windows](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fflake%20milestone%3Av1.6%20label%3Asig%2Fwindows): 0 (unchanged from last report)
+
+#### Action Required
+- **Do not open a flake issue without assigning a SIG to that issue**
+- **Do not remove a milestone without assigning a new milestone**
+- Move all non release blocking issues out of `v1.6` milestone and into _either_ the `v1.6.1` or `v1.7` milestones
+- Assign owners for each blocking issue from each SIG for all remaining release blocking issues
+- Provide status updates within 24hrs for all flakes assigned to your SIG
+- Continue to ensure flakes are moved into the correct milestone
+  - 1.6 *for blocking issues*
+  - 1.6.1 *for important but not blocking issues*
+  - 1.7 *for non critical issues to address later*
+
+### Bugs
+- [Total in 1.6 milestone](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fbug%20milestone%3Av1.6): 0 (unchanged from last report)
+- [Without Milestone](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fbug%20no%3Amilestone): 105 (**unchanged from last report**)
+
+#### Action Required
+- Bug assignees please label all bugs with the appropriate SIG(s)
+- **Bug assignees please move all non release blocking bugs out of the `v1.6` milestone** and into the `v1.6.1` or `v1.7` milestones
+- Bug assignees please provide regular status updates for all bugs with fix or triage in progress
+- Bug assignees and SIGs please close fixed bugs
+- As spare time allows *please* help to begin addressing bugs without a milestone. Some of these bugs can probably be closed but we should be kind to the community and address these issues.
+
+## Test Failures
+- [k8s.io] Rescheduler [Serial] should ensure that critical pod is scheduled in case there is no resources available
+
+### Action Required
+- Please remove Cassandra and Hazelcast example tests which seem to be misconfigured
+- Use the new [triage tool](https://storage.googleapis.com/k8s-gubernator/triage/index.html?test=Simple%20pod%20should%20handle%20in-cluster%20config%7CNginx%20should%20conform%20to%20Ingress%20spec%7CPreStop%20should%20call%20prestop%20when%20killing%20a%20pod), thanks SIG Testing and Team/Test-Infra!
+
+## Suite Failures
+- https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gce-1.5-1.6-upgrade-cluster
+- https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gce-1.5-1.6-upgrade-cluster-new
+- https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gce-1.5-1.6-upgrade-master
+- https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-container_vm-1.4-container_vm-1.6-upgrade-cluster
+- https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-container_vm-1.4-container_vm-1.6-upgrade-master
+- https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-container_vm-1.4-gci-1.6-upgrade-cluster
+- https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-container_vm-1.4-gci-1.6-upgrade-master
+- https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-container_vm-1.5-container_vm-1.6-upgrade-cluster
+- https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-container_vm-1.5-container_vm-1.6-upgrade-cluster-new
+- https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-container_vm-1.5-container_vm-1.6-upgrade-master
+- https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-container_vm-1.5-gci-1.6-upgrade-cluster
+- https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-container_vm-1.5-gci-1.6-upgrade-master
+- https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-gci-1.4-container_vm-1.6-upgrade-cluster
+- https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-gci-1.4-container_vm-1.6-upgrade-master
+- https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-gci-1.4-gci-1.6-upgrade-cluster
+- https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-gci-1.4-gci-1.6-upgrade-master
+- https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-gci-1.5-container_vm-1.6-upgrade-cluster
+- https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-gci-1.5-container_vm-1.6-upgrade-master
+- https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-gci-1.5-gci-1.6-upgrade-master
+- https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gce-1.6-1.5-downgrade-cluster
+- https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gke-gci-1.6-gci-1.5-downgrade-cluster
+
+### Action Required
+- Address all suite failures *immediately*
+- Pay particular attention to skew test failures
+- Use the new [triage tool](https://storage.googleapis.com/k8s-gubernator/triage/index.html?test=Simple%20pod%20should%20handle%20in-cluster%20config%7CNginx%20should%20conform%20to%20Ingress%20spec%7CPreStop%20should%20call%20prestop%20when%20killing%20a%20pod), thanks SIG Testing and Team/Test-Infra!
+
+## Incomplete Features
+- Open issues filed against [`kubernetes/features` in 1.6 milestone](https://github.com/kubernetes/features/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20milestone%3Av1.6): 29 (**unchanged from last report**)
+- Human curated release notes still incomplete. Specifically very litte curation of [automatically generated release notes](https://github.com/kubernetes/features/blob/release-notes-draft-1.6/release-1.6/release-notes-draft.md#auto-generated-release-notes)
+
+### Action Required
+- Feature owners fill out feature template by **TODAY!**
+- Feature owners submit docs PR which references issue in features repo by **TODAY!**
+- Feature owners prepare release notes by **TODAY!**
+- Address etcd upgrade test failures
+- Make all final changes to the [the release notes draft](https://github.com/kubernetes/features/blob/master/release-1.6/release-notes-draft.md) by **TODAY!**
+
+## Release Machinery
+[ not updated for this report ]
+
+### Action Required
+[ not updated for this report ]
+
+## Actions Taken by Release Team
+- Release will close the following issues
+  - https://github.com/kubernetes/kubernetes/issues/43616
+- Release team has closed the `release-notes-draft-1.6` branch

--- a/releases/release-1.6/go-signal-reports/2017-03-24.md
+++ b/releases/release-1.6/go-signal-reports/2017-03-24.md
@@ -127,14 +127,14 @@
 
 ## Incomplete Features
 - Open issues filed against [`kubernetes/features` in 1.6 milestone](https://github.com/kubernetes/features/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20milestone%3Av1.6): 29 (**unchanged from last report**)
-- Human curated release notes still incomplete. Specifically very litte curation of [automatically generated release notes](https://github.com/kubernetes/features/blob/release-notes-draft-1.6/release-1.6/release-notes-draft.md#auto-generated-release-notes)
+- Human curated release notes still incomplete. Specifically very litte curation of [automatically generated release notes](https://github.com/kubernetes/sig-release/blob/release-notes-draft-1.6/release-1.6/release-notes-draft.md#auto-generated-release-notes)
 
 ### Action Required
 - Feature owners fill out feature template by **TODAY!**
 - Feature owners submit docs PR which references issue in features repo by **TODAY!**
 - Feature owners prepare release notes by **TODAY!**
 - Address etcd upgrade test failures
-- Make all final changes to the [the release notes draft](https://github.com/kubernetes/features/blob/master/release-1.6/release-notes-draft.md) by **TODAY!**
+- Make all final changes to the [the release notes draft](https://github.com/kubernetes/sig-release/blob/master/release-1.6/release-notes-draft.md) by **TODAY!**
 
 ## Release Machinery
 [ not updated for this report ]

--- a/releases/release-1.6/release-1.6.md
+++ b/releases/release-1.6/release-1.6.md
@@ -1,0 +1,65 @@
+# Proposed timeline for 1.6
+We will begin the 1.6 release the first week of 2017.
+We will use the time between releases for planning, designing and bugfixes.
+
+The proposal below is identical in layout to the 1.4 and 1.5 plans with some
+modifications:
+- as before, key days aren't Fridays, since it can be hard to end milestones right up against weekends
+- some sigs will focus on stabilization for 1.6, and there may be fewer new
+  feature proposals
+- there are fewer major holidays and vacation breaks this quarter 
+
+## 1.6 Release Schedule
+- Dec 8 - Jan 3: planning/design/bugfix period
+- Jan 3 (Tues) coding start (7w)
+- Jan 24 (Tues) features repo freeze
+- Jan 30th (Monday) v1.6.0-alpha.1
+- Feb 13th (Monday) v1.6.0-alpha.2
+- Feb 20th (Monday) Cut release-1.6 branch and v1.6.0-beta.0; Feature Burndown Meetings begin
+- Feb 27th (Monday) Start code freeze
+- Feb 28th (Tuesday) v1.6.0-beta.1
+- March 7th (Tuesday) - v1.6.0-beta.2
+- March 14th (Tuesday) Lift code freeze and v1.6.0-rc.1
+- March 22nd (Wednesday) - v1.6.0 (release!)
+
+## 1.6 Details
+
+### Jan 3 - Feb 27
+- 7 week coding period
+- Release 1.6 alphas every 2 weeks
+
+### Feb 20 - Feb 24
+- Community Feature Burndown Meetings held two or three times this week. For those interested in joining please
+  join [the Google Group](https://groups.google.com/forum/#!forum/kubernetes-milestone-burndown)
+- Identify all features going into the release, and make sure alpha, beta, ga is
+  marked in features repo
+
+### Feb 27 - Mar 22
+- Enter code slush on head, no new features or major refactors
+- Fix bugs, and test flakes
+- Start Milestone Burndown meetings (2x per week until the week leading up the
+  release, then every day)
+
+### Mar 8 - Mar 22
+- Open head for 1.7 work on Mar 14, after 1.6 release branch has been fast-forwarded.
+- Fix bugs and run tests, update docs
+- Branch and cut second beta release on Mar 7 (Tuesday)
+- Branch and cut release candidate on Mar 14 (Tuesday)
+- Release 1.6 on March 22 (Wednesday)
+
+
+# Key features
+[Feature tracking spreadsheet
+link](https://docs.google.com/spreadsheets/d/1nspIeRVNjAQHRslHQD1-6gPv99OcYZLMezrBe3Pfhhg/edit#gid=0)
+
+## Notable operational changes
+
+1. Starting in the 1.6 release the [release team](https://github.com/kubernetes/features/blob/master/release-1.6/release_team.md)
+  will use the following procedure to identify release blocking issues
+  1. Any issues listed in the [v1.6 milestone](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20milestone%3Av1.6)
+     will be considered release blocking. It is everyone's responsibility to move non blocking issues out of the `v1.6` milestone. Items targeting 1.7 can be moved into the `v1.7` milestone.
+     milestones **or the release will not ship**
+
+# Contact us
+- [via slack](https://kubernetes.slack.com/messages/k8s-release/)
+- [via email](mailto:kubernetes-release@googlegroups.com)

--- a/releases/release-1.6/release-1.6.md
+++ b/releases/release-1.6/release-1.6.md
@@ -54,7 +54,7 @@ link](https://docs.google.com/spreadsheets/d/1nspIeRVNjAQHRslHQD1-6gPv99OcYZLMez
 
 ## Notable operational changes
 
-1. Starting in the 1.6 release the [release team](https://github.com/kubernetes/features/blob/master/release-1.6/release_team.md)
+1. Starting in the 1.6 release the [release team](https://github.com/kubernetes/sig-release/blob/master/release-1.6/release_team.md)
   will use the following procedure to identify release blocking issues
   1. Any issues listed in the [v1.6 milestone](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20milestone%3Av1.6)
      will be considered release blocking. It is everyone's responsibility to move non blocking issues out of the `v1.6` milestone. Items targeting 1.7 can be moved into the `v1.7` milestone.

--- a/releases/release-1.6/release-notes-draft.md
+++ b/releases/release-1.6/release-notes-draft.md
@@ -1,0 +1,865 @@
+## WARNING: etcd backup strongly recommended
+
+Before updating to 1.6, you are strongly recommended to back up your etcd data.
+Please consult the installation procedure you are using (kargo, kops, kube-up,
+kube-aws, kubeadm etc) for specific advice.
+
+1.6 encourages etcd3, and switching from etcd2 to etcd3 involves a full
+migration of data between different storage engines.  You must stop the API
+from writing to etcd during an etcd2 -> etcd3 migration.  HA installations cannot
+be migrated at the current time using the official Kubernetes procedure.
+
+1.6 will also default to protobuf encoding if using etcd3.  **This change is
+irreversible.**  To rollback, you must restore from a backup made before the
+protobuf/etcd3 switch, and any changes since the backup will be lost.  As 1.5
+does not support protobuf encoding, if you roll back to 1.5 after upgrading to
+protobuf you will be forced to restore from backup, and you will lose any changes
+since you converted to protobuf.  After conversion to protobuf, you should
+validate the correct operation of your cluster thoroughly before returning it
+to normal operation.
+
+Backups are always a good precaution, particularly around upgrades, but this
+upgrade has multiple known issues where the only remedy is to restore from
+backup.
+
+Also, please note:
+- using `application/vnd.kubernetes.protobuf` as the media storage type for 1.6 is default but not required
+- the ability to rollback to etcd2 can be preserved by continuing to use `application/json` as the storage media type. This can be changed to `application/vnd.kubernetes.protobuf` at a later time.
+
+## Major updates and release themes
+
+* Kubernetes now supports up to 5,000 nodes via etcd v3, which is enabled by default.
+* [Role-based access control (RBAC)](https://kubernetes.io//docs/admin/authorization/rbac) has graduated to beta, and defines secure default roles for control plane, node, and controller components.
+* The [`kubeadm` cluster bootstrap tool](https://kubernetes.io/docs/getting-started-guides/kubeadm/) has graduated to beta. Some highlights:
+  * All communication is now over TLS
+  * Authorization plugins can be installed by kubeadm, including the new default of RBAC
+  * The bootstrap token system now allows token management and expiration
+* The [`kubefed` federation bootstrap tool](https://kubernetes.io/docs/tutorials/federation/set-up-cluster-federation-kubefed/) has also graduated to beta.
+* Interaction with container runtimes is now through the CRI interface, enabling easier integration of runtimes with the kubelet. Docker remains the default runtime via Docker-CRI (which moves to beta).
+* Various scheduling features have graduated to beta:
+  * You can now use [multiple schedulers](https://kubernetes.io/docs/admin/multiple-schedulers/)
+  * [Nodes](https://kubernetes.io/docs/user-guide/node-selection/#node-affinity-beta-feature) and [pods](https://kubernetes.io/docs/user-guide/node-selection/#inter-pod-affinity-and-anti-affinity-beta-feature) now support affinity and anti-affinity
+  * Advanced scheduling can be performed with [taints and tolerations](https://kubernetes.io/docs/user-guide/node-selection/#taints-and-tolerations-beta-feature)
+* You can now specify (per pod) how long a pod should stay bound to a node, when there is a node problem. 
+* Various storage features have graduated to GA:
+  * StorageClass pre-installed and set as default on Azure, AWS, GCE, OpenStack, and vSphere
+  * Configurable [Dynamic Provisioning](https://kubernetes.io/docs/user-guide/persistent-volumes/#dynamic) and [StorageClass](https://kubernetes.io/docs/user-guide/persistent-volumes/#storageclasses)
+* DaemonSets [can now be updated by a rolling update](https://kubernetes.io/docs/tasks/manage-daemon/update-daemon-set).
+
+## Action Required
+
+### Certificates API
+* Users of the alpha certificates API should delete v1alpha1 CSRs from the API before upgrading and recreate them as v1beta1 CSR after upgrading. ([#39772](https://github.com/kubernetes/kubernetes/pull/39772), [@mikedanese](https://github.com/mikedanese))
+
+### Cluster Autoscaler
+* If you are using (or planning to use) Cluster Autoscaler please wait for Kubernetes 1.6.1. In 1.6.0 Cluster Autoscaler 
+may occasionally increase the size of the cluster a bit more than it is actually needed, when there are 
+unschedulable pods, scale up is required and cloud provider is slow to set up networking for new nodes. 
+Anyway, the cluster should get back to the proper size after 10 min.
+
+### Deployment
+* Deployment now fully respects ControllerRef to avoid fighting over Pods and ReplicaSets. At the time of upgrade, **you must not have Deployments with selectors that overlap**, or else [ownership of ReplicaSets may change](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/controller-ref.md#upgrading). ([#42175](https://github.com/kubernetes/kubernetes/pull/42175), [@enisoc](https://github.com/enisoc))
+
+### Federation
+* The --dns-provider argument of 'kubefed init' is now mandatory and does not default to `google-clouddns`. To initialize a Federation control plane with Google Cloud DNS, use the following invocation: 'kubefed init --dns-provider=google-clouddns' ([#42092](https://github.com/kubernetes/kubernetes/pull/42092), [@marun](https://github.com/marun))
+* Cluster federation servers have changed the location in etcd where federated services are stored, so existing federated services must be deleted and recreated. Before upgrading, export all federated services from the federation server and delete the services. After upgrading the cluster, recreate the federated services from the exported data. ([#37770](https://github.com/kubernetes/kubernetes/pull/37770), [@enj](https://github.com/enj))
+
+### Internal Storage Layer
+* upgrade to etcd3 prior to upgrading to 1.6 **OR** explicitly specify `--storage-type=etcd2 --storage-media-type=application/json` when starting the apiserver
+
+### Node Components
+* **Kubelet with the Docker-CRI implementation**
+  * The Docker-CRI implementation is enabled by default.
+  * It is not compatible with containers created by older Kubelets. It is
+    recommended to drain your node before upgrade. If you choose to perform
+    an in-place upgrade, the Kubelet will automatically restart all
+    Kubernetes-managed containers on the node.
+  * It is not compatible with CNI plugins that do not conform to the
+    [error handling behavior in the spec](https://github.com/containernetworking/cni/blob/master/SPEC.md#network-configuration-list-error-handling).
+    The plugins are being updated to resolve this issue ([#43488](https://github.com/kubernetes/kubernetes/issues/43488)).
+    You can disable CRI explicitly (`--enable-cri=false`) as a
+    temporary workaround.
+      * The standard `bridge` plugin have been validated to interoperate with
+         the new CRI + CNI code path.
+      * If you are using plugins other than `bridge`, make sure you have
+        updated custom plugins to the latest version that is compatible.
+* **Enhance Kubelet QoS**:
+  * Pods are placed under a new cgroup hierarchy by default. This feature requires
+    draining and restarting the node as part of upgrades. To opt-out set
+    `--cgroups-per-qos=false`.
+  * If `kube-reserved` and/or `system-reserved` are specified, node allocatable
+    will be enforced on all pods by default. To opt-out set
+    `--enforce-node-allocatable=””`
+  * Hard Eviction Thresholds will be subtracted from Capacity while calculating
+    Node Allocatable. This will result in a reduction of schedulable capacity in
+    clusters post upgrade where kubelet hard eviction has been turned on for
+    memory. To opt-out set `--experimental-allocatable-ignore-eviction=true`.
+  * More details on these feature here:
+    https://kubernetes.io/docs/concepts/cluster-administration/node-allocatable/
+* Drop the support for docker 1.9.x. Docker versions 1.10.3, 1.11.2, 1.12.6
+  have been validated.
+* The following deprecated kubelet flags are removed: `--config`, `--auth-path`,
+  `--resource-container`, `--system-container`, `--reconcile-cidr`
+* Remove the temporary fix for pre-1.0 mirror pods. Upgrade directly from
+  pre-1.0 to 1.6 kubelet is not supported.
+* Fluentd was migrated to Daemon Set, which targets nodes with
+  beta.kubernetes.io/fluentd-ds-ready=true label. If you use fluentd in your
+  cluster please make sure that the nodes with version 1.6+ contains this
+  label.
+
+### kubectl
+* Running `kubectl taint` (alpha in 1.5) against a 1.6 server requires upgrading kubectl to version 1.6
+* Running `kubectl taint` (alpha in 1.5) against a 1.5 server requires a kubectl version of 1.5
+* Running `kubectl create secret` no longer accepts passing multiple values to a single --from-literal flag using comma separation
+  * Update command invocations to pass separate --from-literal flags for each value
+
+### RBAC
+* Default ClusterRole and ClusterRoleBinding objects are automatically updated at server start to add missing permissions and subjects (extra permissions and subjects are left in place). To prevent autoupdating a particular role or rolebinding, annotate it with `rbac.authorization.kubernetes.io/autoupdate=false`. ([#41155](https://github.com/kubernetes/kubernetes/pull/41155), [@liggitt](https://github.com/liggitt))
+* `v1beta1` RoleBinding/ClusterRoleBinding subjects changed `apiVersion` to `apiGroup` to fully-qualify a subject. ServiceAccount subjects default to an apiGroup of `""`, User and Group subjects default to an apiGroup of `"rbac.authorization.k8s.io"`. ([#41184](https://github.com/kubernetes/kubernetes/pull/41184), [@liggitt](https://github.com/liggitt))
+* To create or update an RBAC RoleBinding or ClusterRoleBinding object, a user must: ([#39383](https://github.com/kubernetes/kubernetes/pull/39383), [@liggitt](https://github.com/liggitt))
+    * 1. Be authorized to make the create or update API request
+    * 2. Be allowed to bind the referenced role, either by already having all of the permissions contained in the referenced role, or by having the "bind" permission on the referenced role.
+* The `--authorization-rbac-super-user` flag (alpha in 1.5) is deprecated; the `system:masters` group has privileged access ([#38121](https://github.com/kubernetes/kubernetes/pull/38121), [@deads2k](https://github.com/deads2k))
+* special handling of the user `*` in RoleBinding and ClusterRoleBinding objects is removed in v1beta1. To match all users, explicitly bind to the group `system:authenticated` and/or `system:unauthenticated`. Existing v1alpha1 bindings to the user `*` are automatically converted to the group `system:authenticated`. ([#38981](https://github.com/kubernetes/kubernetes/pull/38981), [@liggitt](https://github.com/liggitt))
+
+### Scheduling
+* **Multiple schedulers**
+  * Modify your PodSpecs that currently use the `scheduler.alpha.kubernetes.io/name` annotation on Pod, to instead use the `schedulerName` field in the PodSpec.
+  * Modify any custom scheduler(s) you have written so that they read the `schedulerName` field on Pod instead of the `scheduler.alpha.kubernetes.io/name` annotation. 
+  * Note that you can only start using the `schedulerName` field **after** you upgrade to 1.6; it is not recognized in 1.5.
+
+* **Node affinity/anti-affinity and pod affinity/anti-affinity**
+  * You can continue to use the alpha version of this feature (with one caveat -- see below), in which you specify affinity requests using Pod annotations, in 1.6 by including `AffinityInAnnotations=true` in `--feature-gates`, such as `--feature-gates=FooBar=true,AffinityInAnnotations=true`. Otherwise, you must modify your PodSpecs that currently use the `scheduler.alpha.kubernetes.io/affinity` annotation on Pod, to instead use the `affinity` field in the PodSpec. Support for the annotation will be removed in a future release, so we encourage you to switch to using the field as soon as possible.
+  * Caveat: The alpha version no longer supports, and the beta version does not support, the "empty `podAffinityTerm.namespaces` list means all namespaces" behavior. In both alpha and beta it now means "same namespace as the pod specifying this affinity rule."
+  * Note that you can only start using the `affinity` field **after** you upgrade to 1.6; it is not recognized in 1.5.
+  * The `--failure-domains` scheduler command line-argument is not supported in the beta version of the feature.
+
+* **Taints**
+  * You will need to use `kubectl taint` to re-create all of your taints after kubectl and the master are upgraded to 1.6. Between the time the master is upgraded to 1.6 and when you do this, your existing taints will have no effect. 
+  * You can find out what taints you have in place on a node while you are still running Kubernetes 1.5 by doing `kubectl describe node <node name>`; the `Taints` section will show the taints you have in place. To see the taints that were created under 1.5 when you are running 1.6, do `kubectl get node <node name> -o yaml` and look for the "Annotation" section with the annotation key `scheduler.alpha.kubernetes.io/taints`
+  * You can remove the "old" taints (stored internally as annotations) at any time after the upgrade by doing `kubectl annotate nodes <node name> scheduler.alpha.kubernetes.io/taints-` (note the minus at the end, which means "delete the taint with this key")
+  * Note that because any taints you might have created with Kubernetes 1.5 can only affect the scheduling of new pods (the `NoExecute` taint effect is introduced in 1.6), neither the master upgrade nor your running `kubectl taint` to re-create the taints will affect pods that are already running.
+  * Rescheduler relies on taints, which were changed in a backward incompatible way. Rescheduler 0.3 shipped together with Kubernetes 1.6 understands the new taints and will clean up the old annotations, but Rescheduler 0.2 shipped together with Kubernetes 1.5 doesn't understand the new taints. In order to avoid eviction loop during 1.5->1.6 upgrade you need to either upgrade the master node atomically (for example by using `upgrade.sh` script for GCE) or ensure that the rescheduler is upgraded first, then the scheduler and then all the other master components.
+
+* **Tolerations**
+  * After your master is upgraded to 1.6, you will need to update your PodSpecs to set the `tolerations` field of the PodSpec and remove the `scheduler.alpha.kubernetes.io/tolerations` annotation on the Pod. (It's not strictly necessary to remove the annotation, as it will have no effect once you upgrade to 1.6.) Between the time the master is upgraded to 1.6 and when you do this, tolerations attached to Pods that are created will have no effect. Pods that are already running will not be affected by the upgrade.
+  * You can find the PodSpec tolerations that were created as annotations (if any) in a controller definition by doing `kubectl get <controller kind> <controller name> -o yaml` and looking for the "Annotation" section with the annotation key `scheduler.alpha.kubernetes.io/tolerations` (This will work whether you are running Kubernetes 1.5 or 1.6).
+  * To update a controller's PodSpec to use the field instead of the annotation, use one of the kubectl commands that do update ("kubectl replace" or "kubectl apply" or "kubectl patch") or just delete the controller entirely and re-create it with a new pod template. Note that you will be able to do these things only after the upgrade.
+
+### Service
+* The 'endpoints.beta.kubernetes.io/hostnames-map' annotation is no longer supported.  Users can use the 'Endpoints.subsets[].addresses[].hostname' field instead. ([#39284](https://github.com/kubernetes/kubernetes/pull/39284), [@bowei](https://github.com/bowei))
+
+### StatefulSet
+* StatefulSet now respects ControllerRef to avoid fighting over Pods. At the time of upgrade, **you must not have StatefulSets with selectors that overlap** with any other controllers (such as ReplicaSets), or else [ownership of Pods may change](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/controller-ref.md#upgrading). ([#42080](https://github.com/kubernetes/kubernetes/pull/42080), [@enisoc](https://github.com/enisoc))
+
+### Volume
+* StorageClass pre-installed and set as default on Azure, AWS, GCE, OpenStack, and vSphere.
+  * This is something to pay close attention to if you’ve been using Kubernetes for a while, because it changes the default behavior of PersistentVolumeClaim objects on these clouds.
+  * Marking a StorageClass as default makes it so that even a PersistentVolumeClaim without a StorageClass specified will trigger dynamic provisioning (instead of binding to an existing pool of PVs).
+  * If you depend on the old behavior of volumes binding to existing pool of PersistentVolume objects then modify the StorageClass object and set `storageclass.beta.kubernetes.io/is-default-class` to `false`.
+* Flex volume plugin is updated to support attach/detach interfaces. It broke backward compatibility. Please update your drivers and implement the new callouts.  ([#41804](https://github.com/kubernetes/kubernetes/pull/41804), [@chakri-nelluri](https://github.com/chakri-nelluri))
+
+## Notable Features
+Features for this release were tracked via the use of the [kubernetes/features](https://github.com/kubernetes/features) issues repo.  Each Feature issue is owned by a Special Interest Group from the [kubernetes/community](https://github.com/kubernetes/community/blob/master/sig-list.md).
+
+### Autoscaling
+* **[alpha]** The Horizontal Pod Autoscaler now supports drawing metrics through the API server aggregator.
+* **[alpha]** The Horizontal Pod Autoscaler now supports scaling on multiple, custom metrics.
+* Cluster Autoscaler publishes its status to kube-system/cluster-autoscaler-status ConfigMap.
+* Cluster Autoscaler can continue operations while some nodes are broken or unready.
+* Cluster Autoscaler respects Pod Disruption Budgets when removing a node.
+
+### DaemonSets
+* **[beta]** Introduce the rolling update feature for DaemonSet. See [Performing a Rolling Update on a DaemonSet](https://deploy-preview-2878--kubernetes-io-master-staging.netlify.com/docs/tasks/manage-daemon/update-daemon-set/).
+
+### Deployments
+* **[beta]** Deployments that cannot make progress in rolling out the newest version will now indicate via the API they are blocked ([docs](https://kubernetes.io/docs/user-guide/deployments/#deployment-status))
+
+### Federation
+* **[beta]** `kubefed` has graduated to beta: supports hosting federation on on-prem clusters, automatically configures `kube-dns` in joining clusters and allows passing arguments to federation components.
+
+### Internal Storage Layer
+* **[stable]** The internal storage layer for kubernetes cluster state has been updated to use etcd v3 by default. Existing clusters will have to plan for a data migration window. ([docs](https://github.com/kubernetes/kubernetes.github.io/pull/2763))([kubernetes/features#44](https://github.com/kubernetes/features/issues/44))
+
+### kubeadm
+* **[beta]** Introduces an API for clients to request TLS certificates from the API server. See the [tutorial](https://kubernetes.io/docs/tasks/tls/managing-tls-in-a-cluster).
+* **[beta]** kubeadm is enhanced and improved with a baseline feature set and command line flags that are now marked as beta. Other parts of kubeadm, including subcommands under `kubeadm alpha`, are [still in alpha](https://kubernetes.io/docs/admin/kubeadm/).  Using it is considered safe, although note that upgrades and HA are not yet supported. Please [try it out](https://kubernetes.io/docs/getting-started-guides/kubeadm/) and [give us feedback](https://kubernetes.io/docs/getting-started-guides/kubeadm/#feedback)!
+* **[alpha]** New Bootstrap Token authentication and management method. Works well with kubeadm. kubeadm now supports managing tokens, including time based expiration, after the cluster is launched.  See [kubeadm reference docs](https://kubernetes.io/docs/admin/kubeadm/#manage-tokens) for details.
+* **[alpha]** Adds a new cloud-controller-manager binary that may be used for testing the new out-of-core cloudprovider flow.
+
+### Node Components
+* **[stable]** Init containers have graduated to GA and now appear as a field.
+  The beta annotation value will still be respected and overrides the field
+  value.
+* Kubelet Container Runtime Interface (CRI) support 
+  - **[beta]** The Docker-CRI implementation is enabled by default in kubelet.
+    You can disable it by --enable-cri=false. See
+    [notes on the new implementation](https://github.com/kubernetes/community/blob/master/contributors/devel/container-runtime-interface.md#kubernetes-v16-release-docker-cri-integration-beta)
+    for more details.
+  - **[alpha]** Alpha support for other runtimes:
+    [cri-o](https://github.com/kubernetes-incubator/cri-o/releases/tag/v0.1), [frakti](https://github.com/kubernetes/frakti/releases/tag/v0.1), [rkt](https://github.com/coreos/rkt/issues?q=is%3Aopen+is%3Aissue+label%3Aarea%2Fcri).
+* **[beta]** Node Problem Detector is beta (v0.3.0) now. New
+  features added into node-problem-detector:v0.3.0:
+  - Add support for journald.
+  - The ability to monitor any system daemon logs. Previously only kernel
+    logs were supported.
+  - The ability to be deployed and run as a native daemon.
+* **[alpha]** Critical Pods: When feature gate "ExperimentalCriticalPodAnnotation" is
+  set to true, the system will guarantee scheduling and admission of pods with
+  the following annotation - `scheduler.alpha.kubernetes.io/critical-pod`
+  - This feature should be used in conjunction with the
+    [rescheduler](https://kubernetes.io/docs/admin/rescheduler/) to guarantee
+    resource availability for critical system pods.
+* **[alpha]** `--experimental-nvidia-gpus` flag is replaced by `Accelerators` alpha
+  feature gate along with addition of support for multiple Nvidia GPUs.
+  - To use GPUs, pass `Accelerators=true` as part of `--feature-gates` flag.
+  - More information [here](https://vishh.github.io/docs/user-guide/gpus/).
+* A pod’s Quality of Service Class is now available in its Status.
+* Upgrade cAdvisor library to v0.25.0. Notable changes include,
+  - Container filesystem usage tracking disabled for device mapper due to excessive
+    IOPS.
+  - Ignore `.mount` cgroups, fixing disappearing stats.
+* A new field `terminationMessagePolicy` has been added to containers that allows
+  a user to request FallbackToLogsOnError, which will read from the container's
+  logs to populate the termination message if the user does not write to the
+  termination message log file. The termination message file is now properly
+  readable for end users and has a maximum size (4k bytes) to prevent abuse.
+  Each pod may have up to 12k bytes of termination messages before the contents
+  of each will be truncated.
+* Do not delete pod objects until all its compute resource footprint has been
+  reclaimed.
+  - This feature prevents the node and scheduler from oversubscribing resources
+    that are still being used by a pod in the process of being cleaned up.
+  - This feature can result in increase of Pod Deletion latency especially if the
+    pod has a large filesystem footprint.
+
+### RBAC
+* **[beta]** RBAC API is promoted to v1beta1 (rbac.authorization.k8s.io/v1beta1), and defines default roles for control plane, node, and controller components.
+* **[beta]** The Docker-CRI implementation is Beta and is enabled by default in kubelet.  You can disable it by `--enable-cri=false`. See [notes on the new implementation]( https://github.com/kubernetes/community/blob/master/contributors/devel/container-runtime-interface.md#kubernetes-v16-release-docker-cri-integration-beta) for more details.
+
+### Scheduling
+- **[beta]** The [multiple schedulers](https://kubernetes.io/docs/admin/multiple-schedulers/). This feature allows you to run multiple schedulers in parallel, each responsible for different sets of pods. When using multiple schedulers, the scheduler name is now specified in a new-in-1.6 `schedulerName` field of the PodSpec rather than using the `scheduler.alpha.kubernetes.io/name` annotation on the Pod. When you upgrade to 1.6, the Kubernetes default scheduler will start using the `schedulerName` field of the PodSpec and will ignore the annotation. 
+- **[beta]** [Node affinity/anti-affinity](https://kubernetes.io/docs/user-guide/node-selection/) and **[beta]** [pod affinity/anti-affinity](https://kubernetes.io/docs/user-guide/node-selection/). Node affinity/anti-affinity allow you to specify rules for restricting which node(s) a pod can schedule onto, based on the labels on the node. Pod affinity/anti-affinity allow you to specify rules for spreading and packing pods relative to one another, across arbitrary topologies (node, zone, etc.) These affinity rules are now be specified in a new-in-1.6 `affinity` field of the PodSpec. Kubernetes 1.6 continues to support the alpha `scheduler.alpha.kubernetes.io/affinity` annotation on the Pod if you explicitly enable the alpha feature "AffinityInAnnotations", but it will be removed in a future release. When you upgrade to 1.6, if you have not enabled the alpha feature, then the scheduler will use the `affinity` field in PodSpec and will ignore the annotation. If you have enabled the alpha feature, then the scheduler will use the `affinity` field in PodSpec if it is present, and otherwise will use the annotation.
+- **[beta]** [Taints and tolerations](https://kubernetes.io/docs/user-guide/node-selection/). This feature allows you to specify rules for "repelling" pods from nodes by default, which enables use cases like dedicated nodes and reserving nodes with special features for pods that need those features. We've also added a `NoExecute` taint type that evicts already-running pods, and an associated `tolerationSeconds` field to tolerations to delay the eviction for a specified amount of time. As before, taints are created using `kubectl taint` (but internally they are now represented as a field `taints` in the NodeSpec rather than using the `scheduler.alpha.kubernetes.io/taints` annotation on Node). Tolerations are now specified in a new-in-1.6 `tolerations` field of the PodSpec rather than using the `scheduler.alpha.kubernetes.io/tolerations` annotation on the Pod. When you upgrade to 1.6, the scheduler will start using the fields and will ignore the annotations.
+- **[alpha]** Represent node problems "not ready" and "unreachable" using `NoExecute` taints. In combination with `tolerationSeconds` described below, this allows per-pod specification of how long to remain bound to a node that becomes unreachable or not ready, rather than using the default of 5 minutes. You can enable this alpha feature by including `TaintBasedEvictions=true` in `--feature-gates`, such as `--feature-gates=FooBar=true,TaintBasedEvictions=true`. Documentation is [here](https://kubernetes.io/docs/user-guide/node-selection/).
+
+### Service Catalog
+- **[alpha]** Adds a new API resource `PodPreset` and admission controller to enable defining cross-cutting injection of Volumes and Environment into Pods.
+
+### Volumes
+* **[stable]** StorageClass API is promoted to v1 (storage.k8s.io/v1).
+* **[stable]** Default storage classes are deployed during installation on Azure, AWS, GCE, OpenStack and vSphere.
+* **[stable]** Added ability to populate environment variables from a configmap or secret.
+* **[stable]** Support for user-written/run dynamic PV provisioners. The Kubernetes Incubator contains [a golang library and examples](https://github.com/kubernetes-incubator/external-storage).
+* **[stable]** Volume plugin for ScaleIO enabling pods to seamlessly access and use data stored on Dell EMC ScaleIO volumes.
+* **[stable]** Volume plugin for Portworx added capability to use [Portworx](http://www.portworx.com) as a storage provider for Kubernetes clusters. Portworx pools server capacity and turns servers or cloud instances into converged, highly available compute and storage nodes.
+* **[stable]** Add support to use NFSv3, NFSv4, and GlusterFS on GCE/GKE GCI image based clusters.
+* **[beta]** Added support for mount options in persistent volumes.
+* **[alpha]** All in one volume proposal - a new volume driver capable of projecting secrets, configmaps, and downward API items into the same directory.
+* **[alpha]** Flex volume API and Improved lifecycle (flexvolume).
+
+## Deprecations
+* Remove extensions/v1beta1 Jobs resource, and job/v1beta1 generator. ([#38614](https://github.com/kubernetes/kubernetes/pull/38614), [@soltysh](https://github.com/soltysh))
+* `federation/deploy/deploy.sh` was an interim solution introduced in Kubernetes v1.4 to simplify the federation control plane deployment experience. Now that we have `kubefed`, we are deprecating `deploy.sh` scripts. ([#38902](https://github.com/kubernetes/kubernetes/pull/38902), [@madhusudancs](https://github.com/madhusudancs))
+
+
+### Cluster Provisioning Scripts
+* The bash AWS deployment via kube-up.sh has been deprecated. See http://kubernetes.io/docs/getting-started-guides/aws/ for alternatives. ([#38772](https://github.com/kubernetes/kubernetes/pull/38772), [@zmerlynn](https://github.com/zmerlynn))
+* Remove Azure kube-up as the Azure community has focused efforts elsewhere. ([#41672](https://github.com/kubernetes/kubernetes/pull/41672), [@mikedanese](https://github.com/mikedanese))
+* Remove the deprecated vsphere kube-up. ([#39140](https://github.com/kubernetes/kubernetes/pull/39140), [@kerneltime](https://github.com/kerneltime))
+
+### Other Deprecations
+* Remove cmd/kube-discovery from the tree since it's not necessary anymore ([#42070](https://github.com/kubernetes/kubernetes/pull/42070), [@luxas](https://github.com/luxas))
+
+#### kubeadm
+* Quite a few flags been renamed or removed.  Those options that are removed as flags can still be accessed via the config file.  Most noteably this includes external etcd settings and the option for setting the cloud provider on the API server.  The [kubeadm reference documentation](https://kubernetes.io/docs/admin/kubeadm/) is up to date with the new flags.
+
+## Changes to API Resources
+### ABAC
+* ABAC policies using `"user":"*"` or `"group":"*"` to match all users or groups will only match authenticated requests. To match unauthenticated requests, ABAC policies must explicitly specify `"group":"system:unauthenticated"` ([#38968](https://github.com/kubernetes/kubernetes/pull/38968), [@liggitt](https://github.com/liggitt))
+
+### Admission Control
+* Adds a new API resource `PodPreset` and admission controller to enable defining cross-cutting injection of Volumes and Environment into Pods. ([#41931](https://github.com/kubernetes/kubernetes/pull/41931), [@jessfraz](https://github.com/jessfraz))
+* Enable DefaultTolerationSeconds admission controller by default ([#41815](https://github.com/kubernetes/kubernetes/pull/41815), [@kevin-wangzefeng](https://github.com/kevin-wangzefeng))
+* ResourceQuota ability to support default limited resources ([#36765](https://github.com/kubernetes/kubernetes/pull/36765), [@derekwaynecarr](https://github.com/derekwaynecarr))
+* Add defaultTolerationSeconds admission controller ([#41414](https://github.com/kubernetes/kubernetes/pull/41414), [@kevin-wangzefeng](https://github.com/kevin-wangzefeng))
+* An `automountServiceAccountToken` field was added to ServiceAccount and PodSpec objects. If set to `false` on a pod spec, no service account token is automounted in the pod. If set to `false` on a service account, no service account token is automounted for that service account unless explicitly overridden in the pod spec. ([#37953](https://github.com/kubernetes/kubernetes/pull/37953), [@liggitt](https://github.com/liggitt))
+* Admission control support for versioned configuration files ([#39109](https://github.com/kubernetes/kubernetes/pull/39109), [@derekwaynecarr](https://github.com/derekwaynecarr))
+* Ability to quota storage by storage class ([#34554](https://github.com/kubernetes/kubernetes/pull/34554), [@derekwaynecarr](https://github.com/derekwaynecarr))
+
+### Authentication
+* The authentication.k8s.io API group was promoted to v1([#41058](https://github.com/kubernetes/kubernetes/pull/41058), [@liggitt](https://github.com/liggitt))
+
+### Authorization
+* The authorization.k8s.io API group was promoted to v1 ([#40709](https://github.com/kubernetes/kubernetes/pull/40709), [@liggitt](https://github.com/liggitt))
+* The SubjectAccessReview API now passes subresource and resource name information to the authorizer to answer authorization queries. ([#40935](https://github.com/kubernetes/kubernetes/pull/40935), [@liggitt](https://github.com/liggitt))
+
+### Autoscaling
+* Introduces an new alpha version of the Horizontal Pod Autoscaler including expanded support for specifying metrics. ([#36033](https://github.com/kubernetes/kubernetes/pull/36033), [@DirectXMan12](https://github.com/DirectXMan12))
+* HorizontalPodAutoscaler is no longer supported in extensions/v1beta1 version. Use autoscaling/v1 instead. ([#35782](https://github.com/kubernetes/kubernetes/pull/35782), [@piosz](https://github.com/piosz))
+* Fixes an HPA-related panic due to division-by-zero. ([#39694](https://github.com/kubernetes/kubernetes/pull/39694), [@DirectXMan12](https://github.com/DirectXMan12))
+
+### Certificates
+* The CertificateSigningRequest API added the `extra` field to persist all information about the requesting user. This mirrors the fields in the SubjectAccessReview API used to check authorization. ([#41755](https://github.com/kubernetes/kubernetes/pull/41755), [@liggitt](https://github.com/liggitt))
+* Native support for token based bootstrap flow.  This includes signing a well known ConfigMap in the `kube-public` namespace and cleaning out expired tokens. ([#36101](https://github.com/kubernetes/kubernetes/pull/36101), [@jbeda](https://github.com/jbeda))
+
+### Config Map
+* Volumes and environment variables populated from ConfigMap and Secret objects can now tolerate the named source object or specific keys being missing, by adding `optional: true` to the volume or environment variable source specifications. ([#39981](https://github.com/kubernetes/kubernetes/pull/39981), [@fraenkel](https://github.com/fraenkel))
+* Allow pods to define multiple environment variables from a whole ConfigMap ([#36245](https://github.com/kubernetes/kubernetes/pull/36245), [@fraenkel](https://github.com/fraenkel))
+
+### CronJob
+* Add configurable limits to CronJob resource to specify how many successful and failed jobs are preserved. ([#40932](https://github.com/kubernetes/kubernetes/pull/40932), [@peay](https://github.com/peay))
+
+### Daemon Set
+* DaemonSet now respects ControllerRef to avoid fighting over Pods. ([#42173](https://github.com/kubernetes/kubernetes/pull/42173), [@enisoc](https://github.com/enisoc))
+* Make DaemonSet respect critical pods annotation when scheduling.  ([#42028](https://github.com/kubernetes/kubernetes/pull/42028), [@janetkuo](https://github.com/janetkuo))
+* Implement the update feature for DaemonSet. ([#41116](https://github.com/kubernetes/kubernetes/pull/41116), [@lukaszo](https://github.com/lukaszo))
+* Make DaemonSets survive taint-based evictions when nodes turn unreachable/notReady. ([#41896](https://github.com/kubernetes/kubernetes/pull/41896), [@kevin-wangzefeng](https://github.com/kevin-wangzefeng))
+* Make DaemonSet controller respect node taints and pod tolerations.  ([#41172](https://github.com/kubernetes/kubernetes/pull/41172), [@janetkuo](https://github.com/janetkuo))
+* DaemonSet controller actively kills failed pods (to recreate them) ([#40330](https://github.com/kubernetes/kubernetes/pull/40330), [@janetkuo](https://github.com/janetkuo))
+* DaemonSet ObservedGeneration ([#39157](https://github.com/kubernetes/kubernetes/pull/39157), [@lukaszo](https://github.com/lukaszo))
+
+### Deployment
+* Add ready replicas in Deployments ([#37959](https://github.com/kubernetes/kubernetes/pull/37959), [@kargakis](https://github.com/kargakis))
+* Deployments that cannot make progress in rolling out the newest version will now indicate via the API they are blocked
+* Introduce apps/v1beta1.Deployments resource with modified defaults compared to extensions/v1beta1.Deployments. ([#39683](https://github.com/kubernetes/kubernetes/pull/39683), [@soltysh](https://github.com/soltysh))
+* Introduce new generator for apps/v1beta1 deployments ([#42362](https://github.com/kubernetes/kubernetes/pull/42362), [@soltysh](https://github.com/soltysh))
+
+### Node
+* Set all node conditions to Unknown when node is unreachable ([#36592](https://github.com/kubernetes/kubernetes/pull/36592), [@andrewsykim](https://github.com/andrewsykim))
+
+### Pod
+* Init containers have graduated to GA and now appear as a field.  The beta annotation value will still be respected and overrides the field value. ([#38382](https://github.com/kubernetes/kubernetes/pull/38382), [@hodovska](https://github.com/hodovska))
+* A new field `terminationMessagePolicy` has been added to containers that allows a user to request `FallbackToLogsOnError`, which will read from the container's logs to populate the termination message if the user does not write to the termination message log file.  The termination message file is now properly readable for end users and has a maximum size (4k bytes) to prevent abuse.  Each pod may have up to 12k bytes of termination messages before the contents of each will be truncated. ([#39341](https://github.com/kubernetes/kubernetes/pull/39341), [@smarterclayton](https://github.com/smarterclayton))
+* Fix issue with PodDisruptionBudgets in which `minAvailable` specified as a percentage did not work with StatefulSet Pods. ([#39454](https://github.com/kubernetes/kubernetes/pull/39454), [@foxish](https://github.com/foxish))
+* Node affinity has moved from annotations to api fields in the pod spec.  Node affinity that is defined in the annotations will be ignored. ([#37299](https://github.com/kubernetes/kubernetes/pull/37299), [@rrati](https://github.com/rrati))
+* Moved pod affinity and anti-affinity from annotations to api fields [#25319](https://github.com/kubernetes/kubernetes/pull/25319) ([#39478](https://github.com/kubernetes/kubernetes/pull/39478), [@rrati](https://github.com/rrati))
+* Add QoS pod status field ([#37968](https://github.com/kubernetes/kubernetes/pull/37968), [@sjenning](https://github.com/sjenning))
+
+### Pod Security Policy
+* PodSecurityPolicy resource is now enabled by default in the extensions API group. ([#39743](https://github.com/kubernetes/kubernetes/pull/39743), [@pweil-](https://github.com/pweil-))
+
+### RBAC
+* the `attributeRestrictions` field has been removed from the PolicyRule type in the rbac.authorization.k8s.io/v1alpha1 API. The field was not used by the RBAC authorizer. ([#39625](https://github.com/kubernetes/kubernetes/pull/39625), [@deads2k](https://github.com/deads2k))
+* A user can now be authorized to bind a particular role by having permission to perform the `bind` verb on the referenced role ([#39383](https://github.com/kubernetes/kubernetes/pull/39383), [@liggitt](https://github.com/liggitt))
+
+### Replica Set
+* ReplicaSet has onwer ref of the Deployment that created it ([#35676](https://github.com/kubernetes/kubernetes/pull/35676), [@krmayankk](https://github.com/krmayankk))
+
+### Secrets
+* Populate environment variables from a secrets. ([#39446](https://github.com/kubernetes/kubernetes/pull/39446), [@fraenkel](https://github.com/fraenkel))
+* Added a new secret type "bootstrap.kubernetes.io/token" for dynamically creating TLS bootstrapping bearer tokens. ([#41281](https://github.com/kubernetes/kubernetes/pull/41281), [@ericchiang](https://github.com/ericchiang))
+
+### Service
+* Endpoints, that tolerate unready Pods, are now listing Pods in state Terminating as well ([#37093](https://github.com/kubernetes/kubernetes/pull/37093), [@simonswine](https://github.com/simonswine))
+* Fix Service Update on LoadBalancerSourceRanges Field ([#37720](https://github.com/kubernetes/kubernetes/pull/37720), [@freehan](https://github.com/freehan))
+* Bug fix. Incoming UDP packets not reach newly deployed services ([#32561](https://github.com/kubernetes/kubernetes/pull/32561), [@zreigz](https://github.com/zreigz))
+* Services of type loadbalancer consume both loadbalancer and nodeport quota. ([#39364](https://github.com/kubernetes/kubernetes/pull/39364), [@zhouhaibing089](https://github.com/zhouhaibing089))
+
+### Stateful Set
+
+* Fix zone placement heuristics so that multiple mounts in a StatefulSet pod are created in the same zone ([#40910](https://github.com/kubernetes/kubernetes/pull/40910), [@justinsb](https://github.com/justinsb))
+* Fixes issue [#38418](https://github.com/kubernetes/kubernetes/pull/38418) which, under circumstance, could cause StatefulSet to deadlock.  ([#40838](https://github.com/kubernetes/kubernetes/pull/40838), [@kow3ns](https://github.com/kow3ns))
+  * Mediates issue [#36859](https://github.com/kubernetes/kubernetes/pull/36859). StatefulSet only acts on Pods whose identity matches the StatefulSet, providing a partial mediation for overlapping controllers.
+
+### Taints and Tolerations
+* Add a manager to NodeController that is responsible for removing Pods from Nodes tainted with NoExecute Taints. This feature is beta (as the rest of taints) and enabled by default. It's gated by controller-manager enable-taint-manager flag. ([#40355](https://github.com/kubernetes/kubernetes/pull/40355), [@gmarek](https://github.com/gmarek))
+* Add an alpha feature that makes NodeController set Taints instead of deleting Pods from not Ready Nodes. ([#41133](https://github.com/kubernetes/kubernetes/pull/41133), [@gmarek](https://github.com/gmarek))
+* Make tolerations respect wildcard key ([#39914](https://github.com/kubernetes/kubernetes/pull/39914), [@kevin-wangzefeng](https://github.com/kevin-wangzefeng))
+* Forgiveness alpha version api definition ([#39469](https://github.com/kubernetes/kubernetes/pull/39469), [@kevin-wangzefeng](https://github.com/kevin-wangzefeng))
+* Rescheduler uses taints in v1beta1 and will remove old ones (in version v1alpha1) right after its start. ([#43106](https://github.com/kubernetes/kubernetes/pull/43106), [@piosz](https://github.com/piosz))
+
+### Volumes
+* StorageClassName attribute has been added to PersistentVolume and PersistentVolumeClaim objects and should be used instead of annotation `volume.beta.kubernetes.io/storage-class`. The beta annotation is still working in this release, however it will be removed in a future release. ([#42128](https://github.com/kubernetes/kubernetes/pull/42128), [@jsafrane](https://github.com/jsafrane))
+* Parameter keys in a StorageClass `parameters` map may not use the `kubernetes.io` or `k8s.io` namespaces. ([#41837](https://github.com/kubernetes/kubernetes/pull/41837), [@liggitt](https://github.com/liggitt))
+* Add storage.k8s.io/v1 API ([#40088](https://github.com/kubernetes/kubernetes/pull/40088), [@jsafrane](https://github.com/jsafrane))
+* Alpha version of dynamic volume provisioning is removed in this release. Annotation ([#40000](https://github.com/kubernetes/kubernetes/pull/40000), [@jsafrane](https://github.com/jsafrane))
+    * "volume.alpha.kubernetes.io/storage-class" does not have any special meaning. A default storage class
+    * and  DefaultStorageClass admission plugin can be used to preserve similar behavior of Kubernetes cluster,
+    * see https://kubernetes.io/docs/user-guide/persistent-volumes/#class-1 for details.
+* Reduce verbosity of volume reconciler when attaching volumes ([#36900](https://github.com/kubernetes/kubernetes/pull/36900), [@codablock](https://github.com/codablock))
+* We change the default attach_detach_controller sync period to 1 minute to reduce the query frequency through cloud provider to check whether volumes are attached or not.  ([#41363](https://github.com/kubernetes/kubernetes/pull/41363), [@jingxu97](https://github.com/jingxu97))
+
+## Changes to Major Components
+### API Server
+* **`--anonymous-auth` is enabled by default, unless the API server is started with the `AlwaysAllow` authorizer. ([#38706](https://github.com/kubernetes/kubernetes/pull/38706), [@deads2k](https://github.com/deads2k))**
+* **when using OIDC authentication and specifying --oidc-username-claim=email, an `"email_verified":true` claim must be returned from the identity provider. ([#36087](https://github.com/kubernetes/kubernetes/pull/36087), [@ericchiang](https://github.com/ericchiang))**
+  * `--basic-auth-file` supports optionally specifying groups in the fourth column of the file ([#39651](https://github.com/kubernetes/kubernetes/pull/39651), [@liggitt](https://github.com/liggitt))
+* API server now has two separate limits for read-only and mutating inflight requests. ([#36064](https://github.com/kubernetes/kubernetes/pull/36064), [@gmarek](https://github.com/gmarek))
+* Restored normalization of custom `--etcd-prefix` when `--storage-backend` is set to etcd3 ([#42506](https://github.com/kubernetes/kubernetes/pull/42506), [@liggitt](https://github.com/liggitt))
+* Updating apiserver to return http status code 202 for a delete request when the resource is not immediately deleted because of user requesting cascading deletion using DeleteOptions.OrphanDependents=false. ([#41165](https://github.com/kubernetes/kubernetes/pull/41165), [@nikhiljindal](https://github.com/nikhiljindal))
+* Use full package path for definition name in OpenAPI spec ([#40124](https://github.com/kubernetes/kubernetes/pull/40124), [@mbohlool](https://github.com/mbohlool))
+* Follow redirects for streaming requests (exec/attach/port-forward) in the apiserver by default (alpha -> beta). ([#40039](https://github.com/kubernetes/kubernetes/pull/40039), [@timstclair](https://github.com/timstclair))
+* Add 'X-Content-Type-Options: nosniff" to some error messages ([#37190](https://github.com/kubernetes/kubernetes/pull/37190), [@brendandburns](https://github.com/brendandburns))
+* Fixes bug in resolving client-requested API versions ([#38533](https://github.com/kubernetes/kubernetes/pull/38533), [@DirectXMan12](https://github.com/DirectXMan12))
+* Replace glog.Fatals with fmt.Errorfs ([#38175](https://github.com/kubernetes/kubernetes/pull/38175), [@sttts](https://github.com/sttts))
+* Pipe get options to storage ([#37693](https://github.com/kubernetes/kubernetes/pull/37693), [@wojtek-t](https://github.com/wojtek-t))
+* The --long-running-request-regexp flag to kube-apiserver is deprecated and will be removed in a future release. Long-running requests are now detected based on specific verbs (watch, proxy) or subresources (proxy, portforward, log, exec, attach). ([#38119](https://github.com/kubernetes/kubernetes/pull/38119), [@liggitt](https://github.com/liggitt))
+* if kube-apiserver is started with `--storage-backend=etcd2`, the media type `application/json` is used. ([#43122](https://github.com/kubernetes/kubernetes/pull/43122), [@liggitt](https://github.com/liggitt))
+* API fields that previously serialized null arrays as `null` and empty arrays as `[]` no longer distinguish between those values and always output `[]` when serializing to JSON. ([#43422](https://github.com/kubernetes/kubernetes/pull/43422), [@liggitt](https://github.com/liggitt))
+* Generate OpenAPI definition for inlined types ([#39466](https://github.com/kubernetes/kubernetes/pull/39466), [@mbohlool](https://github.com/mbohlool))
+
+### API Server Aggregator
+* Rename kubernetes-discovery to kube-aggregator ([#39619](https://github.com/kubernetes/kubernetes/pull/39619), [@deads2k](https://github.com/deads2k))
+* Fix connection upgrades through kuberentes-discovery ([#38724](https://github.com/kubernetes/kubernetes/pull/38724), [@deads2k](https://github.com/deads2k))
+
+#### Generic API Server
+* Move pkg/api/rest into genericapiserver ([#39948](https://github.com/kubernetes/kubernetes/pull/39948), [@sttts](https://github.com/sttts))
+* Move non-generic apiserver code out of the generic packages ([#38191](https://github.com/kubernetes/kubernetes/pull/38191), [@sttts](https://github.com/sttts))
+* Fixes API compatibility issue with empty lists incorrectly returning a null `items` field instead of an empty array. ([#39834](https://github.com/kubernetes/kubernetes/pull/39834), [@liggitt](https://github.com/liggitt))
+* Re-add /healthz/ping handler in genericapiserver ([#38603](https://github.com/kubernetes/kubernetes/pull/38603), [@sttts](https://github.com/sttts))
+* Remove genericapiserver.Options.MasterServiceNamespace ([#38186](https://github.com/kubernetes/kubernetes/pull/38186), [@sttts](https://github.com/sttts))
+* genericapiserver: cut off more dependencies – episode 3 ([#40426](https://github.com/kubernetes/kubernetes/pull/40426), [@sttts](https://github.com/sttts))
+* genericapiserver: more dependency cutoffs ([#40216](https://github.com/kubernetes/kubernetes/pull/40216), [@sttts](https://github.com/sttts))
+* genericapiserver: cut off kube pkg/version dependency ([#39943](https://github.com/kubernetes/kubernetes/pull/39943), [@sttts](https://github.com/sttts))
+* genericapiserver: cut off pkg/serviceaccount dependency ([#39945](https://github.com/kubernetes/kubernetes/pull/39945), [@sttts](https://github.com/sttts))
+* genericapiserver: cut off pkg/apis/extensions and pkg/storage dependencies ([#39946](https://github.com/kubernetes/kubernetes/pull/39946), [@sttts](https://github.com/sttts))
+* genericapiserver: cut off certificates api dependency ([#39947](https://github.com/kubernetes/kubernetes/pull/39947), [@sttts](https://github.com/sttts))
+* genericapiserver: extract CA cert from server cert and SNI cert chains ([#39022](https://github.com/kubernetes/kubernetes/pull/39022), [@sttts](https://github.com/sttts))
+* genericapiserver: turn APIContainer.SecretRoutes into a real ServeMux ([#38826](https://github.com/kubernetes/kubernetes/pull/38826), [@sttts](https://github.com/sttts))
+* genericapiserver: unify swagger and openapi in config ([#38690](https://github.com/kubernetes/kubernetes/pull/38690), [@sttts](https://github.com/sttts))
+
+### Client
+* Use Prometheus instrumentation conventions ([#36704](https://github.com/kubernetes/kubernetes/pull/36704), [@fabxc](https://github.com/fabxc))
+* Clients now use the `?watch=true` parameter to make watch API calls, instead of the `/watch/` path prefix ([#41722](https://github.com/kubernetes/kubernetes/pull/41722), [@liggitt](https://github.com/liggitt))
+* Move private key parsing from serviceaccount/jwt.go to client-go/util/cert ([#40907](https://github.com/kubernetes/kubernetes/pull/40907), [@cblecker](https://github.com/cblecker))
+* Caching added to the OIDC client auth plugin to fix races and reduce the time kubectl commands using this plugin take by several seconds. ([#38167](https://github.com/kubernetes/kubernetes/pull/38167), [@ericchiang](https://github.com/ericchiang))
+* Fix resync goroutine leak in ListAndWatch ([#35672](https://github.com/kubernetes/kubernetes/pull/35672), [@tatsuhiro-t](https://github.com/tatsuhiro-t))
+
+#### client-go
+* The main repository does not keep multiple releases of clientsets anymore. Please find previous releases at https://github.com/kubernetes/client-go ([#38154](https://github.com/kubernetes/kubernetes/pull/38154), [@caesarxuchao](https://github.com/caesarxuchao))
+* Support whitespace in command path for gcp auth plugin ([#41653](https://github.com/kubernetes/kubernetes/pull/41653), [@jlowdermilk](https://github.com/jlowdermilk))
+* client-go no longer imports GCP OAuth2 and OpenID Connect packages by default. ([#41532](https://github.com/kubernetes/kubernetes/pull/41532), [@ericchiang](https://github.com/ericchiang))
+* Added bool type support for jsonpath. ([#39063](https://github.com/kubernetes/kubernetes/pull/39063), [@xingzhou](https://github.com/xingzhou))
+* Preventing nil pointer reference in client_config ([#40508](https://github.com/kubernetes/kubernetes/pull/40508), [@vjsamuel](https://github.com/vjsamuel))
+* Prevent hotloops on error conditions, which could fill up the disk faster than log rotation can free space. ([#40497](https://github.com/kubernetes/kubernetes/pull/40497), [@lavalamp](https://github.com/lavalamp))
+
+### Cloud Provider
+
+#### AWS
+* Allow to running the master with a different AWS account or even on a different cloud provider than the nodes. ([#39996](https://github.com/kubernetes/kubernetes/pull/39996), [@scheeles](https://github.com/scheeles))
+* Support shared tag `kubernetes.io/cluster/<clusterid>` ([#41695](https://github.com/kubernetes/kubernetes/pull/41695), [@justinsb](https://github.com/justinsb))
+* Do not consider master instance zones for dynamic volume creation ([#41702](https://github.com/kubernetes/kubernetes/pull/41702), [@justinsb](https://github.com/justinsb))
+* Fix AWS device allocator to only use valid device names ([#41455](https://github.com/kubernetes/kubernetes/pull/41455), [@gnufied](https://github.com/gnufied))
+* Trust region if found from AWS metadata ([#38880](https://github.com/kubernetes/kubernetes/pull/38880), [@justinsb](https://github.com/justinsb))
+* Remove duplicate calls to DescribeInstance during volume operations ([#39842](https://github.com/kubernetes/kubernetes/pull/39842), [@gnufied](https://github.com/gnufied))
+* Recognize eu-west-2 region ([#38746](https://github.com/kubernetes/kubernetes/pull/38746), [@justinsb](https://github.com/justinsb))
+* Recognize ca-central-1 region ([#38410](https://github.com/kubernetes/kubernetes/pull/38410), [@justinsb](https://github.com/justinsb))
+* Add sequential allocator for device names. ([#38818](https://github.com/kubernetes/kubernetes/pull/38818), [@jsafrane](https://github.com/jsafrane))
+
+#### Azure
+* Fix failing load balancers in Azure ([#40405](https://github.com/kubernetes/kubernetes/pull/40405), [@codablock](https://github.com/codablock))
+* Reduce time needed to attach Azure disks ([#40066](https://github.com/kubernetes/kubernetes/pull/40066), [@codablock](https://github.com/codablock))
+* Remove Azure Subnet RouteTable check ([#38334](https://github.com/kubernetes/kubernetes/pull/38334), [@mogthesprog](https://github.com/mogthesprog))
+* Add support for Azure Container Registry, update Azure dependencies ([#37783](https://github.com/kubernetes/kubernetes/pull/37783), [@brendandburns](https://github.com/brendandburns))
+* Allow backendpools in Azure Load Balancers which are not owned by cloud provider ([#36882](https://github.com/kubernetes/kubernetes/pull/36882), [@codablock](https://github.com/codablock))
+
+#### GCE
+* On GCI by default logrotate is disabled for application containers in favor of rotation mechanism provided by docker logging driver. ([#40634](https://github.com/kubernetes/kubernetes/pull/40634), [@crassirostris](https://github.com/crassirostris))
+
+#### GKE
+* New GKE certificates controller. ([#41160](https://github.com/kubernetes/kubernetes/pull/41160), [@pipejakob](https://github.com/pipejakob))
+
+#### vSphere
+* Reverts to looking up the current VM in vSphere using the machine's UUID, either obtained via sysfs or via the `vm-uuid` parameter in the cloud configuration file. ([#40892](https://github.com/kubernetes/kubernetes/pull/40892), [@robdaemon](https://github.com/robdaemon))
+* Fix for detach volume when node is not present/ powered off ([#40118](https://github.com/kubernetes/kubernetes/pull/40118), [@BaluDontu](https://github.com/BaluDontu))
+* Adding vmdk file extension for vmDiskPath in vsphere DeleteVolume ([#40538](https://github.com/kubernetes/kubernetes/pull/40538), [@divyenpatel](https://github.com/divyenpatel))
+* Changed default scsi controller type in vSphere Cloud Provider ([#38426](https://github.com/kubernetes/kubernetes/pull/38426), [@abrarshivani](https://github.com/abrarshivani))
+* Fixes NotAuthenticated errors that appear in the kubelet and kube-controller-manager due to never logging in to vSphere ([#36169](https://github.com/kubernetes/kubernetes/pull/36169), [@robdaemon](https://github.com/robdaemon))
+* Fix panic in vSphere cloud provider ([#38423](https://github.com/kubernetes/kubernetes/pull/38423), [@BaluDontu](https://github.com/BaluDontu))
+* Fix space issue in volumePath with vSphere Cloud Provider ([#38338](https://github.com/kubernetes/kubernetes/pull/38338), [@BaluDontu](https://github.com/BaluDontu))
+
+### Federation
+
+#### kubefed
+* Flag cleanup ([#41335](https://github.com/kubernetes/kubernetes/pull/41335), [@irfanurrehman](https://github.com/irfanurrehman))
+* Create configmap for the cluster kube-dns when cluster joins and remove when it unjoins ([#39338](https://github.com/kubernetes/kubernetes/pull/39338), [@irfanurrehman](https://github.com/irfanurrehman))
+* Support configuring dns-provider ([#40528](https://github.com/kubernetes/kubernetes/pull/40528), [@shashidharatd](https://github.com/shashidharatd))
+* Bug fix relating kubeconfig path in kubefed init ([#41410](https://github.com/kubernetes/kubernetes/pull/41410), [@irfanurrehman](https://github.com/irfanurrehman))
+* Add override flags options to kubefed init ([#40917](https://github.com/kubernetes/kubernetes/pull/40917), [@irfanurrehman](https://github.com/irfanurrehman))
+* Add option to expose federation apiserver on nodeport service ([#40516](https://github.com/kubernetes/kubernetes/pull/40516), [@shashidharatd](https://github.com/shashidharatd))
+* Add option to disable persistence storage for etcd ([#40862](https://github.com/kubernetes/kubernetes/pull/40862), [@shashidharatd](https://github.com/shashidharatd))
+* kubefed init creates a service account for federation controller manager in the federation-system namespace and binds that service account to the federation-system:federation-controller-manager role that has read and list access on secrets in the federation-system namespace.  ([#40392](https://github.com/kubernetes/kubernetes/pull/40392), [@madhusudancs](https://github.com/madhusudancs))
+* Implement dry run support in kubefed init ([#36447](https://github.com/kubernetes/kubernetes/pull/36447), [@irfanurrehman](https://github.com/irfanurrehman))
+* Make federation etcd PVC size configurable ([#36310](https://github.com/kubernetes/kubernetes/pull/36310), [@irfanurrehman](https://github.com/irfanurrehman))
+
+#### Other Notable Changes
+* Federated Ingress over GCE no longer requires separate firewall rules to be created for each cluster to circumvent flapping firewall health checks. ([#41942](https://github.com/kubernetes/kubernetes/pull/41942), [@csbell](https://github.com/csbell))
+* Add support for finalizers in federated configmaps (deletes configmaps from underlying clusters). ([#40464](https://github.com/kubernetes/kubernetes/pull/40464), [@csbell](https://github.com/csbell))
+* Add support for DeleteOptions.OrphanDependents for federated services. Setting it to false while deleting a federated service also deletes the corresponding services from all registered clusters. ([#36390](https://github.com/kubernetes/kubernetes/pull/36390), [@nikhiljindal](https://github.com/nikhiljindal))
+* Add `--controllers` flag to federation controller manager for enable/disable federation ingress controller ([#36643](https://github.com/kubernetes/kubernetes/pull/36643), [@kzwang](https://github.com/kzwang))
+* Stop deleting services from underlying clusters when federated service is deleted. ([#37353](https://github.com/kubernetes/kubernetes/pull/37353), [@nikhiljindal](https://github.com/nikhiljindal))
+* Expose autoscaling apis through federation api server ([#38976](https://github.com/kubernetes/kubernetes/pull/38976), [@irfanurrehman](https://github.com/irfanurrehman))
+* Federation: Add `batch/jobs` API objects to federation-apiserver ([#35943](https://github.com/kubernetes/kubernetes/pull/35943), [@jianhuiz](https://github.com/jianhuiz))
+* Add logging of route53 calls ([#39964](https://github.com/kubernetes/kubernetes/pull/39964), [@justinsb](https://github.com/justinsb))
+
+### Garbage Collector
+* Added foreground garbage collection: the owner object will not be deleted until all its dependents are deleted by the garbage collector. Please checkout the [user doc](https://kubernetes.io/docs/concepts/abstractions/controllers/garbage-collection/) for details. ([#38676](https://github.com/kubernetes/kubernetes/pull/38676), [@caesarxuchao](https://github.com/caesarxuchao))
+  * deleteOptions.orphanDependents is going to be deprecated in 1.7. Please use deleteOptions.propagationPolicy instead.
+
+### kubeadm
+* A new label and taint is used for marking the master. The label is `node-role.kubernetes.io/master=""` and the taint has the effect `NoSchedule`. Tolerate the `node-role.kubernetes.io/master="":NoSchedule` taint to schedule a workload on the master (a networking DaemonSet for example).
+* The kubelet API is now secured, only cluster admins are allowed to access it.
+* Insecure access to the API Server over `localhost:8080` is now disabled.
+* The control plane components now talk securely to each other. The API Server talks securely to the kubelets in the cluster.
+* kubeadm creates RBAC-enabled clusters. This means that some add-ons which worked previously won't work without having their YAML configuration updated. Please see each vendor's own documentation to check that the add-ons you are using will work with Kubernetes 1.6.
+* The kube-discovery Deployment isn't used anymore when creating a kubeadm cluster and shouldn't be used anywhere else either due to its insecure nature.
+* The Certificates API has graduated from alpha to beta. This is a backwards-incompatible change since the alpha support is dropped, and therefore kubeadm v1.5 and v1.6 don't work together (for example kubeadm v1.5 can't join a kubeadm v1.6 cluster).
+* Supporting only etcd3, with 3.0.14 as the minimum version.
+* `kubeadm reset` will no longer drain nodes automatically.  This is because the credentials on nodes do not have permission to perform this operation.  We have documented an [alternate procedure](https://kubernetes.io/docs/getting-started-guides/kubeadm/#tear-down), driven from the API server/master.
+* Hook up kubeadm against the BootstrapSigner ([#41417](https://github.com/kubernetes/kubernetes/pull/41417), [@luxas](https://github.com/luxas))
+* Rename some flags for beta UI and fixup some logic ([#42064](https://github.com/kubernetes/kubernetes/pull/42064), [@luxas](https://github.com/luxas))
+* Insecure access to the API Server at localhost:8080 will be turned off in v1.6 when using kubeadm ([#42066](https://github.com/kubernetes/kubernetes/pull/42066), [@luxas](https://github.com/luxas))
+* Flag --use-kubernetes-version for kubeadm init renamed to --kubernetes-version ([#41820](https://github.com/kubernetes/kubernetes/pull/41820), [@kad](https://github.com/kad))
+* Remove the --cloud-provider flag for beta init UX ([#41710](https://github.com/kubernetes/kubernetes/pull/41710), [@luxas](https://github.com/luxas))
+* Fixed an SELinux issue in kubeadm on Docker 1.12+ by moving etcd SELinux options from container to pod. ([#40682](https://github.com/kubernetes/kubernetes/pull/40682), [@dgoodwin](https://github.com/dgoodwin))
+* Add authorization mode to kubeadm ([#39846](https://github.com/kubernetes/kubernetes/pull/39846), [@andrewrynhard](https://github.com/andrewrynhard))
+* Refactor the certificate and kubeconfig code in the kubeadm binary into two phases ([#39280](https://github.com/kubernetes/kubernetes/pull/39280), [@luxas](https://github.com/luxas))
+* Added kubeadm commands to manage bootstrap tokens and the duration they are valid for. ([#35805](https://github.com/kubernetes/kubernetes/pull/35805), [@dgoodwin](https://github.com/dgoodwin))
+
+### kubectl
+
+#### New Commands
+- `apply set-last-applied` *updates the applied-applied-configuration annotation* ([#41694](https://github.com/kubernetes/kubernetes/pull/41694), [@shiywang](https://github.com/shiywang))
+- `kubectl apply view-last-applied` *viewing the last configuration file applied* ([#41146](https://github.com/kubernetes/kubernetes/pull/41146), [@shiywang](https://github.com/shiywang))
+
+#### Create subcommands
+  - `create poddisruptionbudget` ([#36646](https://github.com/kubernetes/kubernetes/pull/36646), [@kargakis](https://github.com/kargakis))
+  - `create clusterrole` ([#41538](https://github.com/kubernetes/kubernetes/pull/41538), [@xingzhou](https://github.com/xingzhou))
+  - `create role` ([#39852](https://github.com/kubernetes/kubernetes/pull/39852), [@xingzhou](https://github.com/xingzhou))
+  - `create clusterrolebinding` ([#37098](https://github.com/kubernetes/kubernetes/pull/37098), [@deads2k](https://github.com/deads2k))
+  - `create service externalname` ([#34789](https://github.com/kubernetes/kubernetes/pull/34789), [@adohe](https://github.com/adohe))
+- `set selector` - update selector labels ([#38966](https://github.com/kubernetes/kubernetes/pull/38966), [@kargakis](https://github.com/kargakis))
+- `can-i` to see if you can perform an action ([#41077](https://github.com/kubernetes/kubernetes/pull/41077), [@deads2k](https://github.com/deads2k))
+
+#### Updates to existing commands
+* Printing and output
+  * Import a numeric ordering sorting library and use it in the sorting printer. ([#40746](https://github.com/kubernetes/kubernetes/pull/40746), [@matthyx](https://github.com/matthyx))
+  * DaemonSet get and describe show status fields.  ([#42843](https://github.com/kubernetes/kubernetes/pull/42843), [@janetkuo](https://github.com/janetkuo))
+  * Pods describe shows tolerationSeconds ([#42162](https://github.com/kubernetes/kubernetes/pull/42162), [@kevin-wangzefeng](https://github.com/kevin-wangzefeng))
+  * Node describe contains closing paren ([#39217](https://github.com/kubernetes/kubernetes/pull/39217), [@luksa](https://github.com/luksa))
+  * Display pod node selectors with kubectl describe. ([#36396](https://github.com/kubernetes/kubernetes/pull/36396), [@aveshagarwal](https://github.com/aveshagarwal))
+  * Add Version to the resource printer for 'get nodes' ([#37943](https://github.com/kubernetes/kubernetes/pull/37943), [@ailusazh](https://github.com/ailusazh))
+  * Added support for printing in all supported `--output` formats to `kubectl create ...` and `kubectl apply ...` ([#38112](https://github.com/kubernetes/kubernetes/pull/38112), [@juanvallejo](https://github.com/juanvallejo))
+  * Add three more columns to `kubectl get deploy -o wide` output. ([#39240](https://github.com/kubernetes/kubernetes/pull/39240), [@xingzhou](https://github.com/xingzhou))
+  * Fix kubectl get -f <file> -o <nondefault printer> so it prints all items in the file ([#39038](https://github.com/kubernetes/kubernetes/pull/39038), [@ncdc](https://github.com/ncdc))
+  * kubectl describe no longer prints the last-applied-configuration annotation for secrets. ([#34664](https://github.com/kubernetes/kubernetes/pull/34664), [@ymqytw](https://github.com/ymqytw))
+  * Completed pods should not be hidden when requested by name via `kubectl get`. ([#42216](https://github.com/kubernetes/kubernetes/pull/42216), [@smarterclayton](https://github.com/smarterclayton))
+  * Improve formatting of EventSource in kubectl get and kubectl describe ([#40073](https://github.com/kubernetes/kubernetes/pull/40073), [@matthyx](https://github.com/matthyx))
+* Attach now supports multiple types ([#40365](https://github.com/kubernetes/kubernetes/pull/40365), [@shiywang](https://github.com/shiywang))
+* Create now accepts the label selector flag for filtering objects to create ([#40057](https://github.com/kubernetes/kubernetes/pull/40057), [@MrHohn](https://github.com/MrHohn))
+* Top now accepts short forms for "node" and "pod" ("no", "po") ([#39218](https://github.com/kubernetes/kubernetes/pull/39218), [@luksa](https://github.com/luksa))
+* Begin paths for internationalization in kubectl ([#36802](https://github.com/kubernetes/kubernetes/pull/36802), [@brendandburns](https://github.com/brendandburns))
+  * Add initial french translations for kubectl ([#40645](https://github.com/kubernetes/kubernetes/pull/40645), [@brendandburns](https://github.com/brendandburns))
+
+#### Updates to apply 
+* New command `apply set-last-applied` *updates the applied-applied-configuration annotation* ([#41694](https://github.com/kubernetes/kubernetes/pull/41694), [@shiywang](https://github.com/shiywang))
+* New command `apply view-last-applied` *command for viewing the last configuration file applied* ([#41146](https://github.com/kubernetes/kubernetes/pull/41146), [@shiywang](https://github.com/shiywang))
+* `apply` now supports explicitly clearing values by setting them to null ([#40630](https://github.com/kubernetes/kubernetes/pull/40630), [@liggitt](https://github.com/liggitt))
+* Warn user when using `apply` on a resource lacking the `LastAppliedConfig` annotation ([#36672](https://github.com/kubernetes/kubernetes/pull/36672), [@ymqytw](https://github.com/ymqytw))
+* PATCH (i.e. apply and edit) now supports merging lists of primitives ([#38665](https://github.com/kubernetes/kubernetes/pull/38665), [@ymqytw](https://github.com/ymqytw))
+* `apply` falls back to generic 3-way JSON merge patch for Third Party Resource or unregistered types ([#40666](https://github.com/kubernetes/kubernetes/pull/40666), [@ymqytw](https://github.com/ymqytw))
+
+#### Updates to edit
+* `edit` now supports Third party resources and extension API servers. ([#41304](https://github.com/kubernetes/kubernetes/pull/41304), [@liggitt](https://github.com/liggitt))
+  * Now to edit a particular API version, provide the fully-qualify the resource, version, and group used to fetch the object (for example, `job.v1.batch/myjob`)
+  * Client-side conversion is no longer done, and the `--output-version` option is deprecated for `kubectl edit`.
+* `edit` works as intended with apply and will not change the annotation
+  * No longer updates the last-applied-configuration annotation when --save-config is unspecified or false. ([#41924](https://github.com/kubernetes/kubernetes/pull/41924), [@ymqytw](https://github.com/ymqytw))
+  * Fixes issue that caused apply to revert changes made by edit
+
+#### Bug fixes
+* Fixed --save-config in create subcommand to save the annotation ([#40289](https://github.com/kubernetes/kubernetes/pull/40289), [@xilabao](https://github.com/xilabao))
+* Fixed an issue where 'kubectl get --sort-by=' would return an error if the specified fields in sort were not specified in one or more of the returned objects. ([#40541](https://github.com/kubernetes/kubernetes/pull/40541), [@fabianofranz](https://github.com/fabianofranz))
+  * Previously this would cause the command to fail regardless of whether or not the field was present in the object model
+  * Now the command will succeed even if the sort-by field is missing from one or more of the objects
+* Fixed issue with kubectl proxy so it will now proxy an empty path - e.g. http://localhost:8001 ([#39226](https://github.com/kubernetes/kubernetes/pull/39226), [@luksa](https://github.com/luksa))
+* Fixed an issue where commas were not accepted in --from-literal flags for the creation of secrets. ([#35191](https://github.com/kubernetes/kubernetes/pull/35191), [@SamiHiltunen](https://github.com/SamiHiltunen))
+  * Passing multiple values separated by a comma in a single --from-literal flag is no longer supported. Please use multiple --from-literal flags to provide multiple values. 
+* Fixed a bug where the --server, --token, and --certificate-authority flags were not overriding the related in-cluster configs when provided in a `kubectl` call inside a cluster. ([#39006](https://github.com/kubernetes/kubernetes/pull/39006), [@fabianofranz](https://github.com/fabianofranz))
+
+#### Other Notable Changes
+* The api server will publish the extensions/Deployments API as preferred over the apps/Deployment (introduced in 1.6). ([#43553](https://github.com/kubernetes/kubernetes/pull/43553), [@liggitt](https://github.com/liggitt))
+  * This will ensure certain commands in 1.5 versions of kubectl continue function when run against a 1.6 server. (e.g. `kubectl edit deployment`) 
+* Taint
+  * The `taint` command will not function in a skewed 1.5 / 1.6 environment - client and server versions must match (See Action required section above)
+  * Change taints/tolerations to api fields ([#38957](https://github.com/kubernetes/kubernetes/pull/38957), [@aveshagarwal](https://github.com/aveshagarwal))
+  * Make kubectl taint command respect effect NoExecute ([#42120](https://github.com/kubernetes/kubernetes/pull/42120), [@kevin-wangzefeng](https://github.com/kevin-wangzefeng))
+* Allow drain --force to remove pods whose managing resource is deleted. ([#41864](https://github.com/kubernetes/kubernetes/pull/41864), [@marun](https://github.com/marun))
+* `--output-version` is ignored for all commands except `kubectl convert`.  This is consistent with the generic nature of `kubectl` CRUD commands and the previous removal of `--api-version`.  Specific versions can be specified in the resource field: `resource.version.group`, `jobs.v1.batch`. ([#41576](https://github.com/kubernetes/kubernetes/pull/41576), [@deads2k](https://github.com/deads2k))
+* Allow missing keys in templates by default ([#39486](https://github.com/kubernetes/kubernetes/pull/39486), [@ncdc](https://github.com/ncdc))
+* Add error message when trying to use clusterrole with namespace in kubectl ([#36424](https://github.com/kubernetes/kubernetes/pull/36424), [@xilabao](https://github.com/xilabao))
+* When deleting an object with `--grace-period=0`, the client will begin a graceful deletion and wait until the resource is fully deleted.  To force deletion, use the `--force` flag. ([#37263](https://github.com/kubernetes/kubernetes/pull/37263), [@smarterclayton](https://github.com/smarterclayton))
+
+### Node Components
+* Kubelet config should ignore file start with dots.
+  ([#39196](https://github.com/kubernetes/kubernetes/pull/39196),
+  [@resouer](https://github.com/resouer))
+* Bump GCI to gci-stable-56-9000-84-2.
+  ([#41819](https://github.com/kubernetes/kubernetes/pull/41819),
+  [@dchen1107](https://github.com/dchen1107))
+* Bump GCE ContainerVM to container-vm-v20170214 to address CVE-2016-9962.
+  ([#41449](https://github.com/kubernetes/kubernetes/pull/41449),
+  [@zmerlynn](https://github.com/zmerlynn))
+* Kubelet: Remove the PLEG health check from /healthz, Kubelet will now report
+* NodeNotReady on failed PLEG health check.
+  ([#41569](https://github.com/kubernetes/kubernetes/pull/41569),
+  [@yujuhong](https://github.com/yujuhong))
+* CRI: upgrade protobuf to v3. Protobuf v2 and v3 are not compatible.
+  ([#39158](https://github.com/kubernetes/kubernetes/pull/39158), [@feiskyer](https://github.com/feiskyer))
+* kubelet exports metrics for cgroup management (#41988, @sjenning)
+* Experimental support to reserve a pod's memory request from being utilized by
+  pods in lower QoS tiers.
+  ([#41149](https://github.com/kubernetes/kubernetes/pull/41149),
+  [@sjenning](https://github.com/sjenning))
+* Port forwarding can forward over websockets or SPDY.
+  ([#33684](https://github.com/kubernetes/kubernetes/pull/33684),
+  [@fraenkel](https://github.com/fraenkel))
+* Flag gate faster evictions based on node memory pressure using kernel memcg
+  notifications - `--experimental-kernel-memcg-notification`.
+  ([#38258](https://github.com/kubernetes/kubernetes/pull/38258),
+  [@derekwaynecarr](https://github.com/derekwaynecarr)) 
+* Nodes can now report two additional address types in their status: InternalDNS
+  and ExternalDNS. The apiserver can use --kubelet-preferred-address-types to
+  give priority to the type of address it uses to reach nodes.
+  ([#34259](https://github.com/kubernetes/kubernetes/pull/34259), [@liggitt](https://github.com/liggitt))
+
+#### Bug fixes
+* Add image cache to fix the issue where kubelet hands when reporting the node
+  status. ([#38375](https://github.com/kubernetes/kubernetes/pull/38375),
+  [@Random-Liu](https://github.com/Random-Liu))
+* Fix logic error in graceful deletion that caused pods not being able to
+  be deleted. ([#37721](https://github.com/kubernetes/kubernetes/pull/37721),
+  [@derekwaynecarr](https://github.com/derekwaynecarr))
+* Fix ConfigMap for Windows Containers.
+  ([#39373](https://github.com/kubernetes/kubernetes/pull/39373),
+  [@jbhurat](https://github.com/jbhurat))
+* Fix the “pod rejected by kubelet may stay at pending forever” bug.
+  (https://github.com/kubernetes/kubernetes/pull/37661),
+  [@yujuhong](https://github.com/yujuhong))
+
+### kube-controller-manager
+* add --controllers to controller manager ([#39740](https://github.com/kubernetes/kubernetes/pull/39740), [@deads2k](https://github.com/deads2k))
+
+### kube-dns
+* Adds support for configurable DNS stub domains and upstream nameservers.
+  The following configuration options have been added to the `kube-system:kube-dns` ConfigMap:
+  ```
+  "stubDomains": {
+    "acme.local": ["1.2.3.4"]
+  },
+  ```
+  is a map of domain to list of nameservers for the domain. This is used
+  to inject private DNS domains into the kube-dns namespace. In the above
+  example, any DNS requests for *.acme.local will be served by the
+  nameserver 1.2.3.4.
+  ```
+  "upstreamNameservers": ["8.8.8.8", "8.8.4.4"]
+  ```
+  is a list of upstreamNameservers to use, overriding the configuration
+  specified in /etc/resolv.conf.
+  
+* An empty `kube-system:kube-dns` ConfigMap will be created for the cluster if one did not already exist.
+
+### kube-proxy
+* **- Add tcp/udp userspace proxy support for Windows. ([#41487](https://github.com/kubernetes/kubernetes/pull/41487), [@anhowe](https://github.com/anhowe))**
+* Add DNS suffix search list support in Windows kube-proxy. ([#41618](https://github.com/kubernetes/kubernetes/pull/41618), [@JiangtianLi](https://github.com/JiangtianLi))
+* Add a KUBERNETES_NODE_* section to build kubelet/kube-proxy for windows ([#38919](https://github.com/kubernetes/kubernetes/pull/38919), [@brendandburns](https://github.com/brendandburns))
+* Remove outdated net.experimental.kubernetes.io/proxy-mode and net.beta.kubernetes.io/proxy-mode annotations from kube-proxy. ([#40585](https://github.com/kubernetes/kubernetes/pull/40585), [@cblecker](https://github.com/cblecker))
+* proxy/iptables: don't sync proxy rules if services map didn't change ([#38996](https://github.com/kubernetes/kubernetes/pull/38996), [@dcbw](https://github.com/dcbw))
+* Update kube-proxy image to be based off of Debian 8.6 base image. ([#39695](https://github.com/kubernetes/kubernetes/pull/39695), [@ixdy](https://github.com/ixdy))
+* Update amd64 kube-proxy base image to debian-iptables-amd64:v5 ([#39725](https://github.com/kubernetes/kubernetes/pull/39725), [@ixdy](https://github.com/ixdy))
+* Clean up the kube-proxy container image by removing unnecessary packages and files. ([#42090](https://github.com/kubernetes/kubernetes/pull/42090), [@timstclair](https://github.com/timstclair))
+* Better compat with very old iptables (e.g. CentOS 6) ([#37594](https://github.com/kubernetes/kubernetes/pull/37594), [@thockin](https://github.com/thockin))
+
+### Scheduler
+* Add the support to the scheduler for spreading pods of StatefulSets. ([#41708](https://github.com/kubernetes/kubernetes/pull/41708), [@bsalamat](https://github.com/bsalamat))
+* Added support to minimize sending verbose node information to scheduler extender by sending only node names and expecting extenders to cache the rest of the node information ([#41119](https://github.com/kubernetes/kubernetes/pull/41119), [@sarat-k](https://github.com/sarat-k))
+* Support KUBE_MAX_PD_VOLS on Azure ([#41398](https://github.com/kubernetes/kubernetes/pull/41398), [@codablock](https://github.com/codablock))
+* Mark multi-scheduler graduation to beta and then v1. ([#38871](https://github.com/kubernetes/kubernetes/pull/38871), [@k82cn](https://github.com/k82cn))
+* Scheduler treats StatefulSet pods as belonging to a single equivalence class. ([#39718](https://github.com/kubernetes/kubernetes/pull/39718), [@foxish](https://github.com/foxish))
+* Update FitError as a message component into the PodConditionUpdater. ([#39491](https://github.com/kubernetes/kubernetes/pull/39491), [@jayunit100](https://github.com/jayunit100))
+* Fix comment and optimize code ([#38084](https://github.com/kubernetes/kubernetes/pull/38084), [@tanshanshan](https://github.com/tanshanshan))
+* Add flag to enable contention profiling in scheduler. ([#37357](https://github.com/kubernetes/kubernetes/pull/37357), [@gmarek](https://github.com/gmarek))
+* Try self-repair scheduler cache or panic ([#37379](https://github.com/kubernetes/kubernetes/pull/37379), [@wojtek-t](https://github.com/wojtek-t))
+
+### Volume Plugins
+
+#### Azure Disk
+* restrict name length for Azure specifications ([#40030](https://github.com/kubernetes/kubernetes/pull/40030), [@colemickens](https://github.com/colemickens))
+
+#### GlusterFS
+* The glusterfs dynamic volume provisioner will now choose a unique GID for new persistent volumes from a range that can be configured in the storage class with the "gidMin" and "gidMax" parameters. The default range is 2000 - 2147483647 (max int32). ([#37886](https://github.com/kubernetes/kubernetes/pull/37886), [@obnoxxx](https://github.com/obnoxxx))
+
+#### Photon
+* Fix photon controller plugin to construct with correct PdID ([#37167](https://github.com/kubernetes/kubernetes/pull/37167), [@luomiao](https://github.com/luomiao))
+
+#### rbd
+* force unlock rbd image if the image is not used ([#41597](https://github.com/kubernetes/kubernetes/pull/41597), [@rootfs](https://github.com/rootfs))
+
+#### vSphere
+* Fix fsGroup to vSphere ([#38655](https://github.com/kubernetes/kubernetes/pull/38655), [@abrarshivani](https://github.com/abrarshivani))
+* Fix issue when attempting to unmount a wrong vSphere volume ([#37413](https://github.com/kubernetes/kubernetes/pull/37413), [@BaluDontu](https://github.com/BaluDontu))
+
+#### Other Notable Changes
+* Implement bulk polling of volumes ([#41306](https://github.com/kubernetes/kubernetes/pull/41306), [@gnufied](https://github.com/gnufied))
+* Check if pathExists before performing Unmount ([#39311](https://github.com/kubernetes/kubernetes/pull/39311), [@rkouj](https://github.com/rkouj))
+* Unmount operation should not fail if volume is already unmounted ([#38547](https://github.com/kubernetes/kubernetes/pull/38547), [@rkouj](https://github.com/rkouj))
+* Provide kubernetes-controller-manager flags to control volume attach/detach reconciler sync.  The duration of the syncs can be controlled, and the syncs can be shut off as well.  ([#39551](https://github.com/kubernetes/kubernetes/pull/39551), [@chrislovecnm](https://github.com/chrislovecnm))
+* Fix unmountDevice issue caused by shared mount in GCI ([#38411](https://github.com/kubernetes/kubernetes/pull/38411), [@jingxu97](https://github.com/jingxu97))
+* Fix permissions when using fsGroup ([#37009](https://github.com/kubernetes/kubernetes/pull/37009), [@sjenning](https://github.com/sjenning))
+* Fixed issues [#39202](https://github.com/kubernetes/kubernetes/pull/39202), [#41041](https://github.com/kubernetes/kubernetes/pull/41041) and [#40941](https://github.com/kubernetes/kubernetes/pull/40941) that caused the iSCSI connections to be prematurely closed when deleting a pod with an iSCSI persistent volume attached and that prevented the use of newly created LUNs on targets with preestablished connections. ([#41196](https://github.com/kubernetes/kubernetes/pull/41196), [@CristianPop](https://github.com/CristianPop))
+
+## Changes to Cluster Provisioning Scripts
+
+### AWS
+* Deployment of AWS Kubernetes clusters using the in-tree bash deployment (i.e. cluster/kube-up.sh or get-kube.sh) is obsolete. v1.5.x will be the last release to support cluster/kube-up.sh with AWS. For a list of viable alternatives, see: http://kubernetes.io/docs/getting-started-guides/aws/  ([#42196](https://github.com/kubernetes/kubernetes/pull/42196), [@zmerlynn](https://github.com/zmerlynn))
+* Fix an issue where AWS tear-down leaks an DHCP Option Set. ([#38645](https://github.com/kubernetes/kubernetes/pull/38645), [@zmerlynn](https://github.com/zmerlynn))
+
+### Juju
+* The kubernetes-master, kubernetes-worker and kubeapi-load-balancer charms have gained an nrpe-external-master relation, allowing the integration of their monitoring in an external Nagios server. ([#41923](https://github.com/kubernetes/kubernetes/pull/41923), [@Cynerva](https://github.com/Cynerva))
+* Disable anonymous auth on kubelet ([#41919](https://github.com/kubernetes/kubernetes/pull/41919), [@Cynerva](https://github.com/Cynerva))
+* Fix shebangs in charm actions to use python3 ([#42058](https://github.com/kubernetes/kubernetes/pull/42058), [@Cynerva](https://github.com/Cynerva))
+* K8s master charm now properly keeps distributed master files in sync for an HA control plane. ([#41351](https://github.com/kubernetes/kubernetes/pull/41351), [@chuckbutler](https://github.com/chuckbutler))
+* Improve status messages ([#40691](https://github.com/kubernetes/kubernetes/pull/40691), [@Cynerva](https://github.com/Cynerva))
+* Splits Juju Charm layers into master/worker roles ([#40324](https://github.com/kubernetes/kubernetes/pull/40324), [@chuckbutler](https://github.com/chuckbutler))
+    * Adds support for 1.5.x series of Kubernetes
+    * Introduces a tactic for keeping templates in sync with upstream eliminating template drift
+    * Adds CNI support to the Juju Charms
+    * Adds durable storage support to the Juju Charms
+    * Introduces an e2e Charm layer for repeatable testing efforts and validation of clusters
+
+### libvirt CoreOS
+* To add local registry to libvirt_coreos ([#36751](https://github.com/kubernetes/kubernetes/pull/36751), [@sdminonne](https://github.com/sdminonne))
+
+### GCE
+* **the `gce` provider enables both RBAC authorization and the permissive legacy ABAC policy that makes all service accounts superusers. To opt out of the permissive ABAC policy, export the environment variable `ENABLE_LEGACY_ABAC=false` before running `cluster/kube-up.sh`. ([#43544](https://github.com/kubernetes/kubernetes/pull/43544), [@liggitt](https://github.com/liggitt))**
+* **the `gce` provider ensures the bootstrap admin token user is included in the super-user group ([#39537](https://github.com/kubernetes/kubernetes/pull/39537), [@liggitt](https://github.com/liggitt))**
+* Remove support for debian masters in GCE kube-up. ([#41666](https://github.com/kubernetes/kubernetes/pull/41666), [@mikedanese](https://github.com/mikedanese))
+* Remove support for trusty in GCE kube-up. ([#41670](https://github.com/kubernetes/kubernetes/pull/41670), [@mikedanese](https://github.com/mikedanese))
+* Don't fail if the grep fails to match any resources ([#41933](https://github.com/kubernetes/kubernetes/pull/41933), [@ixdy](https://github.com/ixdy))
+* Fix the output of health-mointor.sh ([#41525](https://github.com/kubernetes/kubernetes/pull/41525), [@yujuhong](https://github.com/yujuhong))
+* Added configurable etcd initial-cluster-state to kube-up script. ([#41332](https://github.com/kubernetes/kubernetes/pull/41332), [@jszczepkowski](https://github.com/jszczepkowski))
+* The kube-apiserver [basic audit log](https://kubernetes.io/docs/admin/audit/) can be enabled in GCE by exporting the environment variable `ENABLE_APISERVER_BASIC_AUDIT=true` before running `cluster/kube-up.sh`. This will log to `/var/log/kube-apiserver-audit.log` and use the same `logrotate` settings as `/var/log/kube-apiserver.log`. ([#41211](https://github.com/kubernetes/kubernetes/pull/41211), [@enisoc](https://github.com/enisoc))
+* On kube-up.sh clusters on GCE, kube-scheduler now contacts the API on the secured port. ([#41285](https://github.com/kubernetes/kubernetes/pull/41285), [@liggitt](https://github.com/liggitt))
+* Use existing ABAC policy file when upgrading GCE cluster ([#40172](https://github.com/kubernetes/kubernetes/pull/40172), [@liggitt](https://github.com/liggitt))
+* Ensure the GCI metadata files do not have newline at the end ([#38727](https://github.com/kubernetes/kubernetes/pull/38727), [@Amey-D](https://github.com/Amey-D))
+* Fixed detection of master during creation of multizone nodes cluster by kube-up. ([#38617](https://github.com/kubernetes/kubernetes/pull/38617), [@jszczepkowski](https://github.com/jszczepkowski))
+* Fixed validation of multizone cluster for GCE ([#38695](https://github.com/kubernetes/kubernetes/pull/38695), [@jszczepkowski](https://github.com/jszczepkowski))
+* Fix GCI mounter issue ([#38124](https://github.com/kubernetes/kubernetes/pull/38124), [@jingxu97](https://github.com/jingxu97))
+* Exit with error if <version number or publication> is not the final parameter. ([#37723](https://github.com/kubernetes/kubernetes/pull/37723), [@mtaufen](https://github.com/mtaufen))
+* GCI: Remove /var/lib/docker/network ([#37593](https://github.com/kubernetes/kubernetes/pull/37593), [@yujuhong](https://github.com/yujuhong))
+* Fix the equality checks for numeric values in cluster/gce/util.sh. ([#37638](https://github.com/kubernetes/kubernetes/pull/37638), [@roberthbailey](https://github.com/roberthbailey))
+* Modify GCI mounter to enable NFSv3 ([#37582](https://github.com/kubernetes/kubernetes/pull/37582), [@jingxu97](https://github.com/jingxu97))
+* Use gsed on the Mac ([#37562](https://github.com/kubernetes/kubernetes/pull/37562), [@roberthbailey](https://github.com/roberthbailey))
+* Bump GCI 
+* to gci-beta-56-9000-80-0 ([#41027](https://github.com/kubernetes/kubernetes/pull/41027), [@dchen1107](https://github.com/dchen1107))
+* to gci-stable-56-9000-84-2 ([#41819](https://github.com/kubernetes/kubernetes/pull/41819), [@dchen1107](https://github.com/dchen1107))
+* Bump GCE ContainerVM
+  * to container-vm-v20161208 ([release notes](https://cloud.google.com/compute/docs/containers/container_vms#changelog)) ([#38432](https://github.com/kubernetes/kubernetes/pull/38432), [@timstclair](https://github.com/timstclair))
+  * to container-vm-v20170201 to address CVE-2016-9962. ([#40828](https://github.com/kubernetes/kubernetes/pull/40828), [@zmerlynn](https://github.com/zmerlynn))
+  * to container-vm-v20170117 to pick up CVE fixes in base image. ([#40094](https://github.com/kubernetes/kubernetes/pull/40094), [@zmerlynn](https://github.com/zmerlynn))
+  * to container-vm-v20170214 to address CVE-2016-9962. ([#41449](https://github.com/kubernetes/kubernetes/pull/41449), [@zmerlynn](https://github.com/zmerlynn))
+
+### OpenStack
+* Do not daemonize `salt-minion` for the openstack-heat provider. ([#40722](https://github.com/kubernetes/kubernetes/pull/40722), [@micmro](https://github.com/micmro))
+* OpenStack-Heat will now look for an image named "CentOS-7-x86_64-GenericCloud-1604". To restore the previous behavior set OPENSTACK_IMAGE_NAME="CentOS7" ([#40368](https://github.com/kubernetes/kubernetes/pull/40368), [@sc68cal](https://github.com/sc68cal))
+* Fixes a bug in the OpenStack-Heat kubernetes provider, in the handling of differences between the Identity v2 and Identity v3 APIs ([#40105](https://github.com/kubernetes/kubernetes/pull/40105), [@sc68cal](https://github.com/sc68cal))
+
+### Container Images
+* Update gcr.io/google-containers/rescheduler to v0.2.2, which uses busybox as a base image instead of ubuntu. ([#41911](https://github.com/kubernetes/kubernetes/pull/41911), [@ixdy](https://github.com/ixdy))
+* Remove unnecessary metrics (http/process/go) from being exposed by etcd-version-monitor ([#41807](https://github.com/kubernetes/kubernetes/pull/41807), [@shyamjvs](https://github.com/shyamjvs))
+* Align the hyperkube image to support running binaries at /usr/local/bin/ like the other server images ([#41017](https://github.com/kubernetes/kubernetes/pull/41017), [@luxas](https://github.com/luxas))
+* Bump up GLBC version from 0.9.0-beta to 0.9.1 ([#41037](https://github.com/kubernetes/kubernetes/pull/41037), [@bprashanth](https://github.com/bprashanth))
+
+### Other Notable Changes
+* The default client certificate generated by kube-up now contains the superuser `system:masters` group ([#39966](https://github.com/kubernetes/kubernetes/pull/39966), [@liggitt](https://github.com/liggitt))
+* Added support for creating HA clusters for centos using kube-up.sh. ([#39462](https://github.com/kubernetes/kubernetes/pull/39462), [@Shawyeok](https://github.com/Shawyeok))
+* Enable lazy inode table and journal initialization for ext3 and ext4 ([#38865](https://github.com/kubernetes/kubernetes/pull/38865), [@codablock](https://github.com/codablock))
+* Since `kubernetes.tar.gz` no longer includes client or server binaries, `cluster/kube-{up,down,push}.sh` now automatically download released binaries if they are missing. ([#38730](https://github.com/kubernetes/kubernetes/pull/38730), [@ixdy](https://github.com/ixdy))
+* fix broken cluster/centos and enhance the style ([#34002](https://github.com/kubernetes/kubernetes/pull/34002), [@xiaoping378](https://github.com/xiaoping378))
+* Set kernel.softlockup_panic =1 based on the flag. ([#38001](https://github.com/kubernetes/kubernetes/pull/38001), [@dchen1107](https://github.com/dchen1107))
+* configure local-up-cluster.sh to handle auth proxies ([#36838](https://github.com/kubernetes/kubernetes/pull/36838), [@deads2k](https://github.com/deads2k))
+* `kube-up.sh`/`kube-down.sh` no longer force update gcloud for provider=gce|gke. ([#36292](https://github.com/kubernetes/kubernetes/pull/36292), [@jlowdermilk](https://github.com/jlowdermilk))
+* Collect logs for dead kubelets too ([#37671](https://github.com/kubernetes/kubernetes/pull/37671), [@mtaufen](https://github.com/mtaufen))
+
+## Changes to Addons
+
+### Dashboard
+* Update dashboard version to v1.6.0 ([#43210](https://github.com/kubernetes/kubernetes/pull/43210), [@floreks](https://github.com/floreks))
+
+### DNS
+* Updates the dnsmasq cache/mux layer to be managed by dnsmasq-nanny. ([#41826](https://github.com/kubernetes/kubernetes/pull/41826), [@bowei](https://github.com/bowei))
+  dnsmasq-nanny manages dnsmasq based on values from the
+  kube-system:kube-dns configmap:
+  ```
+  "stubDomains": {
+  "acme.local": ["1.2.3.4"]
+   },
+  ```
+  
+  is a map of domain to list of nameservers for the domain. This is used
+  to inject private DNS domains into the kube-dns namespace. In the above
+  example, any DNS requests for `*.acme.local` will be served by the
+  ```
+  nameserver 1.2.3.4.
+  ```
+  
+  ```
+  upstreamNameservers": ["8.8.8.8", "8.8.4.4"]
+  ```
+  is a list of upstreamNameservers to use, overriding the configuration
+  specified in `/etc/resolv.conf`.
+* `kube-dns` now runs using a separate `system:serviceaccount:kube-system:kube-dns` service account which is automatically bound to the correct RBAC permissions. ([#38816](https://github.com/kubernetes/kubernetes/pull/38816), [@deads2k](https://github.com/deads2k))
+* Use kube-dns:1.11.0 ([#39925](https://github.com/kubernetes/kubernetes/pull/39925), [@sadlil](https://github.com/sadlil))
+
+### DNS Autoscaler
+* Patch CVE-2016-8859 in gcr.io/google-containers/cluster-proportional-autoscaler-amd64 ([#42933](https://github.com/kubernetes/kubernetes/pull/42933), [@timstclair](https://github.com/timstclair))
+
+### Cluster Autoscaler
+* Allow the Horizontal Pod Autoscaler controller to talk to the metrics API and custom metrics API as standard APIs. ([#41824](https://github.com/kubernetes/kubernetes/pull/41824), [@DirectXMan12](https://github.com/DirectXMan12))
+
+### Cluster Load Balancing
+* Update defaultbackend image to 1.3 ([#42212](https://github.com/kubernetes/kubernetes/pull/42212), [@timstclair](https://github.com/timstclair))
+
+### etcd Empty Dir Cleanup
+* Base etcd-empty-dir-cleanup on busybox, run as nobody, and update to etcdctl 3.0.14 ([#41674](https://github.com/kubernetes/kubernetes/pull/41674), [@ixdy](https://github.com/ixdy))
+
+### Fluentd
+* Migrated fluentd addon to daemon set ([#32088](https://github.com/kubernetes/kubernetes/pull/32088), [@piosz](https://github.com/piosz))
+* Fluentd was migrated to Daemon Set, which targets nodes with beta.kubernetes.io/fluentd-ds-ready=true label. If you use fluentd in your cluster please make sure that the nodes with version 1.6+ contains this label. ([#42931](https://github.com/kubernetes/kubernetes/pull/42931), [@piosz](https://github.com/piosz))
+* Fluentd-gcp containers spawned by DaemonSet are now configured using ConfigMap ([#42126](https://github.com/kubernetes/kubernetes/pull/42126), [@crassirostris](https://github.com/crassirostris))
+* Cleanup fluentd-gcp image: rebase on debian-base, switch to upstream packages, remove fluent-ui & rails ([#41998](https://github.com/kubernetes/kubernetes/pull/41998), [@timstclair](https://github.com/timstclair))
+* On GCE, the apiserver audit log (`/var/log/kube-apiserver-audit.log`) will be sent through fluentd if enabled. It will go to the same place as `kube-apiserver.log`, but tagged as its own stream. ([#41360](https://github.com/kubernetes/kubernetes/pull/41360), [@enisoc](https://github.com/enisoc))
+* If `experimentalCriticalPodAnnotation` feature gate is set to true, fluentd pods will not be evicted by the kubelet. ([#41035](https://github.com/kubernetes/kubernetes/pull/41035), [@vishh](https://github.com/vishh))
+* fluentd config for GKE clusters updated: detect exceptions in container log streams and forward them as one log entry. ([#39656](https://github.com/kubernetes/kubernetes/pull/39656), [@thomasschickinger](https://github.com/thomasschickinger))
+* Make fluentd pods critical ([#39146](https://github.com/kubernetes/kubernetes/pull/39146), [@crassirostris](https://github.com/crassirostris))
+* Fluentd/Elastisearch add-on: correctly parse and index kubernetes labels ([#36857](https://github.com/kubernetes/kubernetes/pull/36857), [@Shrugs](https://github.com/Shrugs))
+
+### Heapster
+* Bumped Heapster to v1.3.0. ([#43298](https://github.com/kubernetes/kubernetes/pull/43298), [@piosz](https://github.com/piosz))
+  * More details about the release https://github.com/kubernetes/heapster/releases/tag/v1.3.0
+
+### Registry
+* Use daemonset in docker registry add on ([#35582](https://github.com/kubernetes/kubernetes/pull/35582), [@surajssd](https://github.com/surajssd))
+* contribute deis/registry-proxy as a replacement for kube-registry-proxy ([#35797](https://github.com/kubernetes/kubernetes/pull/35797), [@bacongobbler](https://github.com/bacongobbler))
+
+## External Dependency Version Information
+
+Continuous integration builds have used the following versions of external dependencies, however, this is not a strong recommendation and users should consult an appropriate installation or upgrade guide before deciding what versions of etcd, docker or rkt to use. 
+
+* Docker versions 1.10.3, 1.11.2, 1.12.6 have been validated
+  * Docker version 1.12.6 known issues
+    * overlay2 driver not fully supported
+    * live-restore not fully supported 
+    * no shared pid namespace support
+  * Docker version 1.11.2 known issues
+    * Kernel crash with Aufs storage driver on Debian Jessie ([#27885](https://github.com/kubernetes/kubernetes/issues/27885))
+      which can be identified by the [node problem detector](http://kubernetes.io/docs/admin/node-problem/)
+    * Leaked File descriptors ([#275](https://github.com/docker/containerd/issues/275))
+    * Additional memory overhead per container ([#21737](https://github.com/docker/docker/issues/21737))
+  * Docker 1.10.3 contains [backports provided by RedHat](https://github.com/docker/docker/compare/v1.10.3...runcom:docker-1.10.3-stable) for known issues
+  * Support for Docker version 1.9.x has been removed
+* rkt version 1.23.0+
+  * known issues with the rkt runtime are [listed in the Getting Started Guide](http://kubernetes.io/docs/getting-started-guides/rkt/notes/)
+* etcd version 3.0.17

--- a/releases/release-1.6/release_team.md
+++ b/releases/release-1.6/release_team.md
@@ -1,0 +1,13 @@
+|  **Role** | **Name** | **GitHub/Slack ID** |
+|  ------ | ------ | ------ |
+|  Lead | Dan Gillespie | ethernetdan |
+|  Secondary |Caleb Miles	  | calebamiles |
+|  Features | Ihor Dvoretskyi | idvoretskyi |
+|  Release branch | Anthony Yeh | enisoc |
+|  Infra | Jeff Grafton | ixdy |
+|  Docs | Devin Donnelly | devin-donnelly |
+|  Bugs | Caleb Miles | calebamiles |
+|  Testing | Maru Newby | marun |
+|  Manual upgrade | Anthony Howe | anhowe |
+|  Automatic upgrade | Steve Kriss | steve_k |
+| Spiritual advisor | Phillip Wittrock | pwittrock |

--- a/releases/release-1.7/release-1.7.md
+++ b/releases/release-1.7/release-1.7.md
@@ -70,7 +70,7 @@ link](https://docs.google.com/spreadsheets/d/1IJSTd3MHorwUt8i492GQaKKuAFsZppauT4
 
 ## Notable operational changes
 
-1. Starting in the 1.7 release the [release team](https://github.com/kubernetes/features/blob/master/release-1.7/release_team.md)
+1. Starting in the 1.7 release the [release team](https://github.com/kubernetes/sig-release/blob/master/release-1.7/release_team.md)
   will use the following procedure to identify release blocking issues
   1. Any issues listed in the [v1.7 milestone](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20milestone%3Av1.7)
      will be considered release blocking. It is everyone's responsibility to move non blocking issues out of the `v1.7` milestone. Items targeting 1.7 can be moved into the `v1.7` milestone.

--- a/releases/release-1.7/release-1.7.md
+++ b/releases/release-1.7/release-1.7.md
@@ -1,0 +1,81 @@
+# Proposed timeline for 1.7
+We will begin the 1.7 release the first week of April 2017.
+
+The proposal below is similar in layout to the 1.5 and 1.6 plans with some
+modifications:
+- as before, key days aren't Fridays, since it can be hard to end milestones right up against weekends
+
+## 1.7 Release Schedule
+- April 3 (Mon) coding start (7w)
+- April 6th (Thurs): v1.7.0-alpha.1
+- April 19th (Weds): v1.7.0-alpha.2
+- May 1 (Mon) features repo freeze
+- May 3 (Weds): v1.7.0-alpha.3
+- May 17(Weds): v1.7.0-alpha.4
+- May 31 (Weds): v1.7.0-beta.0
+- Jun 1 (Thurs): Code Freeze 
+- Jun 7 (Weds): v1.7.0-beta.1
+- June 14 (Weds): v1.7.0-beta.2
+- June 19th (Mon): v1.8.0-alpha.1
+- June 21th (Weds): v1.7.release-candidate
+- June 28th (Weds):  v1.7.0 (release!)
+
+## 1.7 Details
+
+### April 3 - May 31
+- 8 week coding period
+- Release 1.7 alphas every 2 weeks
+- April 6th (Thurs) v1.7.0-alpha.1
+- April 19th (Weds): v1.7.0-alpha.2
+- April 26 (Weds) features repo freeze: all features going into release should
+  have an associated issue in the features repo
+- May 3 (Weds): v1.7.0-alpha.3
+- May 17(Weds): v1.7.0-alpha.4
+- May 31 (Weds): v1.7.0-beta.0
+  * Create release branch.
+  * Set up CI for branch.
+  * Begin regular fast-forwards (at least daily to keep CI up-to-date).
+
+### June 1 (Thurs) - June 15(Thurs)
+- June 1 Begin Feature Freeze
+  * Deadline for feature-related PRs to be in submit queue
+  * Add milestone restriction on submit queue.
+  * Community Feature Burndown Meetings held two or three times until release week (then every day). For those interested in joining please join [the Google Group](https://groups.google.com/forum/#!forum/kubernetes-milestone-burndown)
+  * Focus on bugfix, test flakes and stabilization
+  * Ensure docs and release notes are written
+  * Identify all features going into the release, and make sure alpha, beta, ga is marked in features repo
+- Jun 7 (Weds): v1.7.0-beta.1 cut
+- June 14: End of Code Slush
+  * v1.7.0-beta.2 cut
+  * Final fast-forward of release branch.
+  * All changes for the release must now be cherrypicked in batches by branch
+  manager.
+  * Remove milestone restriction on submit queue. Bot drains backlog over the
+  weekend.
+
+### June 19 - June 28
+- June 19th (Mon): v1.8.0-alpha.1
+- June 21th (Weds): v1.7.release-candidate
+  * RC means no known release-blockers outstanding.
+  * Only accept cherrypicks for release-blockers.
+  * Announce on mailing lists, Twitter, etc. to beg people to try the RC for real.
+  * Perhaps managed k8s providers make rc.1 available on early access channels.
+  * More RCs as needed to verify release-blocking fixes.
+- Release 1.7 on June 28 (Wednesday)
+
+
+# Key features
+[Feature tracking spreadsheet
+link](https://docs.google.com/spreadsheets/d/1IJSTd3MHorwUt8i492GQaKKuAFsZppauT4v1LJ91WHY/edit?usp=sharing)
+
+## Notable operational changes
+
+1. Starting in the 1.7 release the [release team](https://github.com/kubernetes/features/blob/master/release-1.7/release_team.md)
+  will use the following procedure to identify release blocking issues
+  1. Any issues listed in the [v1.7 milestone](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20milestone%3Av1.7)
+     will be considered release blocking. It is everyone's responsibility to move non blocking issues out of the `v1.7` milestone. Items targeting 1.7 can be moved into the `v1.7` milestone.
+     milestones **or the release will not ship**
+
+# Contact us
+- [via slack](https://kubernetes.slack.com/messages/k8s-release/)
+- [via email](mailto:kubernetes-release@googlegroups.com)

--- a/releases/release-1.7/release-notes-draft.md
+++ b/releases/release-1.7/release-notes-draft.md
@@ -1,0 +1,1069 @@
+## **Major Themes**
+
+Kubernetes 1.7 is a milestone release that adds security, stateful application, and extensibility features motivated by widespread production use of Kubernetes.
+
+Security enhancements in this release include encrypted secrets (alpha), network policy for pod-to-pod communication, the node authorizer to limit Kubelet access to API resources, and Kubelet client / server TLS certificate rotation (alpha).  
+
+Major features for stateful applications include automated updates to StatefulSets, enhanced updates for DaemonSets, a burst mode for faster StatefulSets scaling, and (alpha) support for local storage.
+
+Extensibility features include API aggregation (beta), CustomResourceDefinitions (beta) in favor of ThirdPartyResources, support for extensible admission controllers (alpha), pluggable cloud providers (alpha), and container runtime interface (CRI) enhancements.
+
+## **Action Required Before Upgrading**
+
+### Network
+
+* NetworkPolicy has been promoted from extensions/v1beta1 to the new networking.k8s.io/v1 API group. The structure remains unchanged from the v1beta1 API. The net.beta.kubernetes.io/network-policy annotation on Namespaces (used to opt in to isolation) has been removed. Instead, isolation is now determined on a per-pod basis. A NetworkPolicy may target a pod for isolation by including the pod in its spec.podSelector. Targeted Pods accept the traffic specified in the respective NetworkPolicy (and nothing else). Pods not targeted by any NetworkPolicy accept all traffic by default. ([#39164](https://github.com/kubernetes/kubernetes/pull/39164), [@danwinship](https://github.com/danwinship))
+
+	**Action Required:** When upgrading to Kubernetes 1.7 (and a [network plugin](https://kubernetes.io/docs/tasks/administer-cluster/declare-network-policy/) that supports the new NetworkPolicy v1 semantics), you should consider the following.
+
+	The v1beta1 API used an annotation on Namespaces to activate the DefaultDeny policy for an entire Namespace. To activate default deny in the v1 API, you can create a NetworkPolicy that matches all Pods but does not allow any traffic:
+
+    ```yaml
+    kind: NetworkPolicy
+    apiVersion: networking.k8s.io/v1
+    metadata:
+      name: default-deny
+    spec:
+      podSelector:
+    ```
+
+	This will ensure that Pods that aren't matched by any other NetworkPolicy will continue to be fully-isolated, as they were in v1beta1.
+
+	In Namespaces that previously did not have the "DefaultDeny" annotation, you should delete any existing NetworkPolicy objects. These had no effect in the v1beta1 API, but with v1 semantics they might cause some traffic to be unintentionally blocked.
+
+
+### Storage
+
+* Alpha volume provisioning is removed and default storage class should be used instead. ([#44090](https://github.com/kubernetes/kubernetes/pull/44090), [@NickrenREN](https://github.com/NickrenREN))
+
+* Portworx volume driver no longer has to run on the master. ([#45518](https://github.com/kubernetes/kubernetes/pull/45518), [@harsh-px](https://github.com/harsh-px))
+
+* Default behavior in Cinder storageclass is changed. If availability is not specified, the zone is chosen by algorithm. It makes possible to spread stateful pods across many zones. ([#44798](https://github.com/kubernetes/kubernetes/pull/44798), [@zetaab](https://github.com/zetaab))
+
+* PodSpecs containing parent directory references such as `..` (for example, `../bar`) in hostPath volume path or in volumeMount subpaths must be changed to the simple absolute path. Backsteps `..` are no longer allowed.([#47290](https://github.com/kubernetes/kubernetes/pull/47290), [@jhorwit2](https://github.com/jhorwit2)).
+
+
+### API Machinery
+
+* The Namespace API object no longer supports the deletecollection operation. ([#46407](https://github.com/kubernetes/kubernetes/pull/46407), [@liggitt](https://github.com/liggitt))
+
+* The following alpha API groups were unintentionally enabled by default in previous releases, and will no longer be enabled by default in v1.8: ([#47690](https://github.com/kubernetes/kubernetes/pull/47690), [@caesarxuchao](https://github.com/caesarxuchao))
+
+    * rbac.authorization.k8s.io/v1alpha1
+
+    * settings.k8s.io/v1alpha1
+
+    * If you wish to continue using them in v1.8, please enable them explicitly using the `--runtime-config` flag on the apiserver (for example, `--runtime-config="rbac.authorization.k8s.io/v1alpha1,settings.k8s.io/v1alpha1"`)
+
+* `cluster/update-storage-objects.sh` now supports updating StorageClasses in etcd to storage.k8s.io/v1. You must do this prior to upgrading to 1.8. ([#46116](https://github.com/kubernetes/kubernetes/pull/46116), [@ncdc](https://github.com/ncdc))
+
+
+### Controller Manager
+
+* kube-controller-manager has dropped support for the `--insecure-experimental-approve-all-kubelet-csrs-for-group` flag. It is accepted in 1.7, but ignored. Instead, the csrapproving controller uses authorization checks to determine whether to approve certificate signing requests: ([#45619](https://github.com/kubernetes/kubernetes/pull/45619), [@mikedanese](https://github.com/mikedanese))
+
+    * Before upgrading, users must ensure their controller manager will enable the csrapproving controller, create an RBAC ClusterRole and ClusterRoleBinding to approve CSRs for the same group, then upgrade. Example roles to enable the equivalent behavior can be found in the [TLS bootstrapping](https://kubernetes.io/docs/admin/kubelet-tls-bootstrapping/) documentation.
+
+
+### kubectl (CLI)
+* `kubectl create role` and  `kubectl create clusterrole`  invocations must be updated to specify multiple resource names as repeated  `--resource-name` arguments instead of comma-separated arguments to a single `--resource-name` argument. E.g. `--resource-name=x,y` must become `--resource-name x --resource-name y` ([#44950](https://github.com/kubernetes/kubernetes/pull/44950), [@xilabao](https://github.com/xilabao))
+
+* `kubectl create rolebinding` and `kubectl create clusterrolebinding` invocations must be updated to  specify multiple subjects as repeated  `--user`, `--group`, or `--serviceaccount` arguments instead of comma-separated arguments to a single `--user`, `--group`, or `--serviceaccount`.  E.g. `--user=x,y` must become `--user x --user y`  ([#43903](https://github.com/kubernetes/kubernetes/pull/43903), [@xilabao](https://github.com/xilabao))
+
+
+### kubeadm
+
+* kubeadm: Modifications to cluster-internal resources installed by kubeadm will be overwritten when upgrading from v1.6 to v1.7. ([#47081](https://github.com/kubernetes/kubernetes/pull/47081), [@luxas](https://github.com/luxas))
+
+* kubeadm deb/rpm packages: cAdvisor doesn't listen on `0.0.0.0:4194` without authentication/authorization because of the possible information leakage. The cAdvisor API can still be accessed via `https://{node-ip}:10250/stats/`, though. ([kubernetes/release#356](https://github.com/kubernetes/release/pull/356), [@luxas](https://github.com/luxas))
+
+
+### Cloud Providers
+
+* Azure: Container permissions for provisioned volumes have changed to private. If you have existing Azure volumes that were created by Kubernetes v1.6.0-v1.6.5, you should change the permissions on them manually. ([#47605](https://github.com/kubernetes/kubernetes/pull/47605), [@brendandburns](https://github.com/brendandburns))
+
+* GKE/GCE: New and upgraded 1.7 GCE/GKE clusters no longer have an RBAC ClusterRoleBinding that grants the cluster-admin ClusterRole to the default service account in the kube-system Namespace. ([#46750](https://github.com/kubernetes/kubernetes/pull/46750), [@cjcullen](https://github.com/cjcullen)). If this permission is still desired, run the following command to explicitly grant it, either before or after upgrading to 1.7:
+    ```
+    kubectl create clusterrolebinding kube-system-default --serviceaccount=kube-system:default --clusterrole=cluster-admin
+    ```
+
+## **Known Issues**
+
+Populated via [v1.7.x known issues / FAQ accumulator](https://github.com/kubernetes/kubernetes/issues/46733)
+
+* The kube-apiserver discovery APIs (for example, `/apis`) return information about the API groups being served, and can change dynamically.
+During server startup, prior to the server reporting healthy (via `/healthz`), not all API groups may be reported.
+Wait for the server to report healthy (via `/healthz`) before depending on the information provided by the discovery APIs.
+Additionally, since the information returned from the discovery APIs may change dynamically, a cache of the results should not be considered authoritative.
+ETag support is planned in a future version to facilitate client caching.
+([#47977](https://github.com/kubernetes/kubernetes/issues/47977), [#44957](https://github.com/kubernetes/kubernetes/issues/44957))
+
+* The DaemonSet controller will evict running Pods that do not tolerate the NoSchedule taint if the taint is added to a Node.  There is an open PR ([#48189](https://github.com/kubernetes/kubernetes/pull/48189)) to resolve this issue, but as this issue also exists in 1.6, and as we do not wish to risk release stability by merging it directly prior to a release without sufficient testing, we have decided to defer merging the PR until the next point release for each minor version ([#48190](https://github.com/kubernetes/kubernetes/issues/48190)).
+
+* Protobuf serialization does not distinguish between `[]` and `null`.
+API fields previously capable of storing and returning either `[]` and `null` via JSON API requests (for example, the Endpoints `subsets` field)
+can now store only `null` when created using the protobuf content-type or stored in etcd using protobuf serialization (the default in 1.6).
+JSON API clients should tolerate `null` values for such fields, and treat `null` and `[]` as equivalent in meaning unless specifically documented otherwise for a particular field. ([#44593](https://github.com/kubernetes/kubernetes/issues/44593))
+
+## **Deprecations**
+
+### Cluster provisioning scripts
+* cluster/ubuntu: Removed due to [deprecation](https://github.com/kubernetes/kubernetes/tree/master/cluster#cluster-configuration) and lack of maintenance. ([#44344](https://github.com/kubernetes/kubernetes/pull/44344), [@mikedanese](https://github.com/mikedanese))
+
+* cluster/aws: Removed due to [deprecation](https://github.com/kubernetes/kubernetes/pull/38772) and lack of maintenance. ([#42196](https://github.com/kubernetes/kubernetes/pull/42196), [@zmerlynn](https://github.com/zmerlynn))
+
+
+### Client libraries
+* Swagger 1.2 spec (`/swaggerapi/*`) is deprecated. Please use OpenAPI instead.
+
+### DaemonSet
+* DaemonSet’s spec.templateGeneration has been deprecated.  ([#45924](https://github.com/kubernetes/kubernetes/pull/45924), [@janetkuo](https://github.com/janetkuo))
+
+### kube-proxy
+* In 1.7, the kube-proxy component has been converted to use a configuration file. The old flags still work in 1.7, but they are being deprecated and will be removed in a future release. Cluster administrators are advised to switch to using the configuration file, but no action is strictly necessary in 1.7. ([#34727](https://github.com/kubernetes/kubernetes/pull/34727), [@ncdc](https://github.com/ncdc))
+
+### Namespace
+* The Namespace API object no longer supports the deletecollection operation. ([#46407](https://github.com/kubernetes/kubernetes/pull/46407), [@liggitt](https://github.com/liggitt))
+
+
+### Scheduling
+* If you are using `AffinityInAnnotations=true` in `--feature-gates`, then the 1.7 release is your last opportunity to convert from specifying affinity/anti-affinity using the scheduler.alpha.kubernetes.io/affinity annotation on Pods, to using the Affinity field of PodSpec. Support for the alpha version of node and pod affinity (which uses the scheduler.alpha.kubernetes.io/affinity annotations on Pods) is going away **in Kubernetes 1.8** (not this release, but the next release). If you have not enabled AffinityInAnnotations=true in `--feature-gates`, then this change does not affect you.
+
+## **Notable Features**
+
+Features for this release were tracked via the use of the [kubernetes/features](https://github.com/kubernetes/features) issues repo. Each Feature issue is owned by a Special Interest Group from [kubernetes/community](https://github.com/kubernetes/community)
+
+## Kubefed
+
+* Deprecate the `--secret-name` flag from `kubefed join`, instead generating the secret name arbitrarily. ([#42513](https://github.com/kubernetes/kubernetes/pull/42513), [@perotinus](https://github.com/perotinus))
+
+
+### **Kubernetes API**
+#### User Provided Extensions
+* [beta] ThirdPartyResource is deprecated. Please migrate to the successor, CustomResourceDefinition. For more information, see [Custom Resources](https://kubernetes.io/docs/concepts/api-extension/custom-resources/) and [Migrate a ThirdPartyResource to CustomResourceDefinition](https://kubernetes.io/docs/tasks/access-kubernetes-api/migrate-third-party-resource/).
+
+* [beta] User-provided apiservers can be aggregated (served along with) the rest of the Kubernetes API. See [Extending the Kubernetes API with the aggregation layer](https://kubernetes.io/docs/concepts/api-extension/apiserver-aggregation/), [Configure the aggregation layer](https://kubernetes.io/docs/tasks/access-kubernetes-api/configure-aggregation-layer/), and [Setup an extension API server](https://kubernetes.io/docs/tasks/access-kubernetes-api/setup-extension-api-server/).
+
+* [alpha] Adding admissionregistration API group which enables dynamic registration of initializers and external admission webhooks. ([#46294](https://github.com/kubernetes/kubernetes/pull/46294), [@caesarxuchao](https://github.com/caesarxuchao))
+
+
+### **Application Deployment**
+#### StatefulSet
+* [beta] StatefulSet supports [RollingUpdate](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#rolling-updates) and [OnDelete](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#on-delete) update strategies.
+
+* [alpha] StatefulSet authors should be able to relax the [ordering](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#orderedready-pod-management) and [parallelism](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#parallel-pod-management) policies for software that can safely support rapid, out-of-order changes.
+
+#### DaemonSet
+* [beta] DaemonSet supports history and rollback. See [Performing a Rollback on a DaemonSet](https://kubernetes.io/docs/tasks/manage-daemon/rollback-daemon-set/).
+
+#### Deployments
+* [beta] Deployments uses a hashing collision avoidance mechanism that ensures new rollouts will not block on hashing collisions anymore. ([kubernetes/features#287](https://github.com/kubernetes/features/issues/287))
+
+#### PodDisruptionBudget
+* [beta] PodDisruptionBudget has a new field MaxUnavailable, which allows users to specify the maximum number of disruptions that can be tolerated during eviction. For more information, see [Pod Disruptions](https://kubernetes.io/docs/concepts/workloads/pods/disruptions/) and [Specifying a Disruption Budget for your Application](https://kubernetes.io/docs/tasks/run-application/configure-pdb/).
+
+
+### **Security**
+#### Admission Control
+* [alpha] Add [extensible external admission control](https://kubernetes.io/docs/admin/extensible-admission-controllers/).
+
+#### TLS Bootstrapping
+* [alpha] Rotation of the server TLS certificate on the kubelet. See [TLS bootstrapping - approval controller](https://kubernetes.io/docs/admin/kubelet-tls-bootstrapping/#approval-controller).
+
+* [alpha] Rotation of the client TLS certificate on the kubelet. See [TLS bootstrapping - kubelet configuration](https://kubernetes.io/docs/admin/kubelet-tls-bootstrapping/#kubelet-configuration).
+
+* [beta] [Kubelet TLS Bootstrap](https://kubernetes.io/docs/admin/kubelet-tls-bootstrapping/#kubelet-configuration)
+
+#### Audit Logging
+* [alpha] Advanced Auditing enhances the Kubernetes API [audit logging](https://kubernetes.io/docs/tasks/debug-application-cluster/audit/#audit-logs) capabilities through a customizable policy, pluggable audit backends, and richer audit data.
+
+#### Encryption at Rest
+* [alpha] Encrypt secrets stored in etcd. For more information, see [Securing a Cluster](https://kubernetes.io/docs/tasks/administer-cluster/securing-a-cluster/) and [Encrypting data at rest](https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/).
+
+#### Node Authorization
+* [beta] A new Node authorization mode and NodeRestriction admission plugin, when used in combination, limit nodes' access to specific APIs, so that they may only modify their own Node API object, only modify Pod objects bound to themselves, and only retrieve secrets and configmaps referenced by pods bound to themselves. See [Using Node Authorization](https://kubernetes.io/docs/admin/authorization/node/) for more information.
+
+
+### **Application Autoscaling**
+#### Horizontal Pod Autoscaler
+* [alpha] [HPA Status Conditions](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough/#appendix-horizontal-pod-autoscaler-status-conditions).
+
+
+### **Cluster Lifecycle**
+#### kubeadm
+* [alpha] Manual [upgrades for kubeadm from v1.6 to v1.7](https://kubernetes.io/docs/tasks/administer-cluster/kubeadm-upgrade-1-7/). Automated upgrades ([kubernetes/features#296](https://github.com/kubernetes/features/issues/296)) are targeted for v1.8.
+
+#### Cloud Provider Support
+* [alpha] Improved support for out-of-tree and out-of-process cloud providers, a.k.a pluggable cloud providers. See [Build and Run cloud-controller-manager](https://kubernetes.io/docs/tasks/administer-cluster/running-cloud-controller) documentation.
+
+
+### **Cluster Federation**
+#### Placement Policy
+* [alpha] The federation-apiserver now supports a SchedulingPolicy admission controller that enables policy-based control over placement of federated resources. For more information, see [Set up placement policies in Federation](https://kubernetes.io/docs/tasks/federation/set-up-placement-policies-federation/).
+
+#### Cluster Selection
+* [alpha] Federation [ClusterSelector annotation](https://kubernetes.io/docs/tasks/administer-federation/cluster/#clusterselector-annotation) to direct objects to federated clusters with matching labels.
+
+
+### **Instrumentation**
+#### Core Metrics API
+* [alpha] Introduces a lightweight monitoring component for serving the core resource metrics API used by the Horizontal Pod Autoscaler and other components ([kubernetes/features#271](https://github.com/kubernetes/features/issues/271))
+
+
+### **Internationalization**
+
+* Add Traditional Chinese translation for kubectl ([#46559](https://github.com/kubernetes/kubernetes/pull/46559), [@warmchang](https://github.com/warmchang))
+
+* Add Japanese translation for kubectl ([#46756](https://github.com/kubernetes/kubernetes/pull/46756), [@girikuncoro](https://github.com/girikuncoro))
+
+* Add Simplified Chinese translation for kubectl ([#45573](https://github.com/kubernetes/kubernetes/pull/45573), [@shiywang](https://github.com/shiywang))
+
+### **kubectl (CLI)**
+* Features
+
+  * `kubectl logs` supports specifying a container name when using label selectors ([#44282](https://github.com/kubernetes/kubernetes/pull/44282), [@derekwaynecarr](https://github.com/derekwaynecarr))
+
+  * `kubectl rollout` supports undo and history for DaemonSet ([#46144](https://github.com/kubernetes/kubernetes/pull/46144), [@janetkuo](https://github.com/janetkuo))
+
+  * `kubectl rollout` supports status and history for StatefulSet  ([#46669](https://github.com/kubernetes/kubernetes/pull/46669), [@kow3ns](https://github.com/kow3ns)).
+
+  * Implement `kubectl get controllerrevisions` ([#46655](https://github.com/kubernetes/kubernetes/pull/46655), [@janetkuo](https://github.com/janetkuo))
+
+  * `kubectl create clusterrole` supports `--non-resource-url` ([#45809](https://github.com/kubernetes/kubernetes/pull/45809), [@CaoShuFeng](https://github.com/CaoShuFeng))
+
+  * `kubectl logs` and `kubectl attach` support specifying a wait timeout with `--pod-running-timeout`
+
+  *  ([#41813](https://github.com/kubernetes/kubernetes/pull/41813), [@shiywang](https://github.com/shiywang))
+
+  * New commands
+
+    * Add `kubectl config rename-context` ([#46114](https://github.com/kubernetes/kubernetes/pull/46114), [@arthur0](https://github.com/arthur0))
+
+    * Add `kubectl apply edit-last-applied` subcommand ([#42256](https://github.com/kubernetes/kubernetes/pull/42256), [@shiywang](https://github.com/shiywang))
+
+  * Strategic Merge Patch
+
+    * Reference docs now display the patch type and patch merge key used by `kubectl apply` to merge and identify unique elements in arrays.
+
+      * `kubectl edit` and `kubectl apply` will keep the ordering of elements in merged lists ([#45980](https://github.com/kubernetes/kubernetes/pull/45980), [@mengqiy](https://github.com/mengqiy))
+
+      * New patch directive (retainKeys) to specifying clearing fields missing from the request ([#44597](https://github.com/kubernetes/kubernetes/pull/44597), [@mengqiy](https://github.com/mengqiy))
+
+      * Open API now includes strategic merge patch tags (previously only in go struct tags) ([#44121](https://github.com/kubernetes/kubernetes/pull/44121), [@mbohlool](https://github.com/mbohlool))
+
+  * Plugins
+
+      * Introduces the ability to extend kubectl by adding third-party plugins. Developer preview, please refer to the documentation for instructions about how to use it. ([#37499](https://github.com/kubernetes/kubernetes/pull/37499), [@fabianofranz](https://github.com/fabianofranz))
+
+      * Added support for a hierarchy of kubectl plugins (a tree of plugins as children of other plugins). ([#45981](https://github.com/kubernetes/kubernetes/pull/45981), [@fabianofranz](https://github.com/fabianofranz))
+
+      * Added exported env vars to kubectl plugins so that plugin developers have access to global flags, namespace, the plugin descriptor and the full path to the caller binary.
+
+  * Enhancement
+
+    * `kubectl auth can-i` now supports non-resource URLs ([#46432](https://github.com/kubernetes/kubernetes/pull/46432), [@CaoShuFeng](https://github.com/CaoShuFeng))
+
+    * `kubectl set selector` and `kubectl set subject` no longer print "running in local/dry-run mode..." at the top.  The output can now be piped and interpretted as yaml or json ([#46507](https://github.com/kubernetes/kubernetes/pull/46507), [@bboreham](https://github.com/bboreham))
+
+    * When using an in-cluster client with an empty configuration, the `--namespace` flag is now honored ([#46299](https://github.com/kubernetes/kubernetes/pull/46299), [@ncdc](https://github.com/ncdc))
+
+    * The help message for missingResourceError is now generic ([#45582](https://github.com/kubernetes/kubernetes/pull/45582), [@CaoShuFeng](https://github.com/CaoShuFeng))
+
+    * `kubectl taint node` now supports label selectors ([#44740](https://github.com/kubernetes/kubernetes/pull/44740), [@ravisantoshgudimetla](https://github.com/ravisantoshgudimetla))
+
+    * `kubectl proxy --www` now logs a warning when the dir is invalid  ([#44952](https://github.com/kubernetes/kubernetes/pull/44952), [@CaoShuFeng](https://github.com/CaoShuFeng))
+
+    * `kubectl taint` output has been enhanced with the operation ([#43171](https://github.com/kubernetes/kubernetes/pull/43171), [@ravisantoshgudimetla](https://github.com/ravisantoshgudimetla))
+
+    * kubectl `--user` and `--cluster` now support completion ([#44251](https://github.com/kubernetes/kubernetes/pull/44251), [@superbrothers](https://github.com/superbrothers))
+
+    * `kubectl config use-context` now supports completion ([#42336](https://github.com/kubernetes/kubernetes/pull/42336), [@superbrothers](https://github.com/superbrothers))
+
+    * `kubectl version` now supports `--output` ([#39858](https://github.com/kubernetes/kubernetes/pull/39858), [@alejandroEsc](https://github.com/alejandroEsc))
+
+		* `kubectl create configmap` has a new option `--from-env-file` that populates a configmap from file which follows a key=val format for each line. ([#38882](https://github.com/kubernetes/kubernetes/pull/38882), [@fraenkel](https://github.com/fraenkel))
+
+		* `kubectl create secret` has a new option `--from-env-file` that populates a configmap from file which follows a key=val format for each line.
+
+  * Printing/describe
+
+    * Print conditions of RC/RS in `kubectl describe` command. ([#44710](https://github.com/kubernetes/kubernetes/pull/44710), [@xiangpengzhao](https://github.com/xiangpengzhao))
+
+    * Improved output on `kubectl get` and `kubectl describe` for generic objects. ([#44222](https://github.com/kubernetes/kubernetes/pull/44222), [@fabianofranz](https://github.com/fabianofranz))
+
+    * In `kubectl describe`, find controllers with ControllerRef, instead of showing the original creator. ([#42849](https://github.com/kubernetes/kubernetes/pull/42849), [@janetkuo](https://github.com/janetkuo))
+
+		* `kubectl version` has new flag --output (=json or yaml) allowing result of the command to be parsed in either json format or yaml. ([#39858](https://github.com/kubernetes/kubernetes/pull/39858), [@alejandroEsc](https://github.com/alejandroEsc))
+
+
+  * Bug fixes
+
+    * Fix some false negatives in detection of meaningful conflicts during strategic merge patch with maps and lists. ([#43469](https://github.com/kubernetes/kubernetes/pull/43469), [@enisoc](https://github.com/enisoc))
+
+		* Fix false positive "meaningful conflict" detection for strategic merge patch with integer values. ([#44788](https://github.com/kubernetes/kubernetes/pull/44788), [@enisoc](https://github.com/enisoc))
+
+		* Restored the ability of kubectl running inside a pod to consume resource files specifying a different namespace than the one the pod is running in. ([#44862](https://github.com/kubernetes/kubernetes/pull/44862), [@liggitt](https://github.com/liggitt))
+
+    * Kubectl commands run inside a pod using a kubeconfig file now use the namespace specified in the kubeconfig file, instead of using the pod namespace. If no kubeconfig file is used, or the kubeconfig does not specify a namespace, the pod namespace is still used as a fallback. ([#44570](https://github.com/kubernetes/kubernetes/pull/44570), [@liggitt](https://github.com/liggitt))
+
+    * Fixed `kubectl cluster-info` dump to support multi-container pod. ([#44088](https://github.com/kubernetes/kubernetes/pull/44088), [@xingzhou](https://github.com/xingzhou))
+
+    * Kubectl will print a warning when deleting the current context ([#42538](https://github.com/kubernetes/kubernetes/pull/42538), [@adohe](https://github.com/adohe))
+
+    * Fix VolumeClaims/capacity in `kubectl describe statefulsets` output. ([#47573](https://github.com/kubernetes/kubernetes/pull/47573), [@k82cn](https://github.com/k82cn))
+
+		* Fixed the output of kubectl taint node command with minor improvements. ([#43171](https://github.com/kubernetes/kubernetes/pull/43171), [@ravisantoshgudimetla](https://github.com/ravisantoshgudimetla))
+
+
+### **Networking**
+#### Network Policy
+* [stable] [NetworkPolicy](https://kubernetes.io/docs/concepts/services-networking/network-policies/) promoted to GA.
+  * Additionally adds short name "netpol" for networkpolicies ([#42241](https://github.com/kubernetes/kubernetes/pull/42241), [@xiangpengzhao](https://github.com/xiangpengzhao))
+
+
+#### Load Balancing
+* [stable] Source IP Preservation - change Cloud load-balancer strategy to health-checks and respond to health check only on nodes that host pods for the service. See [Create an External Load Balancer - Preserving the client source IP](https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip).
+  Two annotations have been promoted to API fields:
+
+  * Service.Spec.ExternalTrafficPolicy was 'service.beta.kubernetes.io/external-traffic' annotation.
+
+  * Service.Spec.HealthCheckNodePort was 'service.beta.kubernetes.io/healthcheck-nodeport' annotation.
+
+### **Node Components**
+#### Container Runtime Interface
+* [alpha] CRI validation testing, which provides a test framework and a suite of tests to validate that the CRI server implementation meets all the requirements. This allows the CRI runtime developers to verify that their runtime conforms to CRI, without needing to set up Kubernetes components or run Kubernetes end-to-end tests. ([docs](https://github.com/kubernetes/community/blob/master/contributors/devel/cri-validation.md) and [release notes](https://github.com/kubernetes-incubator/cri-tools/releases/tag/v0.1)) ([kubernetes/features#292](https://github.com/kubernetes/features/issues/292))
+
+* [alpha] Adds support of container metrics in CRI ([docs PR](https://github.com/kubernetes/community/pull/742)) ([kubernetes/features#290](https://github.com/kubernetes/features/issues/290))
+
+* [alpha] Integration with [containerd] (https://github.com/containerd/containerd) , which supports basic pod lifecycle and image management. ([docs](https://github.com/kubernetes-incubator/cri-containerd/blob/master/README.md) and [release notes](https://github.com/kubernetes-incubator/cri-containerd/releases/tag/v0.1.0)) ([kubernetes/features#286](https://github.com/kubernetes/features/issues/286))
+
+* [GA] The Docker-CRI implementation is GA. The legacy, non-CRI Docker integration has been completely removed.
+
+* [beta] [CRI-O](https://github.com/kubernetes-incubator/cri-o) v1.0.0-alpha.0. It has passed all e2e tests. ([release notes](https://github.com/kubernetes-incubator/cri-o/releases/tag/v1.0.0-alpha.0))
+
+* [beta] [Frakti](https://github.com/kubernetes/frakti) v1.0. It has passed all node conformance tests. ([release notes](https://github.com/kubernetes/frakti/releases/tag/v1.0))
+
+
+
+### **Scheduling**
+#### Scheduler Extender
+* [alpha] Support for delegating pod binding to a scheduler extender ([kubernetes/features#270](https://github.com/kubernetes/features/issues/270))
+
+### **Storage**
+#### Local Storage
+* [alpha] This feature adds capacity isolation support for local storage at node, container, and volume levels. See updated [Reserve Compute Resources for System Daemons](https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/) documentation.
+
+* [alpha] Make locally attached (non-network attached) storage available as a persistent volume source. For more information, see [Storage Volumes - local](https://kubernetes.io/docs/concepts/storage/volumes/#local).
+
+#### Volume Plugins
+* [stable] Volume plugin for StorageOS provides highly-available cluster-wide persistent volumes from local or attached node storage. See [Persistent Volumes - StorageOS](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#storageos) and [Storage Volumes - StorageOS](https://kubernetes.io/docs/concepts/storage/volumes/#storageos).
+
+#### Metrics
+* [stable] Add support for cloudprovider metrics for storage API calls. See [Controller manager metrics](https://kubernetes.io/docs/concepts/cluster-administration/controller-metrics/) for more information.
+
+### **Other notable changes**
+
+
+#### Admission plugin
+* OwnerReferencesPermissionEnforcement admission plugin ignores pods/status. ([#45747](https://github.com/kubernetes/kubernetes/pull/45747), [@derekwaynecarr](https://github.com/derekwaynecarr))
+
+
+* Ignored mirror pods in PodPreset admission plugin. ([#45958](https://github.com/kubernetes/kubernetes/pull/45958), [@k82cn](https://github.com/k82cn))
+
+#### API Machinery
+* The protobuf serialization of API objects has been updated to store maps in a predictable order to ensure that the representation of that object does not change when saved into etcd. This prevents the same object from being seen as being modified, even when no values have changed. ([#47701](https://github.com/kubernetes/kubernetes/pull/47701), [@smarterclayton](https://github.com/smarterclayton))
+
+* API resource discovery now includes the singularName used to refer to the resource. ([#43312](https://github.com/kubernetes/kubernetes/pull/43312), [@deads2k](https://github.com/deads2k))
+
+* Enhance the garbage collection admission plugin so that a user who doesn't have delete permission of the owning object cannot modify the blockOwnerDeletion field of existing ownerReferences, or add new ownerReferences with blockOwnerDeletion=true ([#43876](https://github.com/kubernetes/kubernetes/pull/43876), [@caesarxuchao](https://github.com/caesarxuchao))
+
+* Exec and portforward actions over SPDY now properly handle redirects sent by the Kubelet ([#44451](https://github.com/kubernetes/kubernetes/pull/44451), [@ncdc](https://github.com/ncdc))
+
+* The proxy subresource APIs for nodes, services, and pods now support the HTTP PATCH method. ([#44929](https://github.com/kubernetes/kubernetes/pull/44929), [@liggitt](https://github.com/liggitt))
+
+* The Categories []string field on discovered API resources represents the list of group aliases (e.g. "all") that each resource belongs to. ([#43338](https://github.com/kubernetes/kubernetes/pull/43338), [@fabianofranz](https://github.com/fabianofranz))
+
+* [alpha] The Kubernetes API supports retrieving tabular output for API resources via a new mime-type application/json;as=Table;v=v1alpha1;g=meta.k8s.io. The returned object (if the server supports it) will be of type meta.k8s.io/v1alpha1 with Table, and contain column and row information related to the resource. Each row will contain information about the resource - by default it will be the object metadata, but callers can add the ?includeObject=Object query parameter and receive the full object. In the future kubectl will use this to retrieve the results of `kubectl get`. ([#40848](https://github.com/kubernetes/kubernetes/pull/40848), [@smarterclayton](https://github.com/smarterclayton))
+
+* The behavior of some watch calls to the server when filtering on fields was incorrect. If watching objects with a filter, when an update was made that no longer matched the filter a DELETE event was correctly sent. However, the object that was returned by that delete was not the (correct) version before the update, but instead, the newer version. That meant the new object was not matched by the filter. This was a regression from behavior between cached watches on the server side and uncached watches, and thus broke downstream API clients. ([#46223](https://github.com/kubernetes/kubernetes/pull/46223), [@smarterclayton](https://github.com/smarterclayton))
+
+* OpenAPI spec is now available in protobuf binary and gzip format (with ETag support) ([#45836](https://github.com/kubernetes/kubernetes/pull/45836), [@mbohlool](https://github.com/mbohlool))
+
+* Updating apiserver to return UID of the deleted resource. Clients can use this UID to verify that the resource was deleted or waiting for finalizers. ([#45600](https://github.com/kubernetes/kubernetes/pull/45600), [@nikhiljindal](https://github.com/nikhiljindal))
+
+* Fix incorrect conflict errors applying strategic merge patches to resources. ([#43871](https://github.com/kubernetes/kubernetes/pull/43871), [@liggitt](https://github.com/liggitt))
+
+* Fix init container status reporting when active deadline is exceeded. ([#46305](https://github.com/kubernetes/kubernetes/pull/46305), [@sjenning](https://github.com/sjenning))
+
+* Moved qos to api.helpers. ([#44906](https://github.com/kubernetes/kubernetes/pull/44906), [@k82cn](https://github.com/k82cn))
+
+* Fix issue with the resource quota controller causing add quota to be resynced at the wrong ([#45685](https://github.com/kubernetes/kubernetes/pull/45685), [@derekwaynecarr](https://github.com/derekwaynecarr))
+
+* Added Group/Version/Kind and Action extension to OpenAPI Operations ([#44787](https://github.com/kubernetes/kubernetes/pull/44787), [@mbohlool](https://github.com/mbohlool))
+
+* Make clear that meta.KindToResource is only a guess ([#45272](https://github.com/kubernetes/kubernetes/pull/45272), [@sttts](https://github.com/sttts))
+
+* Add APIService conditions ([#43301](https://github.com/kubernetes/kubernetes/pull/43301), [@deads2k](https://github.com/deads2k))
+
+* Create and push a docker image for the cloud-controller-manager ([#45154](https://github.com/kubernetes/kubernetes/pull/45154), [@luxas](https://github.com/luxas))
+
+* Deprecated Binding objects in 1.7. ([#47041](https://github.com/kubernetes/kubernetes/pull/47041), [@k82cn](https://github.com/k82cn))
+
+* Adds the Categories []string field to API resources, which represents the list of group aliases (e.g. "all") that every resource belongs to. ([#43338](https://github.com/kubernetes/kubernetes/pull/43338), [@fabianofranz](https://github.com/fabianofranz))
+
+* `--service-account-lookup` now defaults to true, requiring the Secret API object containing the token to exist in order for a service account token to be valid. This enables service account tokens to be revoked by deleting the Secret object containing the token. ([#44071](https://github.com/kubernetes/kubernetes/pull/44071), [@liggitt](https://github.com/liggitt))
+
+* API Registration is now in beta. ([#45247](https://github.com/kubernetes/kubernetes/pull/45247), [@mbohlool](https://github.com/mbohlool))
+
+* The Kubernetes API server now exits if it encounters a networking failure (e.g. the networking interface hosting its address goes away) to allow a process manager (systemd/kubelet/etc) to react to the problem. Previously the server would log the failure and try again to bind to its configured address:port. ([#42272](https://github.com/kubernetes/kubernetes/pull/42272), [@marun](https://github.com/marun))
+
+* The Prometheus metrics for the kube-apiserver for tracking incoming API requests and latencies now return the subresource label for correctly attributing the type of API call. ([#46354](https://github.com/kubernetes/kubernetes/pull/46354), [@smarterclayton](https://github.com/smarterclayton))
+
+* kube-apiserver now drops unneeded path information if an older version of Windows kubectl sends it. ([#44421](https://github.com/kubernetes/kubernetes/pull/44421), [@mml](https://github.com/mml))
+
+
+#### Application autoscaling
+* Make "upscale forbidden window" and "downscale forbidden window"  duration configurable in arguments of kube-controller-manager. ([#42101](https://github.com/kubernetes/kubernetes/pull/42101), [@Dmitry1987](https://github.com/Dmitry1987))
+
+#### Application Deployment
+* StatefulSetStatus now tracks replicas, readyReplicas, currentReplicas, and updatedReplicas. The semantics of replicas is now consistent with DaemonSet and ReplicaSet, and readyReplicas has the semantics that replicas did prior to 1.7 ([#46669](https://github.com/kubernetes/kubernetes/pull/46669), [@kow3ns](https://github.com/kow3ns)).
+
+* ControllerRevision type has been added for StatefulSet and DaemonSet history. Clients should not depend on the stability of this type as it may change, as necessary, in future releases to support StatefulSet and DaemonSet update and rollback. We enable this type as we do with beta features, because StatefulSet update and DaemonSet update are enabled. ([#45867](https://github.com/kubernetes/kubernetes/pull/45867), [@kow3ns](https://github.com/kow3ns))
+
+* PodDisruptionBudget now uses ControllerRef to decide which controller owns a given Pod, so it doesn't get confused by controllers with overlapping selectors. ([#45003](https://github.com/kubernetes/kubernetes/pull/45003), [@krmayankk](https://github.com/krmayankk))
+
+* Deployments are updated to use (1) a more stable hashing algorithm (fnv) than the previous one (adler) and (2) a hashing collision avoidance mechanism that will ensure new rollouts will not block on hashing collisions anymore. ([#44774](https://github.com/kubernetes/kubernetes/pull/44774), [@kargakis](https://github.com/kargakis))([kubernetes/features#287](https://github.com/kubernetes/features/issues/287))
+
+* Deployments and DaemonSets rollouts are considered complete when all of the desired replicas are updated and available. This change affects `kubectl rollout status` and Deployment condition. ([#44672](https://github.com/kubernetes/kubernetes/pull/44672), [@kargakis](https://github.com/kargakis))
+
+* Job controller now respects ControllerRef to avoid fighting over Pods. ([#42176](https://github.com/kubernetes/kubernetes/pull/42176), [@enisoc](https://github.com/enisoc))
+
+* CronJob controller now respects ControllerRef to avoid fighting with other controllers. ([#42177](https://github.com/kubernetes/kubernetes/pull/42177), [@enisoc](https://github.com/enisoc))
+
+#### Cluster Autoscaling
+* Cluster Autoscaler 0.6. More information available [here](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/README.md).
+
+* cluster-autoscaler: Fix duplicate writing of logs. ([#45017](https://github.com/kubernetes/kubernetes/pull/45017), [@MaciekPytel](https://github.com/MaciekPytel))
+
+
+#### Cloud Provider Enhancement
+
+* AWS:
+
+  * New 'service.beta.kubernetes.io/aws-load-balancer-extra-security-groups' Service annotation to specify extra Security Groups to be added to ELB created by AWS cloudprovider ([#45268](https://github.com/kubernetes/kubernetes/pull/45268), [@redbaron](https://github.com/redbaron))
+
+  * Clean up blackhole routes when using kubenet ([#47572](https://github.com/kubernetes/kubernetes/pull/47572), [@justinsb](https://github.com/justinsb))
+
+  * Maintain a cache of all instances, to fix problem with > 200 nodes with ELBs ([#47410](https://github.com/kubernetes/kubernetes/pull/47410), [@justinsb](https://github.com/justinsb))
+
+  * Avoid spurious ELB listener recreation - ignore case when matching protocol ([#47391](https://github.com/kubernetes/kubernetes/pull/47391), [@justinsb](https://github.com/justinsb))
+
+  * Allow configuration of a single security group for ELBs ([#45500](https://github.com/kubernetes/kubernetes/pull/45500), [@nbutton23](https://github.com/nbutton23))
+
+  * Remove check that forces loadBalancerSourceRanges to be 0.0.0.0/0. ([#38636](https://github.com/kubernetes/kubernetes/pull/38636), [@dhawal55](https://github.com/dhawal55))
+
+	* Allow setting KubernetesClusterID or KubernetesClusterTag in combination with VPC. ([#42512](https://github.com/kubernetes/kubernetes/pull/42512), [@scheeles](https://github.com/scheeles))
+
+	* Start recording cloud provider metrics for AWS ([#43477](https://github.com/kubernetes/kubernetes/pull/43477), [@gnufied](https://github.com/gnufied))
+
+	* AWS: Batch DescribeInstance calls with nodeNames to 150 limit, to stay within AWS filter limits. ([#47516](https://github.com/kubernetes/kubernetes/pull/47516), [@gnufied](https://github.com/gnufied))
+
+	* AWS: Process disk attachments even with duplicate NodeNames ([#47406](https://github.com/kubernetes/kubernetes/pull/47406), [@justinsb](https://github.com/justinsb))
+
+  * Allow configuration of a single security group for ELBs ([#45500](https://github.com/kubernetes/kubernetes/pull/45500), [@nbutton23](https://github.com/nbutton23))
+
+  * Fix support running the master with a different AWS account or even on a different cloud provider than the nodes. ([#44235](https://github.com/kubernetes/kubernetes/pull/44235), [@mrIncompetent](https://github.com/mrIncompetent))
+
+  * Support node port health check ([#43585](https://github.com/kubernetes/kubernetes/pull/43585), [@foolusion](https://github.com/foolusion))
+
+  * Support for ELB tagging by users ([#45932](https://github.com/kubernetes/kubernetes/pull/45932), [@lpabon](https://github.com/lpabon))
+
+* Azure:
+
+  * Add support for UDP ports ([#45523](https://github.com/kubernetes/kubernetes/pull/45523), [@colemickens](https://github.com/colemickens))
+
+  * Fix support for multiple loadBalancerSourceRanges ([#45523](https://github.com/kubernetes/kubernetes/pull/45523), [@colemickens](https://github.com/colemickens))
+
+  * Support the Service spec's sessionAffinity ([#45523](https://github.com/kubernetes/kubernetes/pull/45523), [@colemickens](https://github.com/colemickens))
+
+	* Added exponential backoff to Azure cloudprovider ([#46660](https://github.com/kubernetes/kubernetes/pull/46660), [@jackfrancis](https://github.com/jackfrancis))
+
+  * Add support for bring-your-own ip address for Services on Azure ([#42034](https://github.com/kubernetes/kubernetes/pull/42034), [@brendandburns](https://github.com/brendandburns))
+
+  * Add support for Azure internal load balancer ([#43510](https://github.com/kubernetes/kubernetes/pull/43510), [@karataliu](https://github.com/karataliu))
+
+	* Client poll duration is now 5 seconds ([#43699](https://github.com/kubernetes/kubernetes/pull/43699), [@colemickens](https://github.com/colemickens))
+
+	* Azure plugin for client auth ([#43987](https://github.com/kubernetes/kubernetes/pull/43987), [@cosmincojocar](https://github.com/cosmincojocar))
+
+
+* GCP:
+
+  * Bump GLBC version to 0.9.5 - fixes [loss of manually modified GCLB health check settings](https://github.com/kubernetes/kubernetes/issues/47559) upon upgrade from pre-1.6.4 to either 1.6.4 or 1.6.5. ([#47567](https://github.com/kubernetes/kubernetes/pull/47567), [@nicksardo](https://github.com/nicksardo))
+
+  * [beta] Support creation of GCP Internal Load Balancers from Service objects ([#46663](https://github.com/kubernetes/kubernetes/pull/46663), [@nicksardo](https://github.com/nicksardo))
+
+  * GCE installs will now avoid IP masquerade for all RFC-1918 IP blocks, rather than just 10.0.0.0/8. This means that clusters can be created in 192.168.0.0./16 and 172.16.0.0/12 while preserving the container IPs (which would be lost before). ([#46473](https://github.com/kubernetes/kubernetes/pull/46473), [@thockin](https://github.com/thockin))
+
+  * The Calico version included in kube-up for GCE has been updated to v2.2. ([#38169](https://github.com/kubernetes/kubernetes/pull/38169), [@caseydavenport](https://github.com/caseydavenport))
+
+	* ip-masq-agent is now on by default for GCE ([#47794](https://github.com/kubernetes/kubernetes/pull/47794), [@dnardo](https://github.com/dnardo))
+
+  * Add ip-masq-agent addon to the addons folder which is used in GCE if `--non-masquerade-cidr` is set to 0/0 ([#46038](https://github.com/kubernetes/kubernetes/pull/46038), [@dnardo](https://github.com/dnardo))
+
+  * Enable kubelet csr bootstrap in GCE/GKE ([#40760](https://github.com/kubernetes/kubernetes/pull/40760), [@mikedanese](https://github.com/mikedanese))
+
+  * Adds support for allocation of pod IPs via IP aliases. ([#42147](https://github.com/kubernetes/kubernetes/pull/42147), [@bowei](https://github.com/bowei))
+
+	* gce kube-up: The Node authorization mode and NodeRestriction admission controller are now enabled ([#46796](https://github.com/kubernetes/kubernetes/pull/46796), [@mikedanese](https://github.com/mikedanese))
+
+	* Tokens retrieved from Google Cloud with application default credentials will not be cached if the client fails authorization ([#46694](https://github.com/kubernetes/kubernetes/pull/46694), [@matt-tyler](https://github.com/matt-tyler))
+
+	* Add metrics to all major gce operations {latency, errors} ([#44510](https://github.com/kubernetes/kubernetes/pull/44510), [@bowei](https://github.com/bowei))
+
+	    * The new metrics are:
+
+	    * cloudprovider_gce_api_request_duration_seconds{request, region, zone}
+
+	    * cloudprovider_gce_api_request_errors{request, region, zone}
+
+	    * request is the specific function that is used.
+
+	    * region is the target region (Will be "<n/a>" if not applicable)
+
+	    * zone is the target zone (Will be "<n/a>" if not applicable)
+
+	    * Note: this fixes some issues with the previous implementation of metrics for disks:
+
+	      * Time duration tracked was of the initial API call, not the entire operation.
+
+	      * Metrics label tuple would have resulted in many independent histograms stored, one for each disk. (Did not aggregate well).
+
+  * Fluentd now tolerates all NoExecute Taints when run in gcp configuration. ([#45715](https://github.com/kubernetes/kubernetes/pull/45715), [@gmarek](https://github.com/gmarek))
+
+	* Taints support in gce/salt startup scripts. ([#47632](https://github.com/kubernetes/kubernetes/pull/47632), [@mwielgus](https://github.com/mwielgus))
+
+	* GCE installs will now avoid IP masquerade for all RFC-1918 IP blocks, rather than just 10.0.0.0/8. This means that clusters can ([#46473](https://github.com/kubernetes/kubernetes/pull/46473), [@thockin](https://github.com/thockin)) be created in 192.168.0.0./16 and 172.16.0.0/12 while preserving the container IPs (which would be lost before).
+
+	* Support running Ubuntu image on GCE node ([#44744](https://github.com/kubernetes/kubernetes/pull/44744), [@yguo0905](https://github.com/yguo0905))
+
+  * The gce metadata server can now be hidden behind a proxy, hiding the kubelet's token. ([#45565](https://github.com/kubernetes/kubernetes/pull/45565), [@Q-Lee](https://github.com/Q-Lee))
+
+* OpenStack:
+
+    * Fix issue during LB creation where ports were incorrectly assigned to a floating IP ([#44387](https://github.com/kubernetes/kubernetes/pull/44387), [@jamiehannaford](https://github.com/jamiehannaford))
+
+    * Openstack cinder v1/v2/auto API support ([#40423](https://github.com/kubernetes/kubernetes/pull/40423), [@mkutsevol](https://github.com/mkutsevol))
+
+    * OpenStack clusters can now specify whether worker nodes are assigned a floating IP ([#42638](https://github.com/kubernetes/kubernetes/pull/42638), [@jamiehannaford](https://github.com/jamiehannaford))
+
+
+* vSphere:
+
+  * Fix volume detach on node failure. ([#45569](https://github.com/kubernetes/kubernetes/pull/45569), [@divyenpatel](https://github.com/divyenpatel))
+
+  * Report same Node IP as both internal and external. ([#45201](https://github.com/kubernetes/kubernetes/pull/45201), [@abrarshivani](https://github.com/abrarshivani))
+
+  * Filter out IPV6 node addresses. ([#45181](https://github.com/kubernetes/kubernetes/pull/45181), [@BaluDontu](https://github.com/BaluDontu))
+
+  * Fix fetching of VM UUID on Ubuntu 16.04 and Fedora. ([#45311](https://github.com/kubernetes/kubernetes/pull/45311), [@divyenpatel](https://github.com/divyenpatel))
+
+
+#### Cluster Provisioning
+* Juju:
+
+  * Add Kubernetes 1.6 support to Juju charms ([#44500](https://github.com/kubernetes/kubernetes/pull/44500), [@Cynerva](https://github.com/Cynerva))
+
+    * Add metric collection to charms for autoscaling
+
+    * Update kubernetes-e2e charm to fail when test suite fails
+
+    * Update Juju charms to use snaps
+
+    * Add registry action to the kubernetes-worker charm
+
+    * Add support for kube-proxy cluster-cidr option to kubernetes-worker charm
+
+    * Fix kubernetes-master charm starting services before TLS certs are saved
+
+    * Fix kubernetes-worker charm failures in LXD
+
+    * Fix stop hook failure on kubernetes-worker charm
+
+    * Fix handling of juju kubernetes-worker.restart-needed state
+
+    * Fix nagios checks in charms
+
+  * Enable GPU mode if GPU hardware detected ([#43467](https://github.com/kubernetes/kubernetes/pull/43467), [@tvansteenburgh](https://github.com/tvansteenburgh))
+
+  * Fix ceph-secret type to kubernetes.io/rbd in kubernetes-master charm ([#44635](https://github.com/kubernetes/kubernetes/pull/44635), [@Cynerva](https://github.com/Cynerva))
+
+  * Disallows installation of upstream docker from PPA in the Juju kubernetes-worker charm. ([#44681](https://github.com/kubernetes/kubernetes/pull/44681), [@wwwtyro](https://github.com/wwwtyro))
+
+  * Resolves juju vsphere hostname bug showing only a single node in a scaled node-pool. ([#44780](https://github.com/kubernetes/kubernetes/pull/44780), [@chuckbutler](https://github.com/chuckbutler))
+
+  * Fixes a bug in the kubernetes-worker Juju charm code that attempted to give kube-proxy more than one api endpoint. ([#44677](https://github.com/kubernetes/kubernetes/pull/44677), [@wwwtyro](https://github.com/wwwtyro))
+
+  * Added CIFS PV support for Juju Charms ([#45117](https://github.com/kubernetes/kubernetes/pull/45117), [@chuckbutler](https://github.com/chuckbutler))
+
+  * Fixes juju kubernetes master: 1. Get certs from a dead leader. 2. Append tokens. ([#43620](https://github.com/kubernetes/kubernetes/pull/43620), [@ktsakalozos](https://github.com/ktsakalozos))
+
+  * kubernetes-master juju charm properly detects etcd-scale events and reconfigures appropriately. ([#44967](https://github.com/kubernetes/kubernetes/pull/44967), [@chuckbutler](https://github.com/chuckbutler))
+
+ 	* Use correct option name in the kubernetes-worker layer registry action ([#44921](https://github.com/kubernetes/kubernetes/pull/44921), [@jacekn](https://github.com/jacekn))
+
+	* Send dns details only after cdk-addons are configured ([#44945](https://github.com/kubernetes/kubernetes/pull/44945), [@ktsakalozos](https://github.com/ktsakalozos))
+
+	* Added support to the pause action in the kubernetes-worker charm for new flag `--delete-local-data` ([#44931](https://github.com/kubernetes/kubernetes/pull/44931), [@chuckbutler](https://github.com/chuckbutler))
+
+	* Add namespace-{list, create, delete} actions to the kubernetes-master layer ([#44277](https://github.com/kubernetes/kubernetes/pull/44277), [@jacekn](https://github.com/jacekn))
+
+	* Using http2 in kubeapi-load-balancer to fix `kubectl exec` uses ([#43625](https://github.com/kubernetes/kubernetes/pull/43625), [@mbruzek](https://github.com/mbruzek))
+
+
+  * Don't append :443 to registry domain in the kubernetes-worker layer registry action ([#45550](https://github.com/kubernetes/kubernetes/pull/45550), [@jacekn](https://github.com/jacekn))
+
+* kubeadm
+
+  * Enable the Node Authorizer/Admission plugin in v1.7 ([#46879](https://github.com/kubernetes/kubernetes/pull/46879), [@luxas](https://github.com/luxas))
+
+  * Users can now pass extra parameters to etcd in a kubeadm cluster ([#42246](https://github.com/kubernetes/kubernetes/pull/42246), [@jamiehannaford](https://github.com/jamiehannaford))
+
+  * Make kubeadm use the new CSR approver in v1.7 ([#46864](https://github.com/kubernetes/kubernetes/pull/46864), [@luxas](https://github.com/luxas))
+
+  * Allow enabling multiple authorization modes at the same time ([#42557](https://github.com/kubernetes/kubernetes/pull/42557), [@xilabao](https://github.com/xilabao))
+
+  * add proxy client-certs to kube-apiserver to allow it to proxy aggregated api servers ([#43715](https://github.com/kubernetes/kubernetes/pull/43715), [@deads2k](https://github.com/deads2k))* CentOS provider
+
+* hyperkube
+
+  * The hyperkube image has been slimmed down and no longer includes addon manifests and other various scripts. These were introduced for the now removed docker-multinode setup system. ([#44555](https://github.com/kubernetes/kubernetes/pull/44555), [@luxas](https://github.com/luxas))
+
+* Support secure etcd cluster for centos provider. ([#42994](https://github.com/kubernetes/kubernetes/pull/42994), [@Shawyeok](https://github.com/Shawyeok))
+
+* Update to kube-addon-manager:v6.4-beta.2: kubectl v1.6.4 and refreshed base images ([#47389](https://github.com/kubernetes/kubernetes/pull/47389), [@ixdy](https://github.com/ixdy))
+
+* Remove Initializers from admission-control in kubernetes-master charm for pre-1.7 ([#46987](https://github.com/kubernetes/kubernetes/pull/46987), [@Cynerva](https://github.com/Cynerva))
+
+* Added state guards to the idle_status messaging in the kubernetes-master charm to make deployment faster on initial deployment. ([#47183](https://github.com/kubernetes/kubernetes/pull/47183), [@chuckbutler](https://github.com/chuckbutler))
+
+#### Cluster federation
+* Features:
+
+  * Adds annotations to all Federation objects created by kubefed. ([#42683](https://github.com/kubernetes/kubernetes/pull/42683), [@perotinus](https://github.com/perotinus))
+
+	* Mechanism of adding `federation domain maps` to kube-dns deployment via `--federations` flag is superseded by adding/updating `federations` key in `kube-system/kube-dns` configmap. If user is using kubefed tool to join cluster federation, adding federation domain maps to kube-dns is already taken care by `kubefed join` and does not need further action.
+
+	* Prints out status updates when running `kubefed init` ([#41849](https://github.com/kubernetes/kubernetes/pull/41849), [@perotinus](https://github.com/perotinus))
+
+	* `kubefed init` now supports overriding the default etcd image name with the `--etcd-image` parameter. ([#46247](https://github.com/kubernetes/kubernetes/pull/46247), [@marun](https://github.com/marun))
+
+	* kubefed will now configure NodeInternalIP as the federation API server endpoint when NodeExternalIP is unavailable for federation API servers exposed as NodePort services ([#46960](https://github.com/kubernetes/kubernetes/pull/46960), [@lukaszo](https://github.com/lukaszo))
+
+	* Automate configuring nameserver in cluster-dns for CoreDNS provider ([#42895](https://github.com/kubernetes/kubernetes/pull/42895), [@shashidharatd](https://github.com/shashidharatd))
+
+	* A new controller for managing DNS records is introduced which can be optionally disabled to enable third party components to manage DNS records for federated services. ([#450354](https://github.com/kubernetes/kubernetes/pull/45034), [@shashidharatd(https://github.com/shashidharatd)])
+
+  * Remove the `--secret-name` flag from `kubefed join`, instead generating the secret name arbitrarily. ([#42513](https://github.com/kubernetes/kubernetes/pull/42513), [@perotinus](https://github.com/perotinus))
+
+  *  Use StorageClassName for etcd pvc ([#46323](https://github.com/kubernetes/kubernetes/pull/46323), [@marun](https://github.com/marun))
+
+* Bug fixes:
+
+	* Allow disabling federation controllers through override args ([#44209](https://github.com/kubernetes/kubernetes/pull/44209), [@irfanurrehman](https://github.com/irfanurrehman))
+
+	* Kubefed: Use service accounts instead of the user's credentials when accessing joined clusters' API servers. ([#42042](https://github.com/kubernetes/kubernetes/pull/42042), [@perotinus](https://github.com/perotinus))
+
+	* Avoid panic if route53 fields are nil ([#44380](https://github.com/kubernetes/kubernetes/pull/44380), [@justinsb](https://github.com/justinsb))
+
+
+#### Credential provider
+* add rancher credential provider ([#40160](https://github.com/kubernetes/kubernetes/pull/40160), [@wlan0](https://github.com/wlan0))
+
+#### Information for Kubernetes clients (openapi, swagger, client-go)
+* Features:
+
+  * Add Host field to TCPSocketAction ([#42902](https://github.com/kubernetes/kubernetes/pull/42902), [@louyihua](https://github.com/louyihua))
+
+	* Add the ability to lock on ConfigMaps to support HA for self hosted components ([#42666](https://github.com/kubernetes/kubernetes/pull/42666), [@timothysc](https://github.com/timothysc))
+
+	* validateClusterInfo: use clientcmdapi.NewCluster() ([#44221](https://github.com/kubernetes/kubernetes/pull/44221), [@ncdc](https://github.com/ncdc))
+
+	* OpenAPI spec is now available in protobuf binary and gzip format (with ETag support) ([#45836](https://github.com/kubernetes/kubernetes/pull/45836), [@mbohlool](https://github.com/mbohlool))
+
+	* HostAliases is now parsed with hostAliases json keys to be in line with the feature's name. ([#47512](https://github.com/kubernetes/kubernetes/pull/47512), [@rickypai](https://github.com/rickypai))
+
+	* Add redirect support to SpdyRoundTripper ([#44451](https://github.com/kubernetes/kubernetes/pull/44451), [@ncdc](https://github.com/ncdc))
+
+	* Duplicate recurring Events now include the latest event's Message string ([#46034](https://github.com/kubernetes/kubernetes/pull/46034), [@kensimon](https://github.com/kensimon))
+
+* Bug fixes:
+
+  * Fix serialization of EnforceNodeAllocatable ([#44606](https://github.com/kubernetes/kubernetes/pull/44606), [@ivan4th](https://github.com/ivan4th))
+
+	* Use OS-specific libs when computing client User-Agent in kubectl, etc. ([#44423](https://github.com/kubernetes/kubernetes/pull/44423), [@monopole](https://github.com/monopole))
+
+
+#### Instrumentation
+* Bumped Heapster to v1.4.0. More details about the release https://github.com/kubernetes/heapster/releases/tag/v1.4.0
+
+* Fluentd manifest pod is no longer created on non-registered master when creating clusters using kube-up.sh. ([#44721](https://github.com/kubernetes/kubernetes/pull/44721), [@piosz](https://github.com/piosz))
+
+* Stackdriver cluster logging now deploys a new component to export Kubernetes events. ([#46700](https://github.com/kubernetes/kubernetes/pull/46700), [@crassirostris](https://github.com/crassirostris))
+
+* Stackdriver Logging deployment exposes metrics on node port 31337 when enabled. ([#47402](https://github.com/kubernetes/kubernetes/pull/47402), [@crassirostris](https://github.com/crassirostris))
+
+* Upgrade Elasticsearch Addon to v5.4.0 ([#45589](https://github.com/kubernetes/kubernetes/pull/45589), [@it-svit](https://github.com/it-svit))
+
+#### Internal storage layer
+* prevent pods/status from touching ownerreferences ([#45826](https://github.com/kubernetes/kubernetes/pull/45826), [@deads2k](https://github.com/deads2k))
+
+* Ensure that autoscaling/v1 is the preferred version for API discovery when autoscaling/v2alpha1 is enabled. ([#45741](https://github.com/kubernetes/kubernetes/pull/45741), [@DirectXMan12](https://github.com/DirectXMan12))
+
+* The proxy subresource APIs for nodes, services, and pods now support the HTTP PATCH method. ([#44929](https://github.com/kubernetes/kubernetes/pull/44929), [@liggitt](https://github.com/liggitt))
+
+* Fluentd now tolerates all NoExecute Taints when run in gcp configuration. ([#45715](https://github.com/kubernetes/kubernetes/pull/45715), [@gmarek](https://github.com/gmarek))
+
+
+#### Kubernetes Dashboard
+
+* Increase Dashboard's memory requests and limits (#44712, @maciaszczykm)
+
+* Update Dashboard version to 1.6.1 ([#45953](https://github.com/kubernetes/kubernetes/pull/45953), [@maciaszczykm](https://github.com/maciaszczykm))
+
+
+#### kube-dns
+* Updates kube-dns to 1.14.2 ([#45684](https://github.com/kubernetes/kubernetes/pull/45684), [@bowei](https://github.com/bowei))
+
+   * Support kube-master-url flag without kubeconfig
+
+   * Fix concurrent R/Ws in dns.go
+
+   * Fix confusing logging when initialize server
+
+   * Fix printf in cmd/kube-dns/app/server.go
+
+   * Fix version on startup and `--version` flag
+
+   * Support specifying port number for nameserver in stubDomains
+
+#### kube-proxy
+* Features:
+
+  * ratelimit runs of iptables by sync-period flags ([#46266](https://github.com/kubernetes/kubernetes/pull/46266), [@thockin](https://github.com/thockin))
+
+  * Log warning when invalid dir passed to `kubectl proxy --www` ([#44952](https://github.com/kubernetes/kubernetes/pull/44952), [@CaoShuFeng](https://github.com/CaoShuFeng))
+
+  * Add `--write-config-to` flag to kube-proxy to allow users to write the default configuration settings to a file. ([#45908](https://github.com/kubernetes/kubernetes/pull/45908), [@ncdc](https://github.com/ncdc))
+
+	* When switching from the service.beta.kubernetes.io/external-traffic annotation to the new ([#46716](https://github.com/kubernetes/kubernetes/pull/46716), [@thockin](https://github.com/thockin)) externalTrafficPolicy field, the values chnag as follows: * "OnlyLocal" becomes "Local" * "Global" becomes "Cluster".
+
+
+* Bug fixes:
+
+  * Fix corner-case with OnlyLocal Service healthchecks. ([#44313](https://github.com/kubernetes/kubernetes/pull/44313), [@thockin](https://github.com/thockin))
+
+	* Fix DNS suffix search list support in Windows kube-proxy. ([#45642](https://github.com/kubernetes/kubernetes/pull/45642), [@JiangtianLi](https://github.com/JiangtianLi))
+
+#### kube-scheduler
+* Scheduler can receive its policy configuration from a ConfigMap ([#43892](https://github.com/kubernetes/kubernetes/pull/43892), [@bsalamat](https://github.com/bsalamat))
+
+* Aggregated used ports at the NodeInfo level for PodFitsHostPorts predicate. ([#42524](https://github.com/kubernetes/kubernetes/pull/42524), [@k82cn](https://github.com/k82cn))
+
+* leader election lock based on scheduler name ([#42961](https://github.com/kubernetes/kubernetes/pull/42961), [@wanghaoran1988](https://github.com/wanghaoran1988))
+
+  * Fix DNS suffix search list support in Windows kube-proxy. ([#45642](https://github.com/kubernetes/kubernetes/pull/45642), [@JiangtianLi](https://github.com/JiangtianLi))
+
+#### Storage
+
+* Features
+
+  * The options passed to a Flexvolume plugin's mount command now contains the pod name (kubernetes.io/pod.name), namespace (kubernetes.io/pod.namespace), uid (kubernetes.io/pod.uid), and service account name (kubernetes.io/serviceAccount.name). ([#39488](https://github.com/kubernetes/kubernetes/pull/39488), [@liggitt](https://github.com/liggitt))
+
+  * GCE and AWS dynamic provisioners extension: admins can configure zone(s) in which a persistent volume shall be created. ([#38505](https://github.com/kubernetes/kubernetes/pull/38505), [@pospispa](https://github.com/pospispa))
+
+  * Implement API usage metrics for GCE storage. ([#40338](https://github.com/kubernetes/kubernetes/pull/40338), [@gnufied](https://github.com/gnufied))
+
+  * Add support for emitting metrics from openstack cloudprovider about storage operations. ([#46008](https://github.com/kubernetes/kubernetes/pull/46008), [@NickrenREN](https://github.com/NickrenREN))
+
+  * vSphere cloud provider: vSphere storage policy support for dynamic volume provisioning. ([#46176](https://github.com/kubernetes/kubernetes/pull/46176), [@BaluDontu](https://github.com/BaluDontu))
+
+  * Support StorageClass in Azure file volume ([#42170](https://github.com/kubernetes/kubernetes/pull/42170), [@rootfs](https://github.com/rootfs))
+
+  * Start recording cloud provider metrics for AWS ([#43477](https://github.com/kubernetes/kubernetes/pull/43477), [@gnufied](https://github.com/gnufied))
+
+  * Support iSCSI CHAP authentication ([#43396](https://github.com/kubernetes/kubernetes/pull/43396), [@rootfs](https://github.com/rootfs))
+
+  * Openstack cinder v1/v2/auto API support ([#40423](https://github.com/kubernetes/kubernetes/pull/40423), [@mkutsevol](https://github.com/mkutsevol  * cinder: Add support for the KVM virtio-scsi driver ([#41498](https://github.com/kubernetes/kubernetes/pull/41498), [@mikebryant](https://github.com/mikebryant))
+
+  * Alpha feature: allows users to set storage limit to isolate EmptyDir volumes. It enforces the limit by evicting pods that exceed their storage limits ([#45686](https://github.com/kubernetes/kubernetes/pull/45686), [@jingxu97](https://github.com/jingxu97))
+
+* Bug fixes
+
+  * Fixes issue with Flexvolume, introduced in 1.6.0, where drivers without an attacher would fail (node indefinitely waiting for attach). A driver API addition is introduced: drivers that don't implement attach should return attach: false on init. ([#47503](https://github.com/kubernetes/kubernetes/pull/47503), [@chakri-nelluri](https://github.com/chakri-nelluri))
+
+  * Fix dynamic provisioning of PVs with inaccurate AccessModes by refusing to provision when PVCs ask for AccessModes that can't be satisfied by the PVs' underlying volume plugin. ([#47274](https://github.com/kubernetes/kubernetes/pull/47274), [@wongma7](https://github.com/wongma7))
+
+  * Fix pods failing to start if they specify a file as a volume subPath to mount. ([#45623](https://github.com/kubernetes/kubernetes/pull/45623), [@wongma7](https://github.com/wongma7))
+
+  * Fix erroneous FailedSync and FailedMount events being periodically and indefinitely posted on Pods after kubelet is restarted. ([#44781](https://github.com/kubernetes/kubernetes/pull/44781), [@wongma7](https://github.com/wongma7))
+
+  * Fix AWS EBS volumes not getting detached from node if routine to verify volumes are attached runs while the node is down ([#46463](https://github.com/kubernetes/kubernetes/pull/46463), [@wongma7](https://github.com/wongma7))
+
+  * Improves performance of Cinder volume attach/detach operations. ([#41785](https://github.com/kubernetes/kubernetes/pull/41785), [@jamiehannaford](https://github.com/jamiehannaford))
+
+  * Fix iSCSI iSER mounting. ([#47281](https://github.com/kubernetes/kubernetes/pull/47281), [@mtanino](https://github.com/mtanino))
+
+  * iscsi storage plugin: Fix dangling session when using multiple target portal addresses. ([#46239](https://github.com/kubernetes/kubernetes/pull/46239), [@mtanino](https://github.com/mtanino))
+
+
+  * Fix log spam due to unnecessary status update when node is deleted. ([#45923](https://github.com/kubernetes/kubernetes/pull/45923), [@verult](https://github.com/verult))
+
+  * Don't try to attach volume to new node if it is already attached to another node and the volume does not support multi-attach. ([#45346](https://github.com/kubernetes/kubernetes/pull/45346), [@codablock](https://github.com/codablock))
+
+  * detach the volume when pod is terminated ([#45286](https://github.com/kubernetes/kubernetes/pull/45286), [@gnufied](https://github.com/gnufied))
+
+  * Roll up volume error messages in the kubelet sync loop. ([#44938](https://github.com/kubernetes/kubernetes/pull/44938), [@jayunit100](https://github.com/jayunit100))
+
+  * Catch error when failed to make directory in NFS volume plugin ([#38801](https://github.com/kubernetes/kubernetes/pull/38801), [@nak3](https://github.com/nak3))
+
+
+
+#### Networking
+
+* DNS and name resolution
+
+  * Updates kube-dns to 1.14.2 ([#45684](https://github.com/kubernetes/kubernetes/pull/45684), [@bowei](https://github.com/bowei))
+
+    * Support kube-master-url flag without kubeconfig
+
+    * Fix concurrent R/Ws in dns.go
+
+    * Fix confusing logging when initializing server
+
+    * Support specifying port number for nameserver in stubDomains
+
+  * A new field hostAliases has been added to pod.spec to support adding entries to a Pod's /etc/hosts file. ([#44641](https://github.com/kubernetes/kubernetes/pull/44641), [@rickypai](https://github.com/rickypai))
+
+  * Fix DNS suffix search list support in Windows kube-proxy. ([#45642](https://github.com/kubernetes/kubernetes/pull/45642), [@JiangtianLi](https://github.com/JiangtianLi))
+
+* Kube-proxy
+
+  * ratelimit runs of iptables by sync-period flags ([#46266](https://github.com/kubernetes/kubernetes/pull/46266), [@thockin](https://github.com/thockin))
+
+  * Fix corner-case with OnlyLocal Service healthchecks. ([#44313](https://github.com/kubernetes/kubernetes/pull/44313), [@thockin](https://github.com/thockin))
+
+* Exclude nodes labeled as master from LoadBalancer / NodePort; restores documented behaviour. ([#44745](https://github.com/kubernetes/kubernetes/pull/44745), [@justinsb](https://github.com/justinsb))
+
+* Adds support for CNI ConfigLists, which permit plugin chaining. ([#42202](https://github.com/kubernetes/kubernetes/pull/42202), [@squeed](https://github.com/squeed))
+
+* Fix node selection logic on initial LB creation ([#45773](https://github.com/kubernetes/kubernetes/pull/45773), [@justinsb](https://github.com/justinsb))
+
+* When switching from the service.beta.kubernetes.io/external-traffic annotation to the new externalTrafficPolicy field, the values change as follows: * "OnlyLocal" becomes "Local" * "Global" becomes "Cluster". ([#46716](https://github.com/kubernetes/kubernetes/pull/46716), [@thockin](https://github.com/thockin))
+
+* servicecontroller: Fix node selection logic on initial LB creation ([#45773](https://github.com/kubernetes/kubernetes/pull/45773), [@justinsb](https://github.com/justinsb))
+
+* fixed HostAlias in PodSpec to allow foo.bar hostnames instead of just foo DNS labels. ([#46809](https://github.com/kubernetes/kubernetes/pull/46809), [@rickypai](https://github.com/rickypai))
+
+
+#### Node controller
+* Bug fixes:
+
+  * Fix [transition between NotReady and Unreachable taints](https://github.com/kubernetes/kubernetes/issues/43444). ([#44042](https://github.com/kubernetes/kubernetes/pull/44042), [@gmarek](https://github.com/gmarek))
+
+
+#### Node Components
+
+* Features
+
+  * Removes the deprecated kubelet flag `--babysit-daemons` ([#44230](https://github.com/kubernetes/kubernetes/pull/44230), [@mtaufen](https://github.com/mtaufen))
+
+  * make dockershim.sock configurable ([#43914](https://github.com/kubernetes/kubernetes/pull/43914), [@ncdc](https://github.com/ncdc))
+
+  * Support running Ubuntu image on GCE node ([#44744](https://github.com/kubernetes/kubernetes/pull/44744), [@yguo0905](https://github.com/yguo0905))
+
+  * Kubernetes now shares a single PID namespace among all containers in a pod when running with docker >= 1.13.1. This means processes can now signal processes in other containers in a pod, but it also means that the `kubectl exec {pod} kill 1` pattern will cause the Pod to be restarted rather than a single container. ([#45236](https://github.com/kubernetes/kubernetes/pull/45236), [@verb](https://github.com/verb))
+
+  * A new field hostAliases has been added to the pod spec to support [adding entries to a Pod's /etc/hosts file](https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/). ([#44641](https://github.com/kubernetes/kubernetes/pull/44641), [@rickypai](https://github.com/rickypai))
+
+  * With `--feature-gates=RotateKubeletClientCertificate=true` set, the Kubelet will ([#41912](https://github.com/kubernetes/kubernetes/pull/41912), [@jcbsmpsn](https://github.com/jcbsmpsn))
+
+    * request a client certificate from the API server during the boot cycle and pause
+
+    * waiting for the request to be satisfied. It will continually refresh the certificate
+
+  * Create clusters with GPUs in GCE by specifying `type=<gpu-type>,count=<gpu-count>` to NODE_ACCELERATORS environment variable. ([#45130](https://github.com/kubernetes/kubernetes/pull/45130), [@vishh](https://github.com/vishh))
+
+    * List of available GPUs - [https://cloud.google.com/compute/docs/gpus/#introduction](https://cloud.google.com/compute/docs/gpus/#introduction)
+
+  * Disk Pressure triggers the deletion of terminated containers on the node. ([#45896](https://github.com/kubernetes/kubernetes/pull/45896), [@dashpole](https://github.com/dashpole))
+
+  * Support status.hostIP in downward API ([#42717](https://github.com/kubernetes/kubernetes/pull/42717), [@andrewsykim](https://github.com/andrewsykim))
+
+  * Upgrade Node Problem Detector to v0.4.1. New features added:
+
+    * Add /dev/kmsg support for kernel log parsing. ([#112](https://github.com/kubernetes/node-problem-detector/pull/112), [@euank](https://github.com/euank))
+
+    * Add ABRT support. ([#105](https://github.com/kubernetes/node-problem-detector/pull/105), [@juliusmilan](https://github.com/juliusmilan))
+
+    * Add a docker image corruption problem detection in the default docker monitor config. ([#117](https://github.com/kubernetes/node-problem-detector/pull/117), [@ajitak](https://github.com/ajitak))
+    
+  * Upgrade CAdvisor to v0.26.1. New features added:
+
+    * Add Docker overlay2 storage driver support.
+
+    * Add ZFS support.
+
+    * Add UDP metrics (collection disabled by default).
+
+  * Roll up volume error messages in the kubelet sync loop. ([#44938](https://github.com/kubernetes/kubernetes/pull/44938), [@jayunit100](https://github.com/jayunit100))
+  
+  * Allow pods to opt out of PodPreset mutation via an annotation on the pod. ([#44965](https://github.com/kubernetes/kubernetes/pull/44965), [@jpeeler](https://github.com/jpeeler))
+
+  * Add generic Toleration for NoExecute Taints to NodeProblemDetector, so that NPD can be scheduled to nodes with NoExecute taints by default. ([#45883](https://github.com/kubernetes/kubernetes/pull/45883), [@gmarek](https://github.com/gmarek))
+
+  * Prevent kubelet from setting allocatable < 0 for a resource upon initial creation. ([#46516](https://github.com/kubernetes/kubernetes/pull/46516), [@derekwaynecarr](https://github.com/derekwaynecarr))
+
+* Bug fixes
+
+  * Changed Kubelet default image-gc-high-threshold to 85% to resolve a conflict with default settings in docker that prevented image garbage collection from resolving low disk space situations when using devicemapper storage. ([#40432](https://github.com/kubernetes/kubernetes/pull/40432), [@sjenning](https://github.com/sjenning))
+
+  * Mark all static pods on the Master node as critical to prevent preemption ([#47356](https://github.com/kubernetes/kubernetes/pull/47356), [@dashpole](https://github.com/dashpole))
+
+  * Restrict active deadline seconds max allowed value to be maximum uint32 to avoid overflow ([#46640](https://github.com/kubernetes/kubernetes/pull/46640), [@derekwaynecarr](https://github.com/derekwaynecarr))
+
+  * Fix a bug with cAdvisorPort in the KubeletConfiguration that prevented setting it to 0, which is in fact a valid option, as noted in issue [#11710](https://github.com/kubernetes/kubernetes/pull/11710). ([#46876](https://github.com/kubernetes/kubernetes/pull/46876), [@mtaufen](https://github.com/mtaufen))
+
+  * Fix a bug where container cannot run as root when SecurityContext.RunAsNonRoot is false. ([#47009](https://github.com/kubernetes/kubernetes/pull/47009), [@yujuhong](https://github.com/yujuhong))
+
+  * Fix the Kubelet PLEG update timestamp to better reflect the health of the component when the container runtime request hangs. ([#45496](https://github.com/kubernetes/kubernetes/pull/45496), [@andyxning](https://github.com/andyxning))
+
+  * Avoid failing sync loop health check on container runtime errors ([#47124](https://github.com/kubernetes/kubernetes/pull/47124), [@andyxning](https://github.com/andyxning))
+
+  * Fix a bug where Kubelet does not ignore pod manifest files starting with dots ([#45111](https://github.com/kubernetes/kubernetes/pull/45111), [@dwradcliffe](https://github.com/dwradcliffe))
+
+  * Fix kubelet reset liveness probe failure count across pod restart boundaries ([#46371](https://github.com/kubernetes/kubernetes/pull/46371), [@sjenning](https://github.com/sjenning))
+
+  * Fix log spam due to unnecessary status update when node is deleted. ([#45923](https://github.com/kubernetes/kubernetes/pull/45923), [@verult](https://github.com/verult))
+
+  * Fix kubelet event recording for selected events. ([#46246](https://github.com/kubernetes/kubernetes/pull/46246), [@derekwaynecarr](https://github.com/derekwaynecarr))
+
+  * Fix image garbage collector attempting to remove in-use images. ([#46121](https://github.com/kubernetes/kubernetes/pull/46121), [@Random-Liu](https://github.com/Random-Liu))
+
+  * Detach the volume when pod is terminated ([#45286](https://github.com/kubernetes/kubernetes/pull/45286), [@gnufied](https://github.com/gnufied))
+
+  * CRI: Fix StopContainer timeout ([#44970](https://github.com/kubernetes/kubernetes/pull/44970), [@Random-Liu](https://github.com/Random-Liu))
+
+  * CRI: Fix kubelet failing to start when using rkt. ([#44569](https://github.com/kubernetes/kubernetes/pull/44569), [@yujuhong](https://github.com/yujuhong))
+
+  * CRI: `kubectl logs -f` now stops following when container stops, as it did pre-CRI. ([#44406](https://github.com/kubernetes/kubernetes/pull/44406), [@Random-Liu](https://github.com/Random-Liu))
+
+  * Fixes a bug where pods were evicted even after images are successfully deleted. ([#44986](https://github.com/kubernetes/kubernetes/pull/44986), [@dashpole](https://github.com/dashpole))
+
+  * When creating a container using envFrom, ([#42083](https://github.com/kubernetes/kubernetes/pull/42083), [@fraenkel](https://github.com/fraenkel)
+    * validate the name of the ConfigMap in a ConfigMapRef
+    * validate the name of the Secret in a SecretRef
+
+  * Fix the bug where StartedAt time is not reported for exited containers. ([#45977](https://github.com/kubernetes/kubernetes/pull/45977), [@yujuhong](https://github.com/yujuhong))
+
+* Changes/deprecations
+
+  * Marks the Kubelet's `--master-service-namespace` flag deprecated ([#44250](https://github.com/kubernetes/kubernetes/pull/44250), [@mtaufen](https://github.com/mtaufen))
+
+  * Remove PodSandboxStatus.Linux.Namespaces.Network from CRI since it is not used/needed. ([#45166](https://github.com/kubernetes/kubernetes/pull/45166), [@feiskyer](https://github.com/feiskyer))
+
+  * Remove the `--enable-cri` flag. CRI is now the default, and the only way to integrate with Kubelet for the container runtimes.([#45194](https://github.com/kubernetes/kubernetes/pull/45194), [@yujuhong](https://github.com/yujuhong))
+
+  * CRI has been moved to package pkg/kubelet/apis/cri/v1alpha1/runtime as part of Kubelet API path cleanup. ([#47113](https://github.com/kubernetes/kubernetes/pull/47113), [@feiskyer](https://github.com/feiskyer))
+
+
+#### Scheduling
+
+* The fix makes scheduling go routine waiting for cache (e.g. Pod) to be synced. ([#45453](https://github.com/kubernetes/kubernetes/pull/45453), [@k82cn](https://github.com/k82cn))
+
+* Move hardPodAffinitySymmetricWeight to scheduler policy config ([#44159](https://github.com/kubernetes/kubernetes/pull/44159), [@wanghaoran1988](https://github.com/wanghaoran1988))
+
+* Align Extender's validation with prioritizers. ([#45091](https://github.com/kubernetes/kubernetes/pull/45091), [@k82cn](https://github.com/k82cn))
+
+* Removed old scheduler constructor. ([#45472](https://github.com/kubernetes/kubernetes/pull/45472), [@k82cn](https://github.com/k82cn))
+
+* Fixes the overflow for priorityconfig- valid range {1, 9223372036854775806}. ([#45122](https://github.com/kubernetes/kubernetes/pull/45122), [@ravisantoshgudimetla](https://github.com/ravisantoshgudimetla))
+
+* Move hardPodAffinitySymmetricWeight to scheduler policy config ([#44159](https://github.com/kubernetes/kubernetes/pull/44159), [@wanghaoran1988](https://github.com/wanghaoran1988))
+
+
+#### Security
+* Features:
+
+  * Permission to use a PodSecurityPolicy can now be granted within a single namespace by allowing the use verb on the podsecuritypolicies resource within the namespace. ([#42360](https://github.com/kubernetes/kubernetes/pull/42360), [@liggitt](https://github.com/liggitt))
+
+  * Break the 'certificatesigningrequests' controller into a 'csrapprover' controller and 'csrsigner' controller. ([#45514](https://github.com/kubernetes/kubernetes/pull/45514), [@mikedanese](https://github.com/mikedanese))
+
+  * `kubectl auth can-i` now supports non-resource URLs ([#46432](https://github.com/kubernetes/kubernetes/pull/46432), [@CaoShuFeng](https://github.com/CaoShuFeng))
+
+  * Promote kubelet tls bootstrap to beta. Add a non-experimental flag to use it and deprecate the old flag. ([#46799](https://github.com/kubernetes/kubernetes/pull/46799), [@mikedanese](https://github.com/mikedanese))
+
+  * Add the alpha.image-policy.k8s.io/failed-open=true annotation when the image policy webhook encounters an error and fails open. ([#46264](https://github.com/kubernetes/kubernetes/pull/46264), [@Q-Lee](https://github.com/Q-Lee))
+
+  * Add an AEAD encrypting transformer for storing secrets encrypted at rest ([#41939](https://github.com/kubernetes/kubernetes/pull/41939), [@smarterclayton](https://github.com/smarterclayton))
+
+  * Add secretbox and AES-CBC encryption modes to at rest encryption. AES-CBC is considered superior to AES-GCM because it is resistant to nonce-reuse attacks, and secretbox uses Poly1305 and XSalsa20. ([#46916](https://github.com/kubernetes/kubernetes/pull/46916), [@smarterclayton](https://github.com/smarterclayton))
+
+* Bug fixes:
+
+  * Make gcp auth provider not to override the Auth header if it's already exits ([#45575](https://github.com/kubernetes/kubernetes/pull/45575), [@wanghaoran1988](https://github.com/wanghaoran1988))
+
+  * The oidc client plugin has reduce round trips and fix scopes requested ([#45317](https://github.com/kubernetes/kubernetes/pull/45317), [@ericchiang](https://github.com/ericchiang))
+
+  * API requests using impersonation now include the system:authenticated group in the impersonated user automatically. ([#44076](https://github.com/kubernetes/kubernetes/pull/44076), [@liggitt](https://github.com/liggitt))
+
+  * RBAC role and rolebinding auto-reconciliation is now performed only when the RBAC authorization mode is enabled. ([#43813](https://github.com/kubernetes/kubernetes/pull/43813), [@liggitt](https://github.com/liggitt))
+
+  * PodSecurityPolicy now recognizes pods that specify runAsNonRoot: false in their security context and does not overwrite the specified value ([#47073](https://github.com/kubernetes/kubernetes/pull/47073), [@Q-Lee](https://github.com/Q-Lee))
+
+  * Tokens retrieved from Google Cloud with application default credentials will not be cached if the client fails authorization ([#46694](https://github.com/kubernetes/kubernetes/pull/46694), [@matt-tyler](https://github.com/matt-tyler))
+
+  * Update kube-dns, metadata-proxy, and fluentd-gcp, event-exporter, prometheus-to-sd, and ip-masq-agent addons with new base images containing fixes for CVE-2016-4448, CVE-2016-9841, CVE-2016-9843, CVE-2017-1000366, CVE-2017-2616, and CVE-2017-9526. ([#47877](https://github.com/kubernetes/kubernetes/pull/47877), [@ixdy](https://github.com/ixdy))
+
+  * Fixed an issue mounting the wrong secret into pods as a service account token. ([#44102](https://github.com/kubernetes/kubernetes/pull/44102), [@ncdc](https://github.com/ncdc))
+
+#### Scalability
+
+* The HorizontalPodAutoscaler controller will now only send updates when it has new status information, reducing the number of writes caused by the controller. ([#47078](https://github.com/kubernetes/kubernetes/pull/47078), [@DirectXMan12](https://github.com/DirectXMan12))
+
+
+## **External Dependency Version Information**
+
+Continuous integration builds have used the following versions of external dependencies, however, this is not a strong recommendation and users should consult an appropriate installation or upgrade guide before deciding what versions of etcd, docker or rkt to use.
+
+* Docker versions 1.10.3, 1.11.2, 1.12.6 have been validated
+
+    * Docker version 1.12.6 known issues
+
+        * overlay2 driver not fully supported
+
+        * live-restore not fully supported
+
+        * no shared pid namespace support
+
+    * Docker version 1.11.2 known issues
+
+        * Kernel crash with Aufs storage driver on Debian Jessie ([#27885](https://github.com/kubernetes/kubernetes/issues/27885)) which can be identified by the [node problem detector](https://kubernetes.io/docs/tasks/debug-application-cluster/monitor-node-health/)
+
+        * Leaked File descriptors ([#275](https://github.com/docker/containerd/issues/275))
+
+        * Additional memory overhead per container ([#21737](https://github.com/docker/docker/issues/21737))
+
+    * Docker 1.10.3 contains [backports provided by RedHat](https://github.com/docker/docker/compare/v1.10.3...runcom:docker-1.10.3-stable) for known issues
+
+* For issues with Docker 1.13.X please see the [1.13.X tracking issue](https://github.com/kubernetes/kubernetes/issues/42926)
+
+* rkt version 1.23.0+
+
+    * known issues with the rkt runtime are [listed in the Getting Started Guide](https://kubernetes.io/docs/getting-started-guides/rkt/notes/)
+
+* etcd version 3.0.17
+
+* Go version: 1.8.3. [Link to announcement](https://groups.google.com/d/msg/kubernetes-dev/0XRRz6UhhTM/YODWVnuDBQAJ)
+
+    * Kubernetes can only be compiled with Go 1.8. Support for all other versions is dropped.

--- a/releases/release-1.7/release_team.md
+++ b/releases/release-1.7/release_team.md
@@ -1,0 +1,12 @@
+|  **Role** | **Name** (**GitHub/Slack ID**)  | **Shadow Name(s) (GitHub/Slack ID), ...**
+|  ------ | ------ | ------ |
+|  Lead | Dawn Chen (dchen1107) | Maru Newby (marun) |
+|  Secondary | Caleb Miles (calebamiles)| |
+|  Features |Ihor Dvoretskyi (idvoretskyi) | |
+|  Branch Manager | Chao Xu  (caesarxuchao)| |
+|  Test Infra | Sen Lu (krzyzacy) | | |
+|  Docs |Andrew Chen (chenopis) | |
+|  Bugs | Maru Newby (marun) | | |
+|  CI Signal | Eric Chiang (ericchiang) | | |
+|  Upgrade Testing | Jeff Regan (monopole) | | |
+| Patch Release Manager | Wojciech Tyczynski (wojtek-t)| |

--- a/releases/release-1.7/release_team_absence_tracker.md
+++ b/releases/release-1.7/release_team_absence_tracker.md
@@ -1,0 +1,20 @@
+### Release Team absence tracker
+
+Release Team members with upcoming unavailability. The [shared calendar](https://calendar.google.com/calendar/embed?src=coreos.com_regcvcrgvq98lua2ikijg1g1uk%40group.calendar.google.com&ctz=America/Los_Angeles)
+should also be updated.
+
+#### Caleb Miles 
+- contact info
+  - email: [caleb.miles@coreos.com](mailto:caleb.miles@coreos.com)
+  - github: [calebamiles](https://github.com/calebamiles/)
+  - slack: [calebamiles](https://kubernetes.slack.com/team/calebamiles)
+- absences
+  - 8 - 17 May 2017
+
+#### Eric Chiang
+- contact info
+  - email: [eric.chiang@coreos.com](mailto:eric.chiang@coreos.com)
+  - github: [ericchiang](https://github.com/ericchiang/)
+  - slack: [ericchiang](https://kubernetes.slack.com/team/ericchiang)
+- absences
+  - 9 June 2017

--- a/releases/release-1.8/add_release_notes_email_template.md
+++ b/releases/release-1.8/add_release_notes_email_template.md
@@ -1,0 +1,26 @@
+Hello ___SIG Name___!
+
+We are starting to collect release notes for the major changes in Kubernetes 1.8.
+A [draft](https://github.com/kubernetes/features/blob/master/release-1.8/release_notes_draft.md) [1]
+has been prepared in the 1.8 release directory but we need your help to populate the changes by
+component which is how we have organized [previous release notes](https://github.com/kubernetes/features/blob/master/release-1.7/release-notes-draft.md) [2].
+We would like to have the draft release notes finished by 08 September 2017 which is one week after code freeze.
+Once your SIG has filled out their section according to the [guidance](https://github.com/kubernetes/community/issues/484) [3],
+provided by Brian Grant, please check off your section in the checklist
+[embedded in the draft](https://github.com/kubernetes/features/blob/master/release-1.8/release_notes_draft.md#checklist-for-sigs-and-release-team) [4].
+Feel free to submit a pull request against the `master` branch or to merge your changes directly into master once
+there is agreement within the SIG. Please bring any questions to SIG Release on the [mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-release) [5]
+or on [slack](https://kubernetes.slack.com/messages/C56HWQ0TH/) [6].
+
+Thanks!
+
+- The Kubernetes 1.8 Release Team
+
+Links:
+
+1. https://github.com/kubernetes/features/blob/master/release-1.8/release_notes_draft.md
+2. https://github.com/kubernetes/features/blob/master/release-1.7/release-notes-draft.md
+3. https://github.com/kubernetes/community/issues/484
+4. https://github.com/kubernetes/features/blob/master/release-1.8/release_notes_draft.md#checklist-for-sigs-and-release-team
+5. https://groups.google.com/forum/#!forum/kubernetes-sig-release
+6. https://kubernetes.slack.com/messages/C56HWQ0TH/

--- a/releases/release-1.8/add_release_notes_email_template.md
+++ b/releases/release-1.8/add_release_notes_email_template.md
@@ -1,13 +1,13 @@
 Hello ___SIG Name___!
 
 We are starting to collect release notes for the major changes in Kubernetes 1.8.
-A [draft](https://github.com/kubernetes/features/blob/master/release-1.8/release_notes_draft.md) [1]
+A [draft](https://github.com/kubernetes/sig-release/blob/master/release-1.8/release_notes_draft.md) [1]
 has been prepared in the 1.8 release directory but we need your help to populate the changes by
-component which is how we have organized [previous release notes](https://github.com/kubernetes/features/blob/master/release-1.7/release-notes-draft.md) [2].
+component which is how we have organized [previous release notes](https://github.com/kubernetes/sig-release/blob/master/release-1.7/release-notes-draft.md) [2].
 We would like to have the draft release notes finished by 08 September 2017 which is one week after code freeze.
 Once your SIG has filled out their section according to the [guidance](https://github.com/kubernetes/community/issues/484) [3],
 provided by Brian Grant, please check off your section in the checklist
-[embedded in the draft](https://github.com/kubernetes/features/blob/master/release-1.8/release_notes_draft.md#checklist-for-sigs-and-release-team) [4].
+[embedded in the draft](https://github.com/kubernetes/sig-release/blob/master/release-1.8/release_notes_draft.md#checklist-for-sigs-and-release-team) [4].
 Feel free to submit a pull request against the `master` branch or to merge your changes directly into master once
 there is agreement within the SIG. Please bring any questions to SIG Release on the [mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-release) [5]
 or on [slack](https://kubernetes.slack.com/messages/C56HWQ0TH/) [6].
@@ -18,9 +18,9 @@ Thanks!
 
 Links:
 
-1. https://github.com/kubernetes/features/blob/master/release-1.8/release_notes_draft.md
-2. https://github.com/kubernetes/features/blob/master/release-1.7/release-notes-draft.md
+1. https://github.com/kubernetes/sig-release/blob/master/release-1.8/release_notes_draft.md
+2. https://github.com/kubernetes/sig-release/blob/master/release-1.7/release-notes-draft.md
 3. https://github.com/kubernetes/community/issues/484
-4. https://github.com/kubernetes/features/blob/master/release-1.8/release_notes_draft.md#checklist-for-sigs-and-release-team
+4. https://github.com/kubernetes/sig-release/blob/master/release-1.8/release_notes_draft.md#checklist-for-sigs-and-release-team
 5. https://groups.google.com/forum/#!forum/kubernetes-sig-release
 6. https://kubernetes.slack.com/messages/C56HWQ0TH/

--- a/releases/release-1.8/release-1.8.md
+++ b/releases/release-1.8/release-1.8.md
@@ -1,0 +1,91 @@
+# Proposed timeline for 1.8
+We will begin the 1.8 release the first week of July 2017.
+
+The proposal below is similar in layout to the 1.7 plans with some
+modifications:
+- as before, key days aren't Fridays, since it can be hard to end milestones right up against weekends
+- new in 1.8
+  * alpha's should not be cut unless all master-release-blocking tests are passing
+  * release notes for planned features done 2 weeks out from feature freeze
+  * docs PRs deadlines ahead of release
+
+## 1.8 Release Schedule Key Dates
+- July 5 (Weds) coding start (7w)
+- July 12th (Weds): v1.8.0-alpha.1
+- July 26th (Weds): v1.8.0-alpha.2
+- Aug 1 (Tues): Feature Freeze
+- Aug 9 (Weds): v1.8.0-alpha.3
+- Aug 23 (Weds): v1.8.0-alpha.4
+- Sept 1 (Fri): Code Freeze 
+- Sept 6 (Weds): v1.8.0-beta.0, v1.9.0-alpha.0
+- Sept 13 (Weds): v1.8.0-beta.1
+- Sept 18th (Mon): v1.9.0-alpha.1
+- Sept 20th (Weds): v1.8.release-candidate
+- Sept 27th (Weds):  v1.8.0 release!
+
+## 1.8 Details
+
+### July 5 - Sept 1
+- 8 week coding period
+- Release 1.8 alphas every 2 weeks
+  - Alphas only cut if [release-master-blocking](https://k8s-testgrid.appspot.com/release-master-blocking) are passing
+- July 12th (Weds): v1.8.0-alpha.1
+- July 26th (Weds): v1.8.0-alpha.2
+- Aug 1st (Tues): Feature Freeze: all features going into release should
+  have an associated issue in the features repo
+- Aug 8th (Tues): First draft of feature related release notes due
+- Aug 9th (Weds): v1.8.0-alpha.3
+- Aug 15th (Tues): Final draft of feature related release notes due
+- Aug 23rd (Weds): v1.8.0-alpha.4
+
+### Sept 1 (Fri) - Sept 14 (Thurs)
+- Sept 1st Begin Code Freeze (Code Slush)
+  * Hard deadline for feature-related PRs to be in submit queue
+  * Add milestone restriction on submit queue.
+  * Community Feature Burndown Meetings held two or three times until release week (then every day). For those interested in joining please join [Kubernetes Milestone Burndown Group](https://groups.google.com/forum/#!forum/kubernetes-milestone-burndown)
+  * Focus on bugfix, test flakes and stabilization
+  * Ensure docs and release notes are written
+  * Identify all features going into the release, and make sure alpha, beta, ga is marked in features repo
+  * Release team to create release notes draft doc and share broadly
+- Sept 6th (Weds): v1.8.0-beta.0
+  * Branch Manager to create `release-1.8` branch.
+  * v1.9.0-alpha.0 is cut
+  * Test-infra lead to set up CI for branch.
+  * Begin regular fast-forwards (at least daily to keep CI up-to-date).
+- Sept 8th
+  * Docs PRs must be open for tech review
+- Sept 13th (Weds): End of Code Freeze
+  * v1.8.0-beta.1 cut
+  * Final fast-forward of release branch.
+  * After this, all changes for the release must now be cherrypicked in batches by branch
+  manager.
+  * Remove milestone restriction on submit queue. Bot drains backlog over the
+  weekend.
+
+### Sept 15 - Sept 27
+- Sept 15th (Fri)
+  * Docs PRs lgtm'd and ready for merge
+- Sept 18th (Mon): v1.9.0-alpha.1
+- Sept 20th (Weds): v1.8.release-candidate
+  * RC means no known release-blockers outstanding.
+  * Only accept cherrypicks for release-blockers.
+  * Announce on mailing lists, Twitter, etc. to ask people to build and test the RC and submit feedback
+  * Perhaps managed k8s providers make rc.1 available on early access channels.
+  * More RCs as needed to verify release-blocking fixes.
+- Release 1.8 on Sept 27 (Wednesday)
+
+
+# Key features
+[Feature tracking spreadsheet
+link](https://docs.google.com/spreadsheets/d/1AFksRDgAt6BGA3OjRNIiO3IyKmA-GU7CXaxbihy48ns/edit#gid=0)
+
+## Operational Changes 
+1. For the 1.8 release, the [release team](https://github.com/kubernetes/features/blob/master/release-1.8/release_team.md)
+  will use the following procedure to identify release blocking issues
+  1. Any issues listed in the [v1.8 milestone](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20milestone%3Av1.8)
+     will be considered release blocking. It is everyone's responsibility to move non blocking issues out of the `v1.8` milestone. Items targeting 1.8 can be moved into the `v1.8` milestone.
+     milestones **or the release will not ship**
+
+# Contact us
+- [via slack](https://kubernetes.slack.com/messages/sig-release/)
+- [via email](mailto:kubernetes-release@googlegroups.com)

--- a/releases/release-1.8/release-1.8.md
+++ b/releases/release-1.8/release-1.8.md
@@ -80,7 +80,7 @@ modifications:
 link](https://docs.google.com/spreadsheets/d/1AFksRDgAt6BGA3OjRNIiO3IyKmA-GU7CXaxbihy48ns/edit#gid=0)
 
 ## Operational Changes 
-1. For the 1.8 release, the [release team](https://github.com/kubernetes/features/blob/master/release-1.8/release_team.md)
+1. For the 1.8 release, the [release team](https://github.com/kubernetes/sig-release/blob/master/release-1.8/release_team.md)
   will use the following procedure to identify release blocking issues
   1. Any issues listed in the [v1.8 milestone](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20milestone%3Av1.8)
      will be considered release blocking. It is everyone's responsibility to move non blocking issues out of the `v1.8` milestone. Items targeting 1.8 can be moved into the `v1.8` milestone.

--- a/releases/release-1.8/release-notes-draft.md
+++ b/releases/release-1.8/release-notes-draft.md
@@ -1,0 +1,787 @@
+## Introduction to v1.8.0
+
+Kubernetes version 1.8 includes new features and enhancements, as well as fixes to identified issues. The release notes contain a brief overview of the important changes introduced in this release. The content is organized by Special Interest Groups ([SIGs][]).
+
+For initial installations, see the [Setup topics][] in the Kubernetes
+documentation.
+
+To upgrade to this release from a previous version, take any actions required
+[Before Upgrading](#before-upgrading).
+
+For more information about the release and for the latest documentation,
+see the [Kubernetes documentation](https://kubernetes.io/docs/home/).
+
+[Setup topics]: https://kubernetes.io/docs/setup/pick-right-solution/
+[SIGs]: https://github.com/kubernetes/community/blob/master/sig-list.md
+
+
+## Major Themes
+
+Kubernetes is developed by community members whose work is organized into
+[Special Interest Groups][]. For the 1.8 release, each SIG provides the
+themes that guided their work.
+
+[Special Interest Groups]: https://github.com/kubernetes/community/blob/master/sig-list.md
+
+### SIG API Machinery
+
+[SIG API Machinery][] is responsible for all aspects of the API server: API registration and discovery, generic API CRUD semantics, admission control, encoding/decoding, conversion, defaulting, persistence layer (etcd), OpenAPI, third-party resources, garbage collection, and client libraries.
+
+For the 1.8 release, SIG API Machinery focused on stability and on ecosystem enablement. Features include the ability to break large LIST calls into smaller chunks, improved support for API server customization with either custom API servers or Custom Resource Definitions, and client side event spam filtering.
+
+[Sig API Machinery]: https://github.com/kubernetes/community/tree/master/sig-api-machinery
+
+### SIG Apps
+
+[SIG Apps][] focuses on the Kubernetes APIs and the external tools that are required to deploy and operate Kubernetes workloads.
+
+For the 1.8 release, SIG Apps moved the Kubernetes workloads API to the new apps/v1beta2 group and version. The DaemonSet, Deployment, ReplicaSet, and StatefulSet objects are affected by this change. The new apps/v1beta2 group and version provide a stable and consistent API surface for building applications in Kubernetes. For details about deprecations and behavioral changes, see [Notable Features](#notable-features). SIG Apps intends to promote this version to GA in a future release.
+
+[SIG Apps]: https://github.com/kubernetes/community/tree/master/sig-apps
+
+### SIG Auth
+
+[SIG Auth][] is responsible for Kubernetes authentication and authorization, and for
+cluster security policies.
+
+For the 1.8 release, SIG Auth focused on stablizing existing features that were introduced
+in previous releases. RBAC was moved from beta to v1, and advanced auditing was moved from alpha
+to beta. Encryption of resources stored on disk (resources at rest) remained in alpha, and the SIG began exploring integrations with external key management systems.
+
+[SIG Auth]: https://github.com/kubernetes/community/tree/master/sig-auth
+
+### SIG Autoscaling
+
+[SIG Autoscaling][] is responsible for autoscaling-related components,
+such as the Horizontal Pod Autoscaler and Cluster Autoscaler.
+
+For the 1.8 release, SIG Autoscaling continued to focus on stabilizing
+features introduced in previous releases: the new version of the
+Horizontal Pod Autoscaler API, which supports custom metrics, and
+the Cluster Autoscaler, which provides improved performance and error reporting.
+
+[SIG Autoscaling]: https://github.com/kubernetes/community/tree/master/sig-autoscaling
+
+### SIG Cluster Lifecycle
+
+[SIG Cluster Lifecycle][] is responsible for the user experience of deploying,
+upgrading, and deleting clusters.
+
+For the 1.8 release, SIG Cluster Lifecycle continued to focus on expanding the
+capabilities of kubeadm, which is both a user-facing tool to manage clusters
+and a building block for higher-level provisioning systems. Starting
+with the 1.8 release, kubeadm supports a new upgrade command and includes alpha
+support for self hosting the cluster control plane.
+
+[SIG Cluster Lifecycle]: https://github.com/kubernetes/community/tree/master/sig-cluster-lifecycle
+
+### SIG Instrumentation
+
+[SIG Instrumentation][] is responsible for metrics production and
+collection.
+
+For the 1.8 release, SIG Instrumentation focused on stabilizing the APIs
+and components that are required to support the new version of the Horizontal Pod
+Autoscaler API: the resource metrics API, custom metrics API, and
+metrics-server, which is the new replacement for Heapster in the default monitoring
+pipeline.
+
+[SIG Instrumentation]: https://github.com/kubernetes/community/tree/master/sig-instrumentation
+
+### SIG Multi-cluster (formerly known as SIG Federation)
+
+[SIG Multi-cluster][] is responsible for infrastructure that supports
+the efficient and reliable management of multiple Kubernetes clusters,
+and applications that run in and across multiple clusters.
+
+For the 1.8 release, SIG Multicluster focussed on expanding the set of
+Kubernetes primitives that our Cluster Federation control plane
+supports, expanding the number of approaches taken to multi-cluster
+management (beyond our initial Federation approach), and preparing
+to release Federation for general availability ('GA').
+
+[SIG Multi-cluster]: https://github.com/kubernetes/community/tree/master/sig-federation
+
+### SIG Node
+
+[SIG Node][] is responsible for the components that support the controlled
+interactions between pods and host resources, and manage the lifecycle
+of pods scheduled on a node.
+
+For the 1.8 release, SIG Node continued to focus
+on a broad set of workload types, including hardware and performance
+sensitive workloads such as data analytics and deep learning. The SIG also
+delivered incremental improvements to node reliability.
+
+[SIG Node]: https://github.com/kubernetes/community/tree/master/sig-node
+
+### SIG Network
+
+[SIG Network][] is responsible for networking components, APIs, and plugins in Kubernetes.
+
+For the 1.8 release, SIG Network enhanced the NetworkPolicy API to support pod egress traffic policies.
+The SIG also provided match criteria that allow policy rules to match a source or destination CIDR. Both features are in beta. SIG Network also improved the kube-proxy to include an alpha IPVS mode in addition to the current iptables and userspace modes.
+
+[SIG Network]: https://github.com/kubernetes/community/tree/master/sig-network
+
+### SIG Scalability
+
+[SIG Scalability][] is responsible for scalability testing, measuring and
+improving system performance, and answering questions related to scalability.
+
+For the 1.8 release, SIG Scalability focused on automating large cluster
+scalability testing in a continuous integration (CI) environment. The SIG
+defined a concrete process for scalability testing, created
+documentation for the current scalability thresholds, and defined a new set of
+Service Level Indicators (SLIs) and Service Level Objectives (SLOs) for the system.
+Here's the release [scalability validation report].
+
+[SIG Scalability]: https://github.com/kubernetes/community/tree/master/sig-scalability
+[scalability validation report]: https://github.com/kubernetes/features/tree/master/release-1.8/scalability_validation_report.md
+
+### SIG Scheduling
+
+[SIG Scheduling][] is responsible for generic scheduler and scheduling components.
+
+For the 1.8 release, SIG Scheduling extended the concept of cluster sharing by introducing
+pod priority and pod preemption. These features allow mixing various types of workloads in a single cluster, and help reach
+higher levels of resource utilization and availability.
+These features are in alpha. SIG Scheduling also improved the internal APIs for scheduling and made them easier for other components and external schedulers to use.
+
+[SIG Scheduling]: https://github.com/kubernetes/community/tree/master/sig-scheduling
+
+### SIG Storage
+
+[SIG Storage][] is responsible for storage and volume plugin components.
+
+For the 1.8 release, SIG Storage extended the Kubernetes storage API. In addition to providing simple
+volume availability, the API now enables volume resizing and snapshotting. These features are in alpha.
+The SIG also focused on providing more control over storage: the ability to set requests and
+limits on ephemeral storage, the ability to specify mount options, more metrics, and improvements to Flex driver deployments.
+
+[SIG Storage]: https://github.com/kubernetes/community/tree/master/sig-storage
+
+## Before Upgrading
+
+Consider the following changes, limitations, and guidelines before you upgrade:
+
+* The kubelet now fails if swap is enabled on a node. To override the default and run with /proc/swaps on, set `--fail-swap-on=false`. The experimental flag `--experimental-fail-swap-on` is deprecated in this release, and will be removed in a future release.
+
+* The `autoscaling/v2alpha1` API is now at `autoscaling/v2beta1`. However, the form of the API remains unchanged. Migrate the `HorizontalPodAutoscaler` resources to `autoscaling/v2beta1` to persist the `HorizontalPodAutoscaler` changes introduced in `autoscaling/v2alpha1`. The Horizontal Pod Autoscaler changes include support for status conditions, and autoscaling on memory and custom metrics.
+
+* The metrics APIs, `custom-metrics.metrics.k8s.io` and `metrics`, were moved from `v1alpha1` to `v1beta1`, and renamed to `custom.metrics.k8s.io` and `metrics.k8s.io`, respectively. If you have deployed a custom metrics adapter, ensure that it supports the new API version. If you have deployed Heapster in aggregated API server mode, upgrade Heapster to support the latest API version.
+
+* Advanced auditing is the default auditing mechanism at `v1beta1`. The new version introduces the following changes:
+
+  * The `--audit-policy-file` option is required if the `AdvancedAudit` feature is not explicitly turned off (`--feature-gates=AdvancedAudit=false`) on the API server.
+  * The audit log file defaults to JSON encoding when using the advanced auditing feature gate.
+  * The `--audit-policy-file` option requires `kind` and `apiVersion` fields specifying what format version the `Policy` is using.
+  * The webhook and log file now output the `v1beta1` event format.
+
+    For more details, see [Advanced audit](https://kubernetes.io/docs/tasks/debug-application-cluster/audit/#advanced-audit).
+
+* The deprecated `ThirdPartyResource` (TPR) API was removed.
+  To avoid losing your TPR data, [migrate to CustomResourceDefinition](https://kubernetes.io/docs/tasks/access-kubernetes-api/migrate-third-party-resource/).
+
+* The following deprecated flags were removed from `kube-controller-manager`:
+
+  * `replication-controller-lookup-cache-size`
+  * `replicaset-lookup-cache-size`
+  * `daemonset-lookup-cache-size`
+
+  Don't use these flags. Using deprecated flags causes the server to print a warning. Using a removed flag causes the server to abort the startup.
+
+* StatefulSet: The deprecated `pod.alpha.kubernetes.io/initialized` annotation for interrupting the StatefulSet Pod management is now ignored. StatefulSets with this annotation set to `true` or with no value will behave just as they did in previous versions. Dormant StatefulSets with the annotation set to `false` will become active after upgrading.
+
+* The CronJob object is now enabled by default at `v1beta1`. CronJob `v2alpha1` is still available, but it must be explicitly enabled. We recommend that you move any current CronJob objects to `batch/v1beta1.CronJob`. Be aware that if you specify the deprecated version, you may encounter Resource Not Found errors. These errors occur because the new controllers look for the new version during a rolling update.
+
+* The `batch/v2alpha1.ScheduledJob` was removed. Migrate to `batch/v1beta.CronJob` to continue managing time based jobs.
+
+* The `rbac/v1alpha1`, `settings/v1alpha1`, and `scheduling/v1alpha1` APIs are disabled by default.
+
+* The `system:node` role is no longer automatically granted to the `system:nodes` group in new clusters. The role gives broad read access to resources, including secrets and configmaps. Use the `Node` authorization mode to authorize the nodes in new clusters. To continue providing the `system:node` role to the members of the `system:nodes` group, create an installation-specific `ClusterRoleBinding` in the installation. ([#49638](https://github.com/kubernetes/kubernetes/pull/49638))
+
+## Known Issues
+
+This section contains a list of known issues reported in Kubernetes 1.8 release. The content is populated via [v1.8.x known issues and FAQ accumulator](https://github.com/kubernetes/kubernetes/issues/53004).
+
+* A performance issue was identified in large-scale clusters when deleting thousands of pods simultaneously across hundreds of nodes. Kubelets in this scenario can encounter temporarily increased latency of `delete pod` API calls -- above the target service level objective of 1 second. If you run clusters with this usage pattern and if pod deletion latency could be an issue for you, you might want to wait until the issue is resolved before you upgrade. 
+
+For more information and for updates on resolution of this issue, see [#51899](https://issue.k8s.io/51899).
+
+* Audit logs might impact the API server performance and the latency of large request and response calls. The issue is observed under the following conditions: if `AdvancedAuditing` feature gate is enabled, which is the default case, if audit logging uses the log backend in JSON format, or if the audit policy records large API calls for requests or responses.
+
+For more information, see [#51899](https://github.com/kubernetes/kubernetes/issues/51899).
+
+* Minikube version 0.22.2 or lower does not work with kubectl version 1.8 or higher. This issue is caused by the presence of an unregistered type in the minikube API server. New versions of kubectl force validate the OpenAPI schema, which is not registered with all known types in the minikube API server.
+
+For more information, see [#1996](https://github.com/kubernetes/minikube/issues/1996).
+
+* The `ENABLE_APISERVER_BASIC_AUDIT` configuration parameter for GCE deployments is broken, but deprecated.
+
+For more information, see [#53154](https://github.com/kubernetes/kubernetes/issues/53154).
+
+* `kubectl set` commands placed on ReplicaSet and DaemonSet occasionally return version errors. All set commands, including set image, set env, set resources, and set serviceaccounts, are affected.
+
+For more information, see [#53040](https://github.com/kubernetes/kubernetes/issues/53040).
+
+* Object quotas are not consistently charged or updated. Specifically, the object count quota does not reliably account for uninitialized objects. Some quotas are charged only when an object is initialized. Others are charged when an object is created, whether it is initialized or not. We plan to fix this issue in a future release.
+
+For more information, see [#53109](https://github.com/kubernetes/kubernetes/issues/53109).
+
+## Deprecations
+
+This section provides an overview of deprecated API versions, options, flags, and arguments. Deprecated means that we intend to remove the capability from a future release. After removal, the capability will no longer work. The sections are organized by SIGs.
+
+### Apps
+
+- The `.spec.rollbackTo` field of the Deployment kind is deprecated in `extensions/v1beta1`.
+
+- The `kubernetes.io/created-by` annotation is deprecated and will be removed in version 1.9.
+  Use [ControllerRef](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/controller-ref.md) instead to determine which controller, if any, owns an object.
+
+ - The `batch/v2alpha1.CronJob` is deprecated in favor of `batch/v1beta1`.
+
+ - The `batch/v2alpha1.ScheduledJob` was removed. Use `batch/v1beta1.CronJob` instead.
+
+### Auth
+
+ - The RBAC v1alpha1 API group is deprecated in favor of RBAC v1.
+
+ - The API server flag `--experimental-bootstrap-token-auth` is deprecated in favor of `--enable-bootstrap-token-auth`. The `--experimental-bootstrap-token-auth` flag will be removed in version 1.9.
+
+### Autoscaling
+
+ - Consuming metrics directly from Heapster is deprecated in favor of
+   consuming metrics via an aggregated version of the resource metrics API.
+
+   - In version 1.8, enable this behavior by setting the
+     `--horizontal-pod-autoscaler-use-rest-clients` flag to `true`.
+
+   - In version 1.9, this behavior will be enabled by default, and must be explicitly
+     disabled by setting the `--horizontal-pod-autoscaler-use-rest-clients` flag to `false`.
+
+### Cluster Lifecycle
+
+- The `auto-detect` behavior of the kubelet's `--cloud-provider` flag is deprecated.
+
+  - In version 1.8, the default value for the kubelet's `--cloud-provider` flag is `auto-detect`. Be aware that it works only on GCE, AWS and Azure.
+
+  - In version 1.9, the default will be `""`, which means no built-in cloud provider extension will be enabled by default.
+
+  - Enable an out-of-tree cloud provider with `--cloud-provider=external` in either version.
+
+    For more information on deprecating auto-detecting cloud providers in kubelet, see [PR #51312](https://github.com/kubernetes/kubernetes/pull/51312) and [announcement](https://groups.google.com/forum/#!topic/kubernetes-dev/UAxwa2inbTA).
+
+- The `PersistentVolumeLabel` admission controller in the API server is deprecated.
+
+  - The replacement is running a cloud-specific controller-manager (often referred to as `cloud-controller-manager`) with the `PersistentVolumeLabel` controller enabled. This new controller loop operates as the `PersistentVolumeLabel` admission controller did in previous versions.
+
+  - Do not use the `PersistentVolumeLabel` admission controller in the configuration files and scripts unless you are dependent on the in-tree GCE and AWS cloud providers.
+
+  - The `PersistentVolumeLabel` admission controller will be removed in a future release, when the out-of-tree versions of the GCE and AWS cloud providers move to GA. The cloud providers are marked alpha in version 1.9.
+
+### OpenStack
+
+- The `openstack-heat` provider for `kube-up` is deprecated and will be removed
+  in a future release. Refer to [Issue #49213](https://github.com/kubernetes/kubernetes/issues/49213)
+  for background information.
+
+### Scheduling
+
+  - Opaque Integer Resources (OIRs) are deprecated and will be removed in
+    version 1.9. Extended Resources (ERs) are a drop-in replacement for OIRs. You can use
+    any domain name prefix outside of the `kubernetes.io/` domain instead of the
+    `pod.alpha.kubernetes.io/opaque-int-resource-` prefix.
+
+## Notable Features
+
+### Workloads API (apps/v1beta2)
+
+Kubernetes 1.8 adds the apps/v1beta2 group and version, which now consists of the
+DaemonSet, Deployment, ReplicaSet and StatefulSet kinds. This group and version are part
+of the Kubernetes Workloads API. We plan to move them to v1 in an upcoming release, so you might want to plan your migration accordingly.
+
+For more information, see [the issue that describes this work in detail](https://github.com/kubernetes/features/issues/353)
+
+#### API Object Additions and Migrations
+
+- The DaemonSet, Deployment, ReplicaSet, and StatefulSet kinds
+  are now in the apps/v1beta2 group and version.
+
+- The apps/v1beta2 group version adds a Scale subresource for the StatefulSet
+kind.
+
+- All kinds in the apps/v1beta2 group version add a corresponding conditions
+  kind.
+
+#### Behavioral Changes
+
+ - For all kinds in the API group version, a spec.selector default value is no longer
+ available, because it's incompatible with `kubectl
+ apply` and strategic merge patch. You must explicitly set the spec.selector value
+ in your manifest. An object with a spec.selector value that does not match the labels in
+ its spec.template is invalid.
+
+ - Selector mutation is disabled for all kinds in the
+ app/v1beta2 group version, because the controllers in the workloads API do not handle
+ selector mutation in
+ a consistent way. This restriction may be lifted in the future, but
+ it is likely that that selectors will remain immutable after the move to v1.
+ You can continue to use code that depends on mutable selectors by calling
+ the apps/v1beta1 API in this release, but you should start planning for code
+ that does not depend on mutable selectors.
+
+ - Extended Resources are fully-qualified resource names outside the
+ `kubernetes.io` domain. Extended Resource quantities must be integers.
+ You can specify any resource name of the form `[aaa.]my-domain.bbb/ccc`
+ in place of [Opaque Integer Resources](https://v1-6.docs.kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#opaque-integer-resources-alpha-feature).
+ Extended resources cannot be overcommitted, so make sure that request and limit are equal
+ if both are present in a container spec.
+
+ - The default Bootstrap Token created with `kubeadm init` v1.8 expires
+ and is deleted after 24 hours by default to limit the exposure of the
+ valuable credential. You can create a new Bootstrap Token with
+ `kubeadm token create` or make the default token permanently valid by specifying
+ `--token-ttl 0` to `kubeadm init`. The default token can later be deleted with
+ `kubeadm token delete`.
+
+ - `kubeadm join` now delegates TLS Bootstrapping to the kubelet itself, instead
+ of reimplementing the process. `kubeadm join` writes the bootstrap kubeconfig
+ file to `/etc/kubernetes/bootstrap-kubelet.conf`.
+
+#### Defaults
+
+ - The default spec.updateStrategy for the StatefulSet and DaemonSet kinds is
+ RollingUpdate for the apps/v1beta2 group version. You can explicitly set
+ the OnDelete strategy, and no strategy auto-conversion is applied to
+ replace default values.
+
+ - As mentioned in [Behavioral Changes](#behavioral-changes), selector
+ defaults are disabled.
+
+ - The default spec.revisionHistoryLimit for all applicable kinds in the
+ apps/v1beta2 group version is 10.
+
+ - In a CronJob object, the default spec.successfulJobsHistoryLimit is 3, and
+ the default spec.failedJobsHistoryLimit is 1.
+
+### Workloads API (batch)
+
+- CronJob is now at `batch/v1beta1` ([#41039](https://github.com/kubernetes/kubernetes/issues/41039), [@soltysh](https://github.com/soltysh)).
+
+- `batch/v2alpha.CronJob` is deprecated in favor of `batch/v1beta` and will be removed in a future release.
+
+- Job can now set a failure policy using `.spec.backoffLimit`. The default value for this new field is 6. ([#30243](https://github.com/kubernetes/kubernetes/issues/30243), [@clamoriniere1A](https://github.com/clamoriniere1A)).
+
+- `batch/v2alpha1.ScheduledJob` is removed.
+
+- The Job controller now creates pods in batches instead of all at once. ([#49142](https://github.com/kubernetes/kubernetes/pull/49142), [@joelsmith](https://github.com/joelsmith)).
+
+- Short `.spec.ActiveDeadlineSeconds` is properly applied to a Job. ([#48545]
+(https://github.com/kubernetes/kubernetes/pull/48454), [@weiwei4](https://github.com/weiwei04)).
+
+
+#### CLI Changes
+
+- [alpha] `kubectl` plugins: `kubectl` now allows binary extensibility. You can extend the default set of `kubectl` commands by writing plugins
+  that provide new subcommands. Refer to the documentation for more information.
+
+- `kubectl rollout` and `rollback` now support StatefulSet.
+
+- `kubectl scale` now uses the Scale subresource for kinds in the apps/v1beta2 group.
+
+- `kubectl create configmap` and `kubectl create secret` subcommands now support
+  the `--append-hash` flag, which enables unique but deterministic naming for
+  objects generated from files, for example with `--from-file`.
+
+- `kubectl run` can set a service account name in the generated pod
+  spec with the `--serviceaccount` flag.
+
+- `kubectl proxy` now correctly handles the `exec`, `attach`, and
+  `portforward` commands.  You must pass `--disable-filter` to the command to allow these commands.
+
+- Added `cronjobs.batch` to "all", so that `kubectl get all` returns them.
+
+- Added flag `--include-uninitialized` to `kubectl annotate`, `apply`, `edit-last-applied`,
+  `delete`, `describe`, `edit`, `get`, `label,` and `set`. `--include-uninitialized=true` makes
+  kubectl commands apply to uninitialized objects, which by default are ignored
+  if the names of the objects are not provided. `--all` also makes kubectl
+  commands apply to uninitialized objects. See the
+  [initializer documentation](https://kubernetes.io/docs/admin/extensible-admission-controllers/) for more details.
+
+- Added RBAC reconcile commands with `kubectl auth reconcile -f FILE`. When
+  passed a file which contains RBAC roles, rolebindings, clusterroles, or
+  clusterrolebindings, this command computes covers and adds the missing rules.
+  The logic required to properly apply RBAC permissions is more complicated
+  than a JSON merge because you have to compute logical covers operations between
+  rule sets. This means that we cannot use `kubectl apply` to update RBAC roles
+  without risking breaking old clients, such as controllers.
+
+- `kubectl delete` no longer scales down workload API objects before deletion.
+  Users who depend on ordered termination for the Pods of their StatefulSets
+  must use `kubectl scale` to scale down the StatefulSet before deletion.
+
+- `kubectl run --env` no longer supports CSV parsing. To provide multiple environment
+  variables, use the `--env` flag multiple times instead. Example: `--env ONE=1 --env TWO=2` instead of `--env ONE=1,TWO=2`.
+
+- Removed deprecated command `kubectl stop`.
+
+- Kubectl can now use http caching for the OpenAPI schema. The cache
+  directory can be configured by passing the `--cache-dir` command line flag to kubectl.
+  If set to an empty string, caching is disabled.
+
+- Kubectl now performs validation against OpenAPI schema instead of Swagger 1.2. If
+  OpenAPI is not available on the server, it falls back to the old Swagger 1.2.
+
+- Added Italian translation for kubectl.
+
+- Added German translation for kubectl.
+
+#### Scheduling
+
+* [alpha] This version now supports pod priority and creation of PriorityClasses ([user doc](https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/))([design doc](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/scheduling/pod-priority-api.md))
+
+* [alpha] This version now supports priority-based preemption of pods ([user doc](https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/))([design doc](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/scheduling/pod-preemption.md))
+
+* [alpha] Users can now add taints to nodes by condition ([design doc](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/scheduling/taint-node-by-condition.md))
+
+#### Storage
+
+* [stable] Mount options
+
+  * The ability to specify mount options for volumes is moved from beta to stable.
+
+  * A new `MountOptions` field in the `PersistentVolume` spec is available to specify mount options. This field replaces an annotation.
+
+  * A new `MountOptions` field in the `StorageClass` spec allows configuration of mount options for dynamically provisioned volumes.
+
+* [stable] Support Attach and Detach operations for ReadWriteOnce (RWO) volumes that use iSCSI and Fibre Channel plugins.
+
+* [stable] Expose storage usage metrics
+
+  * The available capacity of a given Persistent Volume (PV) is available by calling the Kubernetes metrics API.
+
+* [stable] Volume plugin metrics
+
+  * Success and latency metrics for all Kubernetes calls are available by calling the Kubernetes metrics API. You can request volume operations, including mount, unmount, attach, detach, provision, and delete.
+
+* [stable] The PV spec for Azure File, CephFS, iSCSI, and Glusterfs is modified to reference namespaced resources.
+
+* [stable] You can now customize the iSCSI initiator name per volume in the iSCSI volume plugin.
+
+* [stable] You can now specify the World Wide Identifier (WWID) for the volume identifier in the Fibre Channel volume plugin.
+
+* [beta] Reclaim policy in StorageClass
+
+  * You can now configure the reclaim policy in StorageClass, instead of defaulting to `delete` for dynamically provisioned volumes.
+
+* [alpha] Volume resizing
+
+  * You can now increase the size of a volume by calling the Kubernetes API.
+
+  * For alpha, this feature increases only the size of the underlying volume. It does not support resizing the file system.
+
+  * For alpha, volume resizing supports only Gluster volumes.
+
+* [alpha] Provide capacity isolation and resource management for local ephemeral storage
+
+  * You can now set container requests, container limits, and node allocatable reservations for the new `ephemeral-storage` resource.
+
+  * The `ephemeral-storage` resource includes all the disk space a container might consume with container overlay or scratch.
+
+* [alpha] Mount namespace propagation
+
+  * The `VolumeMount.Propagation` field for `VolumeMount` in pod containers is now available.
+
+  * You can now set `VolumeMount.Propagation` to `Bidirectional` to enable a particular mount for a container to propagate itself to the host or other containers.
+
+* [alpha] Improve Flex volume deployment
+
+  * Flex volume driver deployment is simplified in the following ways:
+
+    * New driver files can now be automatically discovered and initialized without requiring a kubelet or controller-manager restart.
+
+    * A sample DaemonSet to deploy Flexvolume drivers is now available.
+
+* [prototype] Volume snapshots
+
+  * You can now create a volume snapshot by calling the Kubernetes API.
+
+  * Note that the prototype does not support quiescing before snapshot, so snapshots might be inconsistent.
+
+  * In the prototype phase, this feature is external to the core Kubernetes. It's available at https://github.com/kubernetes-incubator/external-storage/tree/master/snapshot.
+
+### Cluster Federation
+
+#### [alpha] Federated Jobs
+
+Federated Jobs that are automatically deployed to multiple clusters
+are now supported. Cluster selection and weighting determine how Job
+parallelism and completions are spread across clusters. Federated Job
+status reflects the aggregate status across all underlying cluster
+jobs.
+
+#### [alpha] Federated Horizontal Pod Autoscaling (HPA)
+
+Federated HPAs are similar to the traditional Kubernetes HPAs, except
+that they span multiple clusters. Creating a Federated HPA targeting
+multiple clusters ensures that cluster-level autoscalers are
+consistently deployed across those clusters, and dynamically managed
+to ensure that autoscaling can occur optimially in all clusters,
+within a set of global constraints on the the total number of replicas
+permitted across all clusters.  If replicas are not
+required in some clusters due to low system load or insufficient quota
+or capacity in those clusters, additional replicas are made available
+to the autoscalers in other clusters if required.
+
+### Node Components
+
+#### Autoscaling and Metrics
+
+* Support for custom metrics in the Horizontal Pod Autoscaler is now at v1beta1. The associated metrics APIs (custom metrics and resource/master metrics) were also moved to v1beta1. For more information, see [Before Upgrading](#before-upgrading).
+
+* `metrics-server` is now the recommended way to provide the resource
+  metrics API. Deploy `metrics-server` as an add-on in the same way that you deploy Heapster.
+
+##### Cluster Autoscaler
+
+* Cluster autoscaler is now GA
+* Cluster support size is increased to 1000 nodes
+* Respect graceful pod termination of up to 10 minutes
+* Handle zone stock-outs and failures
+* Improve monitoring and error reporting
+
+#### Container Runtime Interface (CRI)
+
+* [alpha] Add a CRI validation test suite and CRI command-line tools. ([#292](https://github.com/kubernetes/features/issues/292), [@feiskyer](https://github.com/feiskyer))
+
+* [stable] [cri-o](https://github.com/kubernetes-incubator/cri-o): CRI implementation for OCI-based runtimes [@mrunalp]
+
+  * Passed all the Kubernetes 1.7 end-to-end conformance test suites.
+  * Verification against Kubernetes 1.8 is planned soon after the release.
+
+* [stable] [frakti](https://github.com/kubernetes/frakti): CRI implementation for hypervisor-based runtimes is now v1.1. [@feiskyer]
+
+  * Enhance CNI plugin compatibility, supports flannel, calico, weave and so on.
+  * Pass all CRI validation conformance tests and node end-to-end conformance tests.
+  * Add experimental Unikernel support.
+
+* [alpha] [cri-containerd](https://github.com/kubernetes-incubator/cri-containerd): CRI implementation for containerd is now v1.0.0-alpha.0, [@Random-Liu]
+
+  * Feature complete. Support the full CRI API defined in v1.8.
+  * Pass all the CRI validation tests and regular node end-to-end tests.
+  * An ansible playbook is provided to configure a Kubernetes cri-containerd cluster with kubeadm.
+
+* Add support in Kubelet to consume container metrics via CRI. [@yguo0905]
+  * There are known bugs that result in errors when querying Kubelet's stats summary API. We expect to fix them in v1.8.1.
+
+#### kubelet
+
+* [alpha] Kubelet now supports alternative container-level CPU affinity policies by using the new CPU manager. ([#375](https://github.com/kubernetes/features/issues/375), [@sjenning](https://github.com/sjenning), [@ConnorDoyle](https://github.com/ConnorDoyle))
+
+* [alpha] Applications may now request pre-allocated hugepages by using the new `hugepages` resource in the container resource requests. ([#275](https://github.com/kubernetes/features/issues/275), [@derekwaynecarr](https://github.com/derekwaynecarr))
+
+* [alpha] Add support for dynamic Kubelet configuration. ([#281](https://github.com/kubernetes/features/issues/281), [@mtaufen](https://github.com/mtaufen))
+
+* [alpha] Add the Hardware Device Plugins API. ([#368](https://github.com/kubernetes/features/issues/368), [@jiayingz], [@RenaudWasTaken])
+
+* [stable] Upgrade cAdvisor to v0.27.1 with the enhancement for node monitoring. [@dashpole]
+
+  * Fix journalctl leak
+  * Fix container memory rss
+  * Fix incorrect CPU usage with 4.7 kernel
+  * OOM parser uses kmsg
+  * Add hugepages support
+  * Add CRI-O support
+
+* Sharing a PID namespace between containers in a pod is disabled by default in version 1.8. To enable for a node, use the `--docker-disable-shared-pid=false` kubelet flag. Be aware that PID namespace sharing requires Docker version greater than or equal to 1.13.1.
+
+* Fix issues related to the eviction manager.
+
+* Fix inconsistent Prometheus cAdvisor metrics.
+
+* Fix issues related to the local storage allocatable feature.
+
+### Auth
+
+* [GA] The RBAC API group has been promoted from v1beta1 to v1. No API changes were introduced.
+
+* [beta] Advanced auditing has been promoted from alpha to beta. The webhook and logging policy formats have changed since alpha, and may require modification.
+
+* [beta] Kubelet certificate rotation through the certificates API has been promoted from alpha to beta. RBAC cluster roles for the certificates controller have been added for common uses of the certificates API, such as the kubelet's.
+
+* [beta] SelfSubjectRulesReview, an API that lets a user see what actions they can perform with a namespace, has been added to the authorization.k8s.io API group. This bulk query is intended to enable UIs to show/hide actions based on the end user, and for users to quickly reason about their own permissions.
+
+* [alpha] Building on the 1.7 work to allow encryption of resources such as secrets, a mechanism to store resource encryption keys in external Key Management Systems (KMS) was introduced. This complements the original file-based storage and allows integration with multiple KMS. A Google Cloud KMS plugin was added and will be usable once the Google side of the integration is complete.
+
+* Websocket requests may now authenticate to the API server by passing a bearer token in a websocket subprotocol of the form `base64url.bearer.authorization.k8s.io.<base64url-encoded-bearer-token>`. ([#47740](https://github.com/kubernetes/kubernetes/pull/47740) [@liggitt](https://github.com/liggitt))
+
+* Advanced audit now correctly reports impersonated user info. ([#48184], [@CaoShuFeng](https://github.com/CaoShuFeng))
+
+* Advanced audit policy now supports matching subresources and resource names, but the top level resource no longer matches the subresouce. For example "pods" no longer matches requests to the logs subresource of pods. Use "pods/logs" to match subresources. ([#48836](https://github.com/kubernetes/kubernetes/pull/48836), [@ericchiang](https://github.com/ericchiang))
+
+* Previously a deleted service account or bootstrapping token secret would be considered valid until it was reaped. It is now invalid as soon as the `deletionTimestamp` is set. ([#48343](https://github.com/kubernetes/kubernetes/pull/48343), [@deads2k](https://github.com/deads2k); [#49057](https://github.com/kubernetes/kubernetes/pull/49057), [@ericchiang](https://github.com/ericchiang))
+
+* The `--insecure-allow-any-token` flag has been removed from the API server. Users of the flag should use impersonation headers instead for debugging. ([#49045](https://github.com/kubernetes/kubernetes/pull/49045), [@ericchiang](https://github.com/ericchiang))
+
+* The NodeRestriction admission plugin now allows a node to evict pods bound to itself. ([#48707](https://github.com/kubernetes/kubernetes/pull/48707), [@danielfm](https://github.com/danielfm))
+
+* The OwnerReferencesPermissionEnforcement admission plugin now requires `update` permission on the `finalizers` subresource of the referenced owner in order to set `blockOwnerDeletion` on an owner reference. ([#49133](https://github.com/kubernetes/kubernetes/pull/49133), [@deads2k](https://github.com/deads2k))
+
+* The SubjectAccessReview API in the `authorization.k8s.io` API group now allows providing the user uid. ([#49677](https://github.com/kubernetes/kubernetes/pull/49677), [@dims](https://github.com/dims))
+
+* After a kubelet rotates its client cert, it now closes its connections to the API server to force a handshake using the new cert. Previously, the kubelet could keep its existing connection open, even if the cert used for that connection was expired and rejected by the API server. ([#49899](https://github.com/kubernetes/kubernetes/pull/49899), [@ericchiang](https://github.com/ericchiang))
+
+* PodSecurityPolicies can now specify a whitelist of allowed paths for host volumes. ([#50212](https://github.com/kubernetes/kubernetes/pull/50212), [@jhorwit2](https://github.com/jhorwit2))
+
+* API server authentication now caches successful bearer token authentication results for a few seconds. ([#50258](https://github.com/kubernetes/kubernetes/pull/50258), [@liggitt](https://github.com/liggitt))
+
+* The OpenID Connect authenticator can now use a custom prefix, or omit the default prefix, for username and groups claims through the --oidc-username-prefix and --oidc-groups-prefix flags. For example, the authenticator can map a user with the username "jane" to "google:jane" by supplying the "google:" username prefix. ([#50875](https://github.com/kubernetes/kubernetes/pull/50875), [@ericchiang](https://github.com/ericchiang))
+
+* The bootstrap token authenticator can now configure tokens with a set of extra groups in addition to `system:bootstrappers`. ([#50933](https://github.com/kubernetes/kubernetes/pull/50933), [@mattmoyer](https://github.com/mattmoyer))
+
+* Advanced audit allows logging failed login attempts.
+ ([#51119](https://github.com/kubernetes/kubernetes/pull/51119), [@soltysh](https://github.com/soltysh))
+
+* A `kubectl auth reconcile` subcommand has been added for applying RBAC resources. When passed a file which contains RBAC roles, rolebindings, clusterroles, or clusterrolebindings, it will compute covers and add the missing rules. ([#51636](https://github.com/kubernetes/kubernetes/pull/51636), [@deads2k](https://github.com/deads2k))
+
+### Cluster Lifecycle
+
+#### kubeadm
+
+* [beta] A new `upgrade` subcommand allows you to automatically upgrade a self-hosted cluster created with kubeadm. ([#296](https://github.com/kubernetes/features/issues/296), [@luxas](https://github.com/luxas))
+
+* [alpha] An experimental self-hosted cluster can now easily be created with `kubeadm init`. Enable the feature by setting the SelfHosting feature gate to true: `--feature-gates=SelfHosting=true` ([#296](https://github.com/kubernetes/features/issues/296), [@luxas](https://github.com/luxas))
+   * **NOTE:** Self-hosting will be the default way to host the control plane in the next release, v1.9
+
+* [alpha] A new `phase` subcommand supports performing only subtasks of the full `kubeadm init` flow. Combined with fine-grained configuration, kubeadm is now more easily consumable by higher-level provisioning tools like kops or GKE. ([#356](https://github.com/kubernetes/features/issues/356), [@luxas](https://github.com/luxas))
+   * **NOTE:** This command is currently staged under `kubeadm alpha phase` and will be graduated to top level in a future release.
+
+#### kops
+
+* [alpha] Added support for targeting bare metal (or non-cloudprovider) machines. ([#360](https://github.com/kubernetes/features/issues/360), [@justinsb](https://github.com/justinsb)).
+
+* [alpha] kops now supports [running as a server](https://github.com/kubernetes/kops/blob/master/docs/api-server/README.md). ([#359](https://github.com/kubernetes/features/issues/359), [@justinsb](https://github.com/justinsb)).
+
+* [beta] GCE support is promoted from alpha to beta. ([#358](https://github.com/kubernetes/features/issues/358), [@justinsb](https://github.com/justinsb)).
+
+#### Cluster Discovery/Bootstrap
+
+* [beta] The authentication and verification mechanism called Bootstrap Tokens is improved. Use Bootstrap Tokens to easily add new node identities to a cluster. ([#130](https://github.com/kubernetes/features/issues/130), [@luxas](https://github.com/luxas), [@jbeda](https://github.com/jbeda)).
+
+#### Multi-platform
+
+* [alpha] The Conformance e2e test suite now passes on the arm, arm64, and ppc64le platforms. ([#288](https://github.com/kubernetes/features/issues/288), [@luxas](https://github.com/luxas), [@mkumatag](https://github.com/mkumatag), [@ixdy](https://github.com/ixdy))
+
+#### Cloud Providers
+
+* [alpha] Support is improved for the pluggable, out-of-tree and out-of-core cloud providers. ([#88](https://github.com/kubernetes/features/issues/88), [@wlan0](https://github.com/wlan0))
+
+### Network
+
+#### network-policy
+
+* [beta] Apply NetworkPolicy based on CIDR ([#50033](https://github.com/kubernetes/kubernetes/pull/50033), [@cmluciano](https://github.com/cmluciano))
+
+* [beta] Support EgressRules in NetworkPolicy ([#51351](https://github.com/kubernetes/kubernetes/pull/51351), [@cmluciano](https://github.com/cmluciano))
+
+#### kube-proxy ipvs mode
+
+[alpha] Support ipvs mode for kube-proxy([#46580](https://github.com/kubernetes/kubernetes/pull/46580), [@haibinxie](https://github.com/haibinxie))
+
+### API Machinery
+
+#### kube-apiserver
+* Fixed an issue with `APIService` auto-registration. This issue affected rolling restarts of HA API servers that added or removed API groups being served.([#51921](https://github.com/kubernetes/kubernetes/pull/51921))
+
+* [Alpha] The Kubernetes API server now supports the ability to break large LIST calls into multiple smaller chunks. A client can specify a limit to the number of results to return. If more results exist, a token is returned that allows the client to continue the previous list call repeatedly until all results are retrieved.  The resulting list is identical to a list call that does not perform chunking, thanks to capabilities provided by etcd3.  This allows the server to use less memory and CPU when very large lists are returned. This feature is gated as APIListChunking and is not enabled by default. The 1.9 release will begin using this by default.([#48921](https://github.com/kubernetes/kubernetes/pull/48921))
+
+* Pods that are marked for deletion and have exceeded their grace period, but are not yet deleted, no longer count toward the resource quota.([#46542](https://github.com/kubernetes/kubernetes/pull/46542))
+
+
+#### Dynamic Admission Control
+
+* Pod spec is mutable when the pod is uninitialized. The API server requires the pod spec to be valid even if it's uninitialized. Updating the status field of uninitialized pods is invalid.([#51733](https://github.com/kubernetes/kubernetes/pull/51733))
+
+* Use of the alpha initializers feature now requires enabling the `Initializers` feature gate. This feature gate is automatically enabled if the `Initializers` admission plugin is enabled.([#51436](https://github.com/kubernetes/kubernetes/pull/51436))
+
+* [Action required] The validation rule for metadata.initializers.pending[x].name is tightened. The initializer name must contain at least three segments, separated by dots. You can create objects with pending initializers and not rely on the API server to add pending initializers according to `initializerConfiguration`. If you do so, update the initializer name in the existing objects and the configuration files to comply with the new validation rule.([#51283](https://github.com/kubernetes/kubernetes/pull/51283))
+
+* The webhook admission plugin now works even if the API server and the nodes are in two separate networks,for example, in GKE.
+The webhook admission plugin now lets the webhook author use the DNS name of the service as the CommonName when generating the server cert for the webhook.
+Action required:
+Regenerate the server cert for the admission webhooks. Previously, the CN value could be ignored while generating the server cert for the admission webhook. Now you must set it to the DNS name of the webhook service: `<service.Name>.<service.Namespace>.svc`.([#50476](https://github.com/kubernetes/kubernetes/pull/50476))
+
+
+#### Custom Resource Definitions (CRDs)
+* [alpha] The CustomResourceDefinition API can now optionally
+  [validate custom objects](https://kubernetes.io/docs/tasks/access-kubernetes-api/extend-api-custom-resource-definitions/#validation)
+  based on a JSON schema provided in the CRD spec.
+  Enable this alpha feature with the `CustomResourceValidation` feature gate in `kube-apiserver`.
+
+#### Garbage Collector
+* The garbage collector now supports custom APIs added via Custom Resource Definitions
+  or aggregated API servers. The garbage collector controller refreshes periodically.
+  Therefore, expect a latency of about 30 seconds between when an API is added and when
+  the garbage collector starts to manage it.
+
+
+#### Monitoring/Prometheus
+* [action required] The WATCHLIST calls are now reported as WATCH verbs in prometheus for the apiserver_request_* series.  A new "scope" label is added to all apiserver_request_* values that is either 'cluster', 'resource', or 'namespace' depending on which level the query is performed at.([#52237](https://github.com/kubernetes/kubernetes/pull/52237))
+
+
+#### Go Client
+* Add support for client-side spam filtering of events([#47367](https://github.com/kubernetes/kubernetes/pull/47367))
+
+
+## External Dependencies
+
+Continuous integration builds use Docker versions 1.11.2, 1.12.6, 1.13.1,
+and 17.03.2. These versions were validated on Kubernetes 1.8. However,
+consult an appropriate installation or upgrade guide before deciding what
+versions of Docker to use.
+
+- Docker 1.13.1 and 17.03.2
+
+    - Shared PID namespace, live-restore, and overlay2 were validated.
+
+    - **Known issues**
+
+        - The default iptables FORWARD policy was changed from ACCEPT to
+          DROP, which causes outbound container traffic to stop working by
+          default. See
+          [#40182](https://github.com/kubernetes/kubernetes/issues/40182) for
+          the workaround.
+
+        - The support for the v1 registries was removed.
+
+- Docker 1.12.6
+
+    - Overlay2 and live-restore are not validated.
+
+    - **Known issues**
+
+        - Shared PID namespace does not work properly.
+          ([#207](https://github.com/kubernetes/community/pull/207#issuecomment-281870043))
+
+        - Docker reports incorrect exit codes for containers.
+          ([#41516](https://github.com/kubernetes/kubernetes/issues/41516))
+
+- Docker 1.11.2
+
+    - **Known issues**
+
+        - Kernel crash with Aufs storage driver on Debian Jessie
+          ([#27885](https://github.com/kubernetes/kubernetes/issues/27885)).
+          The issue can be identified by using the node problem detector.
+
+        - File descriptor leak on init/control.
+          ([#275](https://github.com/containerd/containerd/issues/275))
+
+        - Additional memory overhead per container.
+          ([#21737](https://github.com/kubernetes/kubernetes/pull/21737))
+
+        - Processes may be leaked when Docker is repeatedly terminated in a short
+          time frame.
+          ([#41450](https://github.com/kubernetes/kubernetes/issues/41450))

--- a/releases/release-1.8/release_notes_discussion.md
+++ b/releases/release-1.8/release_notes_discussion.md
@@ -1,0 +1,49 @@
+# Release notes items to discuss (Radhika, Jennifer)
+
+## Gaps
+
+Much content does not indicate what changed in this release. Even detailed descriptions of features don't indicate reliably whether they are new, or changes to existing functionality. Missing also are explanations of why changes were made (or added), or any indication of a use case. Asking for use cases is probably reaching too far, especially at this late date, but some indication of how things changed is important.
+
+The writers propose to contact individual sig leads, or where known the original release note authors, to ask these questions one-on-one and expand the relevant release notes as we revise them. In some cases there's enough information in linked PRs or issues for us to investigate on our own, but we don't have time to go code diving.
+
+## Inconsistent terminology
+
+API changes especially are called out in various ways: they are promoted, graduated, advanced. We should standardize. (Note that none of these is a standard way to refer to version number increases.) The same goes for referring to API groups (themselves a confusing concept to outsiders). Radhika and Jennifer are working on this issue.
+
+## Information architecture
+
+Thinking about useful buckets (getting rid of sig org altogether?). Look at app developer user persona for ideas? (here: https://docs.google.com/document/d/1EdQ8acmuKGlzZy1agejLqmB7cLpTRBJKC0JYptJ-ylg/edit#heading=h.ylz4u4aax62y)
+
+One (example) option (details not final or guaranteed to be accurate):
+
+- Cluster config changes
+    - New Features
+    - API changes
+    - Known Issues
+- Node/pod changes
+    - New Features
+    - API changes
+    - Known Issues
+- Networking changes
+    - New Features
+    - API changes
+    - Known Issues
+- Auth changes
+    - New Features
+    - API changes
+    - Known Issues
+- Command-line tool changes (kubectl)
+    - New Features
+    - API changes
+    - Known Issues
+- Storage changes
+    - New Features
+    - API changes
+    - Known Issues
+
+
+Carrying over known issues from previous releases? (documenting fixes?)
+
+## Publishing process
+
+The release notes are published as part of the lengthy `changelog.md` file. Ideally, the release notes should be published along with the documentation on kubernetes.io. Considering the usability factors, release notes are not consumable in the current form.

--- a/releases/release-1.8/release_team.md
+++ b/releases/release-1.8/release_team.md
@@ -1,0 +1,13 @@
+|  **Role** | **Name** (**GitHub/Slack ID**)  | **Shadow Name(s) (GitHub/Slack ID), ...**
+|  ------ | ------ | ------ |
+|  Lead | Jaice Singer DuMars (jdumars) | |
+|  Secondary | Caleb Miles (calebamiles) | |
+|  Features | Ihor Dvoretskyi (idvoretskyi) | |
+|  Branch Manager | Adam Worrall (abgworrall) | |
+|  Test Infra | Sen Lu (krzyzacy) | Aaron Crickenberger (spiffxp) |
+|  Docs | Steve Perry (steveperry-53) | Zach Corleissen (zcorleissen) |
+|  Release Notes | Radhika Puthiyetath (radhikapc) | Jennifer Rondeau (jrondeau) |
+|  Bugs | Aaron Crickenberger (spiffxp) | Davanum Srinivas (dims) |
+|  Upgrade Testing / CI Signal| Eric Chiang (ericchiang) | |
+|  Patch Release Manager | Joe Betz (jpbetz) | |
+|  Marketing coordinator | Swarna Podila (swarnap) | |

--- a/releases/release-1.8/scalability_validation_report.md
+++ b/releases/release-1.8/scalability_validation_report.md
@@ -1,0 +1,45 @@
+This is the scalability validation report for release-1.8 written as per [this](https://github.com/kubernetes/community/blob/master/contributors/devel/release/scalability-validation.md#concretely-define-test-configuration) template.
+
+Validated large cluster performance under the following configuration:
+- Cloud-provider - GCE
+- No. of nodes - 5000
+- Node machine-type - n1-standard-1; OS - gci; Disk size - 50GB
+- Master machine-type - [auto-calculated]; OS - gci; Disk size - [auto-calculated]
+- Any non-default config used:
+  - KUBE_ENABLE_CLUSTER_MONITORING=none
+  - ENABLE_APISERVER_ADVANCED_AUDIT=false
+  - APISERVER_TEST_ARGS=--max-requests-inflight=3000 --max-mutating-requests-inflight=1000
+  - SCHEDULER_TEST_ARGS=--kube-api-qps=100
+  - CONTROLLER_MANAGER_TEST_ARGS=--kube-api-qps=100 --kube-api-burst=100
+  - TEST_CLUSTER_RESYNC_PERIOD=--min-resync-period=12h
+  - TEST_CLUSTER_DELETE_COLLECTION_WORKERS=--delete-collection-workers=16
+  - ENABLE_BIG_CLUSTER_SUBNETS=true
+- Any important test details:
+  - Services disabled in load test
+  - SLO used for 99%ile for api call latency:
+    - For clusters with <= 500 nodes:
+      - <= 1s for all calls
+    - For clusters with > 500 nodes:
+      - <= 1s for non-list calls
+      - <= 5s for namespaced list calls
+      - <= 10s for cluster-scoped list calls
+- <job-name, run#> of the validating run (to know other specific details from the logs): https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-scale-performance/36
+
+Validated large cluster correctness under the following configuration:
+- Cloud-provider - GCE
+- No. of nodes - 5000
+- Node machine-type - g1-small; OS - gci; Disk size - 50GB
+- One special n1-standard-8 node (out of the 5k nodes) used for heapster
+- Master machine-type - [auto-calculated]; OS - gci; Disk size - [auto-calculated]
+- Any non-default config used:
+  - KUBE_ENABLE_CLUSTER_MONITORING=standalone
+  - ENABLE_APISERVER_ADVANCED_AUDIT=true
+  - APISERVER_TEST_ARGS=--max-requests-inflight=1500 --max-mutating-requests-inflight=500
+  - (rest same as above)
+- Any important test details:
+  - A few e2es around external loadbalancer timing out due to GCE-side issues ([#52495](https://github.com/kubernetes/kubernetes/issues/52495)) - being fixed
+  - A few e2es around heapster and stackdriver logging are flaking - need stabilization
+- <job-name, run#> of the validating run (to know other specific details from the logs): https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-scale-correctness/13
+
+Misc:
+- We're seeing a performance regression in density test wrt api call latency for `delete pods` - [#51899](https://github.com/kubernetes/kubernetes/issues/51899)

--- a/releases/release-1.9/release-1.9.md
+++ b/releases/release-1.9/release-1.9.md
@@ -1,0 +1,140 @@
+# Release 1.9
+
+The 1.9 release cycle begins on Monday, October 2, 2017.
+
+* [Release Team](http://bit.ly/k8s19-team)
+* [Meeting Minutes](http://bit.ly/k8s19-minutes)
+* [Zoom](http://bit.ly/k8s19-zoom)
+* [Slack](https://kubernetes.slack.com/messages/sig-release/)
+* [Forum](https://groups.google.com/forum/#!forum/kubernetes-sig-release)
+* [Feature Tracking Sheet](http://bit.ly/k8s19-features)
+* [Milestone Process](https://github.com/kubernetes/community/blob/master/contributors/devel/release/issues.md)
+
+## Notes
+
+* There are a number of holidays plus KubeCon during Q4, so this release will
+  need to have a reduced scope in order to meet the tight schedule.
+* Features that don't have complete code and tests by [Code Freeze](#code-freeze)
+  **may be disabled by the release team** before cutting the first beta.
+* The release team will escalate [release-master-blocking](https://k8s-testgrid.appspot.com/sig-release-master-blocking)
+  failures to SIGs throughout the cycle, not just near release cuts.
+* Key deliverables (e.g. release cuts) tend to be scheduled on Wednesdays
+  to maintain context while ramping up and then responding to any problems.
+
+## Timeline
+
+* Mon Oct 2: Start of release cycle
+* **Fri Oct 27: [Feature Freeze](#feature-freeze)**
+  * All features must have tracking issues.
+* Wed Nov 1: v1.9.0-alpha.2
+* Wed Nov 15: v1.9.0-alpha.3
+* Thu Nov 16: v1.9.0-beta.0
+  * Create `release-1.9` branch and start daily `branchff`.
+  * Start setting up branch CI.
+* **Mon Nov 20: [Code Slush](#code-slush)**
+  * All PRs must be approved for the milestone to merge.
+* **Wed Nov 22: [Code Freeze](#code-freeze)**
+  * All features must be code-complete (including tests).
+  * All features must have docs PRs open.
+  * Only release-blocking bug fixes allowed after this point.
+* **Mon Nov 27: [Pruning](#pruning)**
+  * The release team may begin **disabling incomplete features** unless they've
+    been granted [exceptions](#exceptions).
+* Wed Nov 29: v1.9.0-beta.1
+  * Begin manual downgrade testing.
+* **Fri Dec 1: [Docs Deadline](#docs)**
+  * All docs PRs must be ready for review.
+* Wed Dec 6: v1.9.0-beta.2 (week of KubeCon)
+* Fri Dec 8: Docs Complete
+  * All docs PRs are LGTM and ready to merge.
+* **Mon Dec 11: End of Code Freeze**
+  * Perform final `branchff`.
+  * The `master` branch reopens for work targeting v1.10.
+  * PRs for v1.9.0 must now be cherry-picked to the `release-1.9` branch.
+* **Wed Dec 13: v1.9.0**
+* Thu Dec 14: v1.10.0-alpha.1
+* Thu Dec 21: Release retrospective (in community meeting slot)
+
+## Details
+
+### Feature Freeze
+
+All features going into the release must have an associated issue in the
+[features repo](https://github.com/kubernetes/features) by **Fri Oct 27**.
+
+SIG PM will then review features and work with other SIGs to draft release notes
+and themes.
+
+### Code Slush
+
+Starting on **Mon Nov 20**, only PRs that are [approved for the milestone](https://github.com/kubernetes/community/blob/master/contributors/devel/release/issues.md)
+will be allowed to merge into the `master` branch.
+All others will be deferred until the end of [Code Freeze](#code-freeze),
+when `master` opens back up for the next release cycle.
+
+Code Slush begins prior to Code Freeze to help reduce noise from miscellaneous
+changes that aren't related to issues that SIGs have approved for the milestone.
+Feature work is still allowed at this point, but it must follow the process to
+get approved for the milestone.
+
+#### Exceptions
+
+Starting at Code Slush, the release team will solicit and rule on
+[exception requests](https://github.com/kubernetes/features/blob/master/EXCEPTIONS.md)
+for feature and test work that is unlikely to be done by Code Freeze.
+
+### Code Freeze
+
+All features going into the release must be code-complete (*including tests*)
+and have [docs PRs](https://kubernetes.io/docs/home/contribute/create-pull-request/)
+open by **Wed Nov 22**.
+
+The docs PRs don't have to be ready to merge, but it should be clear what the
+topic will be and who's responsible for writing it.
+
+After this point, only release-blocking issues and PRs will be allowed in the
+milestone. The milestone bot will remove anything that lacks the
+`priority/critical-urgent` label.
+
+### Pruning
+
+Features that are partially implemented and/or lack sufficient tests may be
+considered for pruning beginning on **Mon Nov 27**,
+unless they've been granted [exceptions](#exceptions).
+
+The release team will work with SIGs and feature owners to evaluate each case,
+but for example, pruning could include actions such as:
+* Disabling the use of a new API or field.
+* Switching the default value of a flag or field.
+* Moving a new API or field behind an Alpha feature gate.
+* Reverting commits or deleting code.
+
+This needs to occur before the first Beta so we have time to gather signal on
+whether the system is stable in this state.
+
+Pruning is intended to be a last resort that is rarely used.
+The goal is just to make code freeze somewhat enforceable despite the lack of a
+feature branch process.
+
+### Docs
+
+If a feature needs documentation, enter `Yes` in the [feature tracking spreadsheet](https://docs.google.com/spreadsheets/d/1WmMJmqLvfIP8ERqgLtkKuE_Q2sVxX8ZrEcNxlVIJnNc/edit#gid=0) and add a link to the documentation PR. You can open documentation PRs in the [kubernetes/website](https://github.com/kubernetes/website) repository.
+
+For documentation PRs:
+- Open PRs against the `release-1.9` branch based off of the [1.9 release PR](https://github.com/kubernetes/website/pull/5978).
+
+    The documentation workflow uses feature branches for release documentation, rather than basing from master. Be sure to open your PR against the [release branch](https://github.com/kubernetes/website/pull/5978).
+
+- Add your PR to the [1.9 Release milestone](https://github.com/kubernetes/website/milestone/16).
+
+### Burndown
+
+Burndown meetings are held two or three times until the final release is near,
+and then every business day until the release.
+
+Join the [Kubernetes Milestone Burndown Group](https://groups.google.com/forum/#!forum/kubernetes-milestone-burndown)
+to get the calendar invite.
+
+* Focus on bugfix, test flakes and stabilization.
+* Ensure docs and release notes are written.
+* Identify all features going into the release, and make sure alpha, beta, ga is marked in features repo.

--- a/releases/release-1.9/release-notes-draft.md
+++ b/releases/release-1.9/release-notes-draft.md
@@ -1,0 +1,647 @@
+## 1.9 Release Notes
+
+## WARNING: etcd backup strongly recommended
+
+Before updating to 1.9, you are strongly recommended to back up your etcd data. Consult the installation procedure you are using (kargo, kops, kube-up, kube-aws, kubeadm etc) for specific advice.
+
+Some upgrade methods might upgrade etcd from 3.0 to 3.1 automatically when you upgrade from Kubernetes 1.8, unless you specify otherwise. Because [etcd does not support downgrading](https://coreos.com/etcd/docs/latest/upgrades/upgrade_3_1.html), you'll need to either remain on etcd 3.1 or restore from a backup if you want to downgrade back to Kubernetes 1.8.
+
+## Introduction to 1.9.0
+
+Kubernetes version 1.9 includes new features and enhancements, as well as fixes to identified issues. The release notes contain a brief overview of the important changes introduced in this release. The content is organized by Special Interest Group ([SIG](https://github.com/kubernetes/community/blob/master/sig-list.md)).
+
+For initial installations, see the [Setup topics](https://kubernetes.io/docs/setup/pick-right-solution/) in the Kubernetes documentation.
+
+To upgrade to this release from a previous version, first take any actions required [Before Upgrading](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.9.md#before-upgrading).
+
+For more information about this release and for the latest documentation, see the [Kubernetes documentation](https://kubernetes.io/docs/home/).
+
+## Major themes
+
+Kubernetes is developed by community members whose work is organized into
+[Special Interest Groups](https://github.com/kubernetes/community/blob/master/sig-list.md), which provide the themes that guide their work. For the 1.9 release, these themes included:
+
+### API Machinery
+
+Extensibility. SIG API Machinery added a new class of admission control webhooks (mutating), and brought the admission control webhooks to beta.
+
+### Apps
+
+The core workloads API, which is composed of the DaemonSet, Deployment, ReplicaSet, and StatefulSet kinds, has been promoted to GA stability in the apps/v1 group version. As such, the apps/v1beta2 group version is deprecated, and all new code should use the kinds in the apps/v1 group version. 
+
+### Auth
+
+SIG Auth focused on extension-related authorization improvements. Permissions can now be added to the built-in RBAC admin/edit/view roles using [cluster role aggregation](https://kubernetes.io/docs/admin/authorization/rbac/#aggregated-clusterroles). [Webhook authorizers](https://kubernetes.io/docs/admin/authorization/webhook/) can now deny requests and short-circuit checking subsequent authorizers. Performance and usability of the beta [PodSecurityPolicy](https://kubernetes.io/docs/concepts/policy/pod-security-policy/) feature was also improved.
+
+### AWS
+
+In v1.9 SIG AWS has improved stability of EBS support across the board. If a Volume is “stuck” in the attaching state to a node for too long a unschedulable taint will be applied to the node, so a Kubernetes admin can [take manual steps to correct the error](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-attaching-volume.html). Users are encouraged to ensure they are monitoring for the taint, and should consider automatically terminating instances in this state.
+
+In addition, support for NVMe disks has been added to Kubernetes, and a service of type LoadBalancer can now be backed with an NLB instead of an ELB (alpha).
+
+### Azure
+
+SIG Azure worked on improvements in the cloud provider, including significant work on the Azure Load Balancer implementation.
+
+### Cluster Lifecycle
+
+SIG Cluster Lifecycle has been focusing on improving kubeadm in order to bring it to GA in a future release, as well as developing the [Cluster API](https://github.com/kubernetes/kube-deploy/tree/master/cluster-api). For kubeadm, most new features, such as support for CoreDNS, IPv6 and Dynamic Kubelet Configuration, have gone in as alpha features. We expect to graduate these features to beta and beyond in the next release. The initial Cluster API spec and GCE sample implementation were developed from scratch during this cycle, and we look forward to stabilizing them into something production-grade during 2018.
+
+### Instrumentation
+
+In v1.9 we focused on improving stability of the components owned by the SIG, including Heapster, Custom Metrics API adapters for Prometheus, and Stackdriver.
+
+### Network
+
+In v1.9 SIG Network has implemented alpha support for IPv6, and alpha support for CoreDNS as a drop-in replacement for kube-dns. Additionally, SIG Network has begun the deprecation process for the extensions/v1beta1 NetworkPolicy API in favor of the networking.k8s.io/v1 equivalent.
+
+### Node
+
+SIG Node iterated on the ability to support more workloads with better performance and improved reliability.  Alpha features were improved around hardware accelerator support, device plugins enablement, and cpu pinning policies to enable us to graduate these features to beta in a future release.  In addition, a number of reliability and performance enhancements were made across the node to help operators in production. 
+
+### OpenStack
+
+In this cycle, SIG OpenStack focused on configuration simplification through smarter defaults and the use of auto-detection wherever feasible (Block Storage API versions, Security Groups) as well as updating API support, including:
+
+*   Block Storage (Cinder) V3 is now supported.
+*   Load Balancer (Octavia) V2 is now supported, in addition to Neutron LBaaS V2.
+*   Neutron LBaas V1 support has been removed.
+
+This work enables Kubernetes to take full advantage of the relevant services as exposed by OpenStack clouds. Refer to the [Cloud Providers](https://kubernetes.io/docs/concepts/cluster-administration/cloud-providers/#openstack) documentation for more information.
+
+### Storage
+
+[SIG Storage](https://github.com/kubernetes/community/tree/master/sig-storage) is responsible for storage and volume plugin components.
+
+For the 1.9 release, SIG Storage made Kubernetes more pluggable and modular by introducing an alpha implementation of the Container Storage Interface (CSI). CSI will make installing new volume plugins as easy as deploying a pod, and enable third-party storage providers to develop their plugins without the need to add code to the core Kubernetes codebase.
+
+The SIG also focused on adding functionality to the Kubernetes volume subsystem, such as alpha support for exposing volumes as block devices inside containers, extending the alpha volume-resizing support to more volume plugins, and topology-aware volume scheduling.
+
+### Windows
+
+We are advancing support for Windows Server and Windows Server Containers to beta along with continued feature and functional advancements on both the Kubernetes and Windows platforms. This opens the door for many Windows-specific applications and workloads to run on Kubernetes, significantly expanding the implementation scenarios and the enterprise reach of Kubernetes.
+
+## Before Upgrading 
+
+Consider the following changes, limitations, and guidelines before you upgrade:
+
+### **API Machinery**
+
+*   The admission API, which is used when the API server calls admission control webhooks, is moved from `admission.v1alpha1` to `admission.v1beta1`. You must **delete any existing webhooks before you upgrade** your cluster, and update them to use the latest API. This change is not backward compatible.
+*   The admission webhook configurations API, part of the admissionregistration API, is now at v1beta1. Delete any existing webhook configurations before you upgrade, and update your configuration files to use the latest API. For this and the previous change, see also [the documentation]([https://kubernetes.io/docs/admin/extensible-admission-controllers/#external-admission-webhooks](https://kubernetes.io/docs/admin/extensible-admission-controllers/#external-admission-webhooks)).
+*   A new `ValidatingAdmissionWebhook` is added (replacing `GenericAdmissionWebhook`) and is available in the generic API server. You must update your API server configuration file to pass the webhook to the `--admission-control` flag. ([#55988](https://github.com/kubernetes/kubernetes/pull/55988),[ @caesarxuchao](https://github.com/caesarxuchao))  ([#54513](https://github.com/kubernetes/kubernetes/pull/54513),[ @deads2k](https://github.com/deads2k))
+*   The deprecated options `--portal-net` and `--service-node-ports` for the API server are removed. ([#52547](https://github.com/kubernetes/kubernetes/pull/52547),[ @xiangpengzhao](https://github.com/xiangpengzhao))
+
+### **Auth**
+
+*   PodSecurityPolicy: A compatibility issue with the allowPrivilegeEscalation field that caused policies to start denying pods they previously allowed was fixed. If you defined PodSecurityPolicy objects using a 1.8.0 client or server and set allowPrivilegeEscalation to false, these objects must be reapplied after you upgrade. ([#53443](https://github.com/kubernetes/kubernetes/pull/53443),[ @liggitt](https://github.com/liggitt))
+*   KMS: Alpha integration with GCP KMS was removed in favor of a future out-of-process extension point. Discontinue use of the GCP KMS integration and ensure [data has been decrypted](https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/#decrypting-all-data) (or reencrypted with a different provider) before upgrading ([#54759](https://github.com/kubernetes/kubernetes/pull/54759),[ @sakshamsharma](https://github.com/sakshamsharma))
+
+### **CLI**
+
+*   Swagger 1.2 validation is removed for kubectl. The options `--use-openapi` and `--schema-cache-dir` are also removed because they are no longer needed. ([#53232](https://github.com/kubernetes/kubernetes/pull/53232),[ @apelisse](https://github.com/apelisse))
+
+### **Cluster Lifecycle**
+
+*   You must either specify the `--discovery-token-ca-cert-hash` flag to `kubeadm join`, or opt out of the CA pinning feature using `--discovery-token-unsafe-skip-ca-verification`.
+*   The default `auto-detect` behavior of the kubelet's `--cloud-provider` flag is removed.
+    *   You can manually set `--cloud-provider=auto-detect`, but be aware that this behavior will be removed completely in a future version.
+    *   Best practice for version 1.9 and future versions is to explicitly set a cloud-provider. See [the documentation](https://kubernetes.io/docs/getting-started-guides/scratch/#cloud-providers)
+*   The kubeadm `--skip-preflight-checks` flag is now deprecated and will be removed in a future release.
+*   If you are using the cloud provider API to determine the external host address of the apiserver, set `--external-hostname` explicitly instead. The cloud provider detection has been deprecated and will be removed in the future ([#54516](https://github.com/kubernetes/kubernetes/pull/54516),[ @dims](https://github.com/dims))
+
+### **Multicluster**
+
+*   Development of Kubernetes Federation has moved to [github.com/kubernetes/federation](github.com/kubernetes/federation). This move out of tree also means that Federation will begin releasing separately from Kubernetes. Impact: 
+    *   Federation-specific behavior will no longer be included in kubectl
+    *   kubefed will no longer be released as part of Kubernetes
+    *   The Federation servers will no longer be included in the hyperkube binary and image. ([#53816](https://github.com/kubernetes/kubernetes/pull/53816),[ @marun](https://github.com/marun))
+
+### **Node**
+
+*   The kubelet `--network-plugin-dir` flag is removed. This flag was deprecated in version 1.7, and is replaced with `--cni-bin-dir`. ([#53564](https://github.com/kubernetes/kubernetes/pull/53564),[ @supereagle](https://github.com/supereagle))
+*   kubelet's `--cloud-provider` flag no longer defaults to "auto-detect". If you want cloud-provider support in kubelet, you must set a specific cloud-provider explicitly. ([#53573](https://github.com/kubernetes/kubernetes/pull/53573),[ @dims](https://github.com/dims))
+
+### **Network**
+
+*   NetworkPolicy objects are now stored in etcd in v1 format. After you upgrade to version 1.9, make sure that all NetworkPolicy objects are migrated to v1. ([#51955](https://github.com/kubernetes/kubernetes/pull/51955), [@danwinship](https://github.com/danwinship))
+*   The API group/version for the kube-proxy configuration has changed from `componentconfig/v1alpha1` to `kubeproxy.config.k8s.io/v1alpha1`. If you are using a config file for kube-proxy instead of the command line flags, you must change its apiVersion to `kubeproxy.config.k8s.io/v1alpha1`. ([#53645](https://github.com/kubernetes/kubernetes/pull/53645), [@xiangpengzhao](https://github.com/xiangpengzhao))
+*   The "ServiceNodeExclusion" feature gate must now be enabled for the `alpha.service-controller.kubernetes.io/exclude-balancer` annotation on nodes to be honored. ([#54644](https://github.com/kubernetes/kubernetes/pull/54644),[ @brendandburns](https://github.com/brendandburns))
+
+### **Scheduling**
+
+*   Taint key `unreachable` is now in GA.
+*   Taint key `notReady` is changed to `not-ready`, and is also now in GA.
+*   These changes are automatically updated for taints. Tolerations for these taints must be updated manually. Specifically, you must:
+    *   Change `node.alpha.kubernetes.io/notReady` to `node.kubernetes.io/not-ready`
+    *   Change `node.alpha.kubernetes.io/unreachable` to  `node.kubernetes.io/unreachable`
+*   The `node.kubernetes.io/memory-pressure` taint now respects the configured whitelist.  To use it, you must add it to the whitelist.([#55251](https://github.com/kubernetes/kubernetes/pull/55251),[ @deads2k](https://github.com/deads2k))
+*   Refactor kube-scheduler configuration ([#52428](https://github.com/kubernetes/kubernetes/pull/52428))
+    *   The kube-scheduler command now supports a --config flag which is the location of a file containing a serialized scheduler configuration. Most other kube-scheduler flags are now deprecated. ([#52562](https://github.com/kubernetes/kubernetes/pull/52562),[ @ironcladlou](https://github.com/ironcladlou))
+*   Opaque integer resources (OIR), which were (deprecated in v1.8.), have been removed. ([#55103](https://github.com/kubernetes/kubernetes/pull/55103),[ @ConnorDoyle](https://github.com/ConnorDoyle))
+
+### **Storage**
+
+*   [alpha] The LocalPersistentVolumes alpha feature now also requires the VolumeScheduling alpha feature.  This is a breaking change, and the following changes are required: 
+    *   The VolumeScheduling feature gate must also be enabled on kube-scheduler and kube-controller-manager components.
+    *   The NoVolumeNodeConflict predicate has been removed.  For non-default schedulers, update your scheduler policy.
+    *   The CheckVolumeBinding predicate must be enabled in non-default schedulers. ([#55039](https://github.com/kubernetes/kubernetes/pull/55039),[ @msau42](https://github.com/msau42))
+
+### **OpenStack**
+
+*   Remove the LbaasV1 of OpenStack cloud provider, currently only support LbaasV2. ([#52717](https://github.com/kubernetes/kubernetes/pull/52717),[ @FengyunPan](https://github.com/FengyunPan))
+
+## Known Issues
+
+This section contains a list of known issues reported in Kubernetes 1.9 release. The content is populated from the [v1.9.x known issues and FAQ accumulator](https://github.com/kubernetes/kubernetes/issues/57159](https://github.com/kubernetes/kubernetes/issues/57159).
+
+*   If you are adding Windows Server Virtual Machines as nodes to your Kubernetes environment, there is a compatibility issue with certain virtualization products. Specifically the Windows version of the kubelet.exe calls `GetPhysicallyInstalledSystemMemory` to get the physical memory installed on Windows machines and reports it as part of node metrics to heapster. This API call fails for VMware and VirtualBox virtualization environments. This issue is not present in bare metal Windows deployments, in Hyper-V, or on some of the popular public cloud providers.
+
+*   If you run `kubectl get po` while the API server in unreachable, a misleading error is returned: `the server doesn't have a resource type "po"`. To work around this issue, specify the full resource name in the command instead of the abbreviation: `kubectl get pods`. This issue will be fixed in a future release.
+
+  For more information, see [#57198](https://github.com/kubernetes/kubernetes/issues/57198).
+
+*   Mutating and validating webhook configurations are continuously polled by the API server (once per second). This issue will be fixed in a future release.
+
+  For more information, see [#56357](https://github.com/kubernetes/kubernetes/issues/56357).
+
+*   Audit logging is slow because writes to the log are performed synchronously with requests to the log. This issue will be fixed in a future release.
+
+  For more information, see [#53006](https://github.com/kubernetes/kubernetes/issues/53006).
+
+*   Custom Resource Definitions (CRDs) are not properly deleted under certain conditions. This issue will be fixed in a future release.
+
+  For more information, see [#56348](https://github.com/kubernetes/kubernetes/issues/56348).
+
+*   API server times out after performing a rolling update of the etcd cluster. This issue will be fixed in a future release.
+
+  For more information, see [#47131](https://github.com/kubernetes/kubernetes/issues/47131)
+
+*   If a namespaced resource is owned by a cluster scoped resource, and the namespaced dependent is processed before the cluster scoped owner has ever been observed by the garbage collector, the dependent will be erroneously deleted.
+
+  For more information, see [#54940](https://github.com/kubernetes/kubernetes/issues/54940)
+
+## Deprecations
+
+This section provides an overview of deprecated API versions, options, flags, and arguments. Deprecated means that we intend to remove the capability from a future release. After removal, the capability will no longer work. The sections are organized by SIGs.
+
+### **API Machinery**
+
+*   The kube-apiserver `--etcd-quorum-read` flag is deprecated and the ability to switch off quorum read will be removed in a future release. ([#53795](https://github.com/kubernetes/kubernetes/pull/53795),[ @xiangpengzhao](https://github.com/xiangpengzhao))
+*   The `/ui` redirect in kube-apiserver is deprecated and will be removed in Kubernetes 1.10. ([#53046](https://github.com/kubernetes/kubernetes/pull/53046), [@maciaszczykm](https://github.com/maciaszczykm))
+*   `etcd2` as a backend is deprecated and support will be removed in Kubernetes 1.13 or 1.14.
+
+### **Auth**
+
+*   Default controller-manager options for `--cluster-signing-cert-file` and `--cluster-signing-key-file` are deprecated and will be removed in a future release. ([#54495](https://github.com/kubernetes/kubernetes/pull/54495),[ @mikedanese](https://github.com/mikedanese))
+*   RBAC objects are now stored in etcd in v1 format. After upgrading to 1.9, ensure all RBAC objects (Roles, RoleBindings, ClusterRoles, ClusterRoleBindings) are at v1. v1alpha1 support is deprecated and will be removed in a future release. ([#52950](https://github.com/kubernetes/kubernetes/pull/52950),[ @liggitt](https://github.com/liggitt))
+
+### **Cluster Lifecycle**
+
+*   kube-apiserver: `--ssh-user` and `--ssh-keyfile` are now deprecated and will be removed in a future release. Users of SSH tunnel functionality in Google Container Engine for the Master -> Cluster communication should plan alternate methods for bridging master and node networks. ([#54433](https://github.com/kubernetes/kubernetes/pull/54433),[ @dims](https://github.com/dims))
+*   The kubeadm `--skip-preflight-checks` flag is now deprecated and will be removed in a future release.
+*   If you are using the cloud provider API to determine the external host address of the apiserver, set `--external-hostname` explicitly instead. The cloud provider detection has been deprecated and will be removed in the future ([#54516](https://github.com/kubernetes/kubernetes/pull/54516),[ @dims](https://github.com/dims))
+
+### **Network**
+
+*   The NetworkPolicy extensions/v1beta1 API is now deprecated and will be removed in a future release. This functionality has been migrated to a dedicated v1 API - networking.k8s.io/v1. v1beta1 Network Policies can be upgraded to the v1 API with the [cluster/update-storage-objects.sh script](https://github.com/danwinship/kubernetes/blob/master/cluster/update-storage-objects.sh). Documentation can be found [here](https://kubernetes.io/docs/concepts/services-networking/network-policies/). ([#56425](https://github.com/kubernetes/kubernetes/pull/56425), [@cmluciano](https://github.com/cmluciano))
+
+### **Storage**
+
+*   The `volume.beta.kubernetes.io/storage-class` annotation is deprecated. It will be removed in a future release. For the StorageClass API object, use v1, and in place of the annotation use `v1.PersistentVolumeClaim.Spec.StorageClassName` and `v1.PersistentVolume.Spec.StorageClassName` instead. ([#53580](https://github.com/kubernetes/kubernetes/pull/53580),[ @xiangpengzhao](https://github.com/xiangpengzhao))
+
+### **Scheduling**
+
+*   The kube-scheduler command now supports a `--config` flag, which is the location of a file containing a serialized scheduler configuration. Most other kube-scheduler flags are now deprecated. ([#52562](https://github.com/kubernetes/kubernetes/pull/52562),[ @ironcladlou](https://github.com/ironcladlou))
+
+### **Node**
+
+*   The kubelet's `--enable-custom-metrics` flag is now deprecated. ([#54154](https://github.com/kubernetes/kubernetes/pull/54154),[ @mtaufen](https://github.com/mtaufen))
+
+## Notable Changes
+
+### **Workloads API (apps/v1)**
+
+As announced with the release of version 1.8, the Kubernetes Workloads API is at v1 in version 1.9. This API consists of the DaemonSet, Deployment, ReplicaSet and StatefulSet kinds.
+
+### **API Machinery**
+
+#### **Admission Control**
+
+*   Admission webhooks are now in beta, and include the following:
+    *   Mutation support for admission webhooks. ([#54892](https://github.com/kubernetes/kubernetes/pull/54892),[ @caesarxuchao](https://github.com/caesarxuchao))
+    *   Webhook admission now takes a config file that describes how to authenticate to webhook servers ([#54414](https://github.com/kubernetes/kubernetes/pull/54414),[ @deads2k](https://github.com/deads2k))
+    *   The dynamic admission webhook now supports a URL in addition to a service reference, to accommodate out-of-cluster webhooks. ([#54889](https://github.com/kubernetes/kubernetes/pull/54889),[ @lavalamp](https://github.com/lavalamp))
+    *   Added `namespaceSelector` to `externalAdmissionWebhook` configuration to allow applying webhooks only to objects in the namespaces that have matching labels. ([#54727](https://github.com/kubernetes/kubernetes/pull/54727),[ @caesarxuchao](https://github.com/caesarxuchao))
+*   Metrics are added for monitoring admission plugins, including the new dynamic (webhook-based) ones. ([#55183](https://github.com/kubernetes/kubernetes/pull/55183),[ @jpbetz](https://github.com/jpbetz))
+*   The PodSecurityPolicy annotation kubernetes.io/psp on pods is set only once on create. ([#55486](https://github.com/kubernetes/kubernetes/pull/55486),[ @sttts](https://github.com/sttts))
+
+#### **API & API server**
+
+*   Fixed a bug related to discovery information for scale subresources in the apps API group ([#54683](https://github.com/kubernetes/kubernetes/pull/54683),[ @liggitt](https://github.com/liggitt))
+*   Fixed a bug that prevented client-go metrics from being registered in Prometheus. This bug affected multiple components. ([#53434](https://github.com/kubernetes/kubernetes/pull/53434),[ @crassirostris](https://github.com/crassirostris))
+
+#### **Audit**
+
+*   Fixed a bug so that `kube-apiserver` now waits for open connections to finish before exiting. This fix provides graceful shutdown and ensures that the audit backend no longer drops events on shutdown. ([#53695](https://github.com/kubernetes/kubernetes/pull/53695),[ @hzxuzhonghu](https://github.com/hzxuzhonghu))
+*   Webhooks now always retry sending if a connection reset error is returned. ([#53947](https://github.com/kubernetes/kubernetes/pull/53947),[ @crassirostris](https://github.com/crassirostris))
+
+#### **Custom Resources**
+
+*   Validation of resources defined by a Custom Resource Definition (CRD) is now in beta ([#54647](https://github.com/kubernetes/kubernetes/pull/54647),[ @colemickens](https://github.com/colemickens))
+*   An example CRD controller has been added, at [github.com/kubernetes/sample-controller](github.com/kubernetes/sample-controller). ([#52753](https://github.com/kubernetes/kubernetes/pull/52753),[ @munnerz](https://github.com/munnerz))
+*   Custom resources served by CustomResourceDefinition objects now support field selectors for `metadata.name` and `metadata.namespace`. Also fixed an issue with watching a single object; earlier versions could watch only a collection, and so a watch on an instance would fail.  ([#53345](https://github.com/kubernetes/kubernetes/pull/53345),[ @ncdc](https://github.com/ncdc))
+
+#### **Other**
+
+*   `kube-apiserver` now runs with the default value for `service-cluster-ip-range` ([#52870](https://github.com/kubernetes/kubernetes/pull/52870),[ @jennybuckley](https://github.com/jennybuckley))
+*   Add `--etcd-compaction-interval` to apiserver for controlling request of compaction to etcd3 from apiserver. ([#51765](https://github.com/kubernetes/kubernetes/pull/51765),[ @mitake](https://github.com/mitake))
+*   The httpstream/spdy calls now support CIDR notation for NO_PROXY ([#54413](https://github.com/kubernetes/kubernetes/pull/54413),[ @kad](https://github.com/kad))
+*   Code generation for CRD and User API server types is improved with the addition of two new scripts to k8s.io/code-generator: `generate-groups.sh` and `generate-internal-groups.sh`. ([#52186](https://github.com/kubernetes/kubernetes/pull/52186),[ @sttts](https://github.com/sttts))
+*   [beta] Flag `--chunk-size={SIZE}` is added to `kubectl get` to customize the number of results returned in large lists of resources. This reduces the perceived latency of managing large clusters because the server returns the first set of results to the client much more quickly. Pass 0 to disable this feature.([#53768](https://github.com/kubernetes/kubernetes/pull/53768),[ @smarterclayton](https://github.com/smarterclayton))
+*   [beta] API chunking via the limit and continue request parameters is promoted to beta in this release. Client libraries using the Informer or ListWatch types will automatically opt in to chunking. ([#52949](https://github.com/kubernetes/kubernetes/pull/52949),[ @smarterclayton](https://github.com/smarterclayton))
+*   The `--etcd-quorum-read` flag now defaults to true to ensure correct operation with HA etcd clusters. This flag is deprecated and the flag will be removed in future versions, as well as the ability to turn off this functionality. ([#53717](https://github.com/kubernetes/kubernetes/pull/53717),[ @liggitt](https://github.com/liggitt))
+*   Add events.k8s.io api group with v1beta1 API containing redesigned event type. ([#49112](https://github.com/kubernetes/kubernetes/pull/49112),[ @gmarek](https://github.com/gmarek))
+*   Fixed a bug where API discovery failures were crashing the kube controller manager via the garbage collector. ([#55259](https://github.com/kubernetes/kubernetes/pull/55259),[ @ironcladlou](https://github.com/ironcladlou))
+*   `conversion-gen` is now usable in a context without a vendored k8s.io/kubernetes. The Kubernetes core API is removed from `default extra-peer-dirs`. ([#54394](https://github.com/kubernetes/kubernetes/pull/54394),[ @sttts](https://github.com/sttts))
+*   Fixed a bug where the `client-gen` tag for code-generator required a newline between a comment block and a statement.  tag shortcomings when newline is omitted ([#53893](https://github.com/kubernetes/kubernetes/pull/53893)) ([#55233](https://github.com/kubernetes/kubernetes/pull/55233),[ @sttts](https://github.com/sttts))
+*   The Apiserver proxy now rewrites the URL when a service returns an absolute path with the request's host. ([#52556](https://github.com/kubernetes/kubernetes/pull/52556),[ @roycaihw](https://github.com/roycaihw))
+*   The gRPC library is updated to pick up data race fix ([#53124](https://github.com/kubernetes/kubernetes/pull/53124)) ([#53128](https://github.com/kubernetes/kubernetes/pull/53128),[ @dixudx](https://github.com/dixudx))
+*   Fixed server name verification of aggregated API servers and webhook admission endpoints ([#56415](https://github.com/kubernetes/kubernetes/pull/56415),[ @liggitt](https://github.com/liggitt))
+
+### **Apps**
+
+*   The `kubernetes.io/created-by` annotation is no longer added to controller-created objects. Use the `metadata.ownerReferences` item with controller set to `true` to determine which controller, if any, owns an object. ([#54445](https://github.com/kubernetes/kubernetes/pull/54445),[ @crimsonfaith91](https://github.com/crimsonfaith91))
+*   StatefulSet controller now creates a label for each Pod in a StatefulSet. The label is `statefulset.kubernetes.io/pod-name`, where `pod-name` = the name of the Pod. This allows users to create a Service per Pod to expose a connection to individual Pods. ([#55329](https://github.com/kubernetes/kubernetes/pull/55329),[ @kow3ns](https://github.com/kow3ns))
+*   DaemonSet status includes a new field named `conditions`, making it consistent with other workloads controllers. ([#55272](https://github.com/kubernetes/kubernetes/pull/55272),[ @janetkuo](https://github.com/janetkuo))
+*   StatefulSet status now supports conditions, making it consistent with other core controllers in v1 ([#55268](https://github.com/kubernetes/kubernetes/pull/55268),[ @foxish](https://github.com/foxish))
+*   The default garbage collection policy for Deployment, DaemonSet, StatefulSet, and ReplicaSet has changed from OrphanDependents to DeleteDependents when the deletion is requested through an `apps/v1` endpoint.  ([#55148](https://github.com/kubernetes/kubernetes/pull/55148),[ @dixudx](https://github.com/dixudx))
+    *   Clients using older endpoints will be unaffected. This change is only at the REST API level and is independent of the default behavior of particular clients (e.g. this does not affect the default for the kubectl `--cascade` flag).
+    *   If you upgrade your client-go libs and use the `AppsV1()` interface, please note that the default garbage collection behavior is changed.
+
+### **Auth**
+
+#### **Audit**
+
+*   RequestReceivedTimestamp and StageTimestamp are added to audit events ([#52981](https://github.com/kubernetes/kubernetes/pull/52981),[ @CaoShuFeng](https://github.com/CaoShuFeng))
+*   Advanced audit policy now supports a policy wide omitStage ([#54634](https://github.com/kubernetes/kubernetes/pull/54634),[ @CaoShuFeng](https://github.com/CaoShuFeng))
+
+#### **RBAC**
+
+*   New permissions have been added to default RBAC roles ([#52654](https://github.com/kubernetes/kubernetes/pull/52654),[ @liggitt](https://github.com/liggitt)):
+    *   The default admin and edit roles now include read/write permissions
+    *   The view role includes read permissions on poddisruptionbudget.policy resources. 
+*   RBAC rules can now match the same subresource on any resource using the form `*/(subresource)`. For example, `*/scale` matches requests to `replicationcontroller/scale`. ([#53722](https://github.com/kubernetes/kubernetes/pull/53722),[ @deads2k](https://github.com/deads2k))
+*   The RBAC bootstrapping policy now allows authenticated users to create selfsubjectrulesreviews. ([#56095](https://github.com/kubernetes/kubernetes/pull/56095),[ @ericchiang](https://github.com/ericchiang))
+*   RBAC ClusterRoles can now select other roles to aggregate. ([#54005](https://github.com/kubernetes/kubernetes/pull/54005),[ @deads2k](https://github.com/deads2k))
+*   Fixed an issue with RBAC reconciliation that caused duplicated subjects in some bootstrapped RoleBinding objects on each restart of the API server. ([#53239](https://github.com/kubernetes/kubernetes/pull/53239),[ @enj](https://github.com/enj))
+
+#### **Other**
+
+*   Pod Security Policy can now manage access to specific FlexVolume drivers ([#53179](https://github.com/kubernetes/kubernetes/pull/53179),[ @wanghaoran1988](https://github.com/wanghaoran1988))
+*   Audit policy files without apiVersion and kind are treated as invalid. ([#54267](https://github.com/kubernetes/kubernetes/pull/54267),[ @ericchiang](https://github.com/ericchiang))
+*   Fixed a bug that where forbidden errors were encountered when accessing ReplicaSet and DaemonSets objects via the apps API group. ([#54309](https://github.com/kubernetes/kubernetes/pull/54309),[ @liggitt](https://github.com/liggitt))
+*   Improved PodSecurityPolicy admission latency. ([#55643](https://github.com/kubernetes/kubernetes/pull/55643),[ @tallclair](https://github.com/tallclair))
+*   kube-apiserver: `--oidc-username-prefix` and `--oidc-group-prefix` flags are now correctly enabled. ([#56175](https://github.com/kubernetes/kubernetes/pull/56175),[ @ericchiang](https://github.com/ericchiang))
+*   If multiple PodSecurityPolicy objects allow a submitted pod, priority is given to policies that do not require default values for any fields in the pod spec. If default values are required, the first policy ordered by name that allows the pod is used. ([#52849](https://github.com/kubernetes/kubernetes/pull/52849),[ @liggitt](https://github.com/liggitt))
+*   A new controller automatically cleans up Certificate Signing Requests that are Approved and Issued, or Denied. ([#51840](https://github.com/kubernetes/kubernetes/pull/51840),[ @jcbsmpsn](https://github.com/jcbsmpsn))
+*   PodSecurityPolicies have been added for all in-tree cluster addons ([#55509](https://github.com/kubernetes/kubernetes/pull/55509),[ @tallclair](https://github.com/tallclair))
+
+#### **GCE**
+
+*   Added support for PodSecurityPolicy on GCE: `ENABLE_POD_SECURITY_POLICY=true` enables the admission controller, and installs policies for default addons. ([#52367](https://github.com/kubernetes/kubernetes/pull/52367),[ @tallclair](https://github.com/tallclair))
+
+### **Autoscaling**
+
+*   HorizontalPodAutoscaler objects now properly functions on scalable resources in any API group. Fixed by adding a polymorphic scale client. ([#53743](https://github.com/kubernetes/kubernetes/pull/53743),[ @DirectXMan12](https://github.com/DirectXMan12))
+*   Fixed a set of minor issues with Cluster Autoscaler 1.0.1 ([#54298](https://github.com/kubernetes/kubernetes/pull/54298),[ @mwielgus](https://github.com/mwielgus))
+*   HPA tolerance is now configurable by setting the `horizontal-pod-autoscaler-tolerance` flag. ([#52275](https://github.com/kubernetes/kubernetes/pull/52275),[ @mattjmcnaughton](https://github.com/mattjmcnaughton))
+*   Fixed a bug that allowed the horizontal pod autoscaler to allocate more `desiredReplica` objects than `maxReplica` objects in certain instances. ([#53690](https://github.com/kubernetes/kubernetes/pull/53690),[ @mattjmcnaughton](https://github.com/mattjmcnaughton))
+
+### **AWS**
+
+*   Nodes can now use instance types (such as C5) that use NVMe. ([#56607](https://github.com/kubernetes/kubernetes/pull/56607), [@justinsb](https://github.com/justinsb))
+*   Nodes are now unreachable if volumes are stuck in the attaching state. Implemented by applying a taint to the node. ([#55558](https://github.com/kubernetes/kubernetes/pull/55558),[ @gnufied](https://github.com/gnufied))
+*   Volumes are now checked for available state before attempting to attach or delete a volume in EBS. ([#55008](https://github.com/kubernetes/kubernetes/pull/55008),[ @gnufied](https://github.com/gnufied))
+*   Fixed a bug where error log messages were breaking into two lines. ([#49826](https://github.com/kubernetes/kubernetes/pull/49826),[ @dixudx](https://github.com/dixudx))
+*   Fixed a bug so that volumes are now detached from stopped nodes. ([#55893](https://github.com/kubernetes/kubernetes/pull/55893),[ @gnufied](https://github.com/gnufied))
+*   You can now override the health check parameters for AWS ELBs by specifying annotations on the corresponding service. The new annotations are: `healthy-threshold`, `unhealthy-threshold`, `timeout`, `interval`. The prefix for all annotations is  `service.beta.kubernetes.io/aws-load-balancer-healthcheck-`. ([#56024](https://github.com/kubernetes/kubernetes/pull/56024),[ @dimpavloff](https://github.com/dimpavloff))
+*   Fixed a bug so that AWS ECR credentials are now supported in the China region. ([#50108](https://github.com/kubernetes/kubernetes/pull/50108),[ @zzq889](https://github.com/zzq889))
+*   Added Amazon NLB support ([#53400](https://github.com/kubernetes/kubernetes/pull/53400),[ @micahhausler](https://github.com/micahhausler))
+*   Additional annotations are now properly set or updated  for AWS load balancers ([#55731](https://github.com/kubernetes/kubernetes/pull/55731),[ @georgebuckerfield](https://github.com/georgebuckerfield))
+*   AWS SDK is updated to version 1.12.7 ([#53561](https://github.com/kubernetes/kubernetes/pull/53561),[ @justinsb](https://github.com/justinsb))
+
+### **Azure**
+
+*   Fixed several issues with properly provisioning Azure disk storage ([#55927](https://github.com/kubernetes/kubernetes/pull/55927),[ @andyzhangx](https://github.com/andyzhangx))
+*   A new service annotation `service.beta.kubernetes.io/azure-dns-label-name` now sets the Azure DNS label for a public IP address. ([#47849](https://github.com/kubernetes/kubernetes/pull/47849),[ @tomerf](https://github.com/tomerf))
+*   Support for GetMountRefs function added; warning messages no longer displayed. ([#54670](https://github.com/kubernetes/kubernetes/pull/54670), [#52401](https://github.com/kubernetes/kubernetes/pull/52401),[ @andyzhangx](https://github.com/andyzhangx))
+*   Fixed an issue where an Azure PersistentVolume object would crash because the value of `volumeSource.ReadOnly` was set to nil. ([#54607](https://github.com/kubernetes/kubernetes/pull/54607),[ @andyzhangx](https://github.com/andyzhangx))
+*   Fixed an issue with Azure disk mount failures on CoreOS and some other distros ([#54334](https://github.com/kubernetes/kubernetes/pull/54334),[ @andyzhangx](https://github.com/andyzhangx))
+*   GRS, RAGRS storage account types are now supported for Azure disks. ([#55931](https://github.com/kubernetes/kubernetes/pull/55931),[ @andyzhangx](https://github.com/andyzhangx))
+*   Azure NSG rules are now restricted so that external access is allowed only to the load balancer IP. ([#54177](https://github.com/kubernetes/kubernetes/pull/54177),[ @itowlson](https://github.com/itowlson))
+*   Azure NSG rules can be consolidated to reduce the likelihood of hitting Azure resource limits (available only in regions where the Augmented Security Groups preview is available).  ([#55740](https://github.com/kubernetes/kubernetes/pull/55740), [@itowlson](https://github.com/itowlson))
+*   The Azure SDK is upgraded to v11.1.1. ([#54971](https://github.com/kubernetes/kubernetes/pull/54971),[ @itowlson](https://github.com/itowlson))
+*   You can now create Windows mount paths  ([#51240](https://github.com/kubernetes/kubernetes/pull/51240),[ @andyzhangx](https://github.com/andyzhangx))
+*   Fixed a controller manager crash issue on a manually created k8s cluster. ([#53694](https://github.com/kubernetes/kubernetes/pull/53694),[ @andyzhangx](https://github.com/andyzhangx))
+*   Azure-based clusters now support unlimited mount points. ([#54668](https://github.com/kubernetes/kubernetes/pull/54668)) ([#53629](https://github.com/kubernetes/kubernetes/pull/53629),[ @andyzhangx](https://github.com/andyzhangx))
+*   Load balancer reconciliation now considers NSG rules based not only on Name, but also on Protocol, SourcePortRange, DestinationPortRange, SourceAddressPrefix, DestinationAddressPrefix, Access, and Direction. This change makes it possible to update NSG rules under more conditions.  ([#55752](https://github.com/kubernetes/kubernetes/pull/55752),[ @kevinkim9264](https://github.com/kevinkim9264))
+*   Custom mountOptions for the azurefile StorageClass object are now respected. Specifically, `dir_mode` and `file_mode` can now be customized. ([#54674](https://github.com/kubernetes/kubernetes/pull/54674),[ @andyzhangx](https://github.com/andyzhangx))
+*   Azure Load Balancer Auto Mode: Services can be annotated to allow auto selection of available load balancers and to provide specific availability sets that host the load balancers (for example, `service.beta.kubernetes.io/azure-load-balancer-mode=auto|as1,as2...`)
+
+### **CLI**
+
+#### **Kubectl**
+
+*   `kubectl cp` can now copy a remote file into a local directory. ([#46762](https://github.com/kubernetes/kubernetes/pull/46762),[ @bruceauyeung](https://github.com/bruceauyeung))
+*   `kubectl cp` now honors destination names for directories. A complete directory is now copied; in previous versions only the file contents were copied. ([#51215](https://github.com/kubernetes/kubernetes/pull/51215),[ @juanvallejo](https://github.com/juanvallejo))
+*   You can now use `kubectl get` with a fieldSelector. ([#50140](https://github.com/kubernetes/kubernetes/pull/50140),[ @dixudx](https://github.com/dixudx))
+*   Secret data containing Docker registry auth objects is now generated using the config.json format ([#53916](https://github.com/kubernetes/kubernetes/pull/53916),[ @juanvallejo](https://github.com/juanvallejo))
+*   `kubectl apply` now calculates the diff between the current and new configurations based on the OpenAPI spec. If the OpenAPI spec is not available, it falls back to baked-in types. ([#51321](https://github.com/kubernetes/kubernetes/pull/51321),[ @mengqiy](https://github.com/mengqiy))
+*   `kubectl explain` now explains `apiservices` and `customresourcedefinition`. (Updated to use OpenAPI instead of Swagger 1.2.) ([#53228](https://github.com/kubernetes/kubernetes/pull/53228),[ @apelisse](https://github.com/apelisse))
+*   `kubectl get` now uses OpenAPI schema extensions by default to select columns for custom types. ([#53483](https://github.com/kubernetes/kubernetes/pull/53483),[ @apelisse](https://github.com/apelisse))
+*   kubectl `top node` now sorts by name and `top pod` sorts by namespace. Fixed a bug where results were inconsistently sorted. ([#53560](https://github.com/kubernetes/kubernetes/pull/53560),[ @dixudx](https://github.com/dixudx))
+*   Added --dry-run option to kubectl drain. ([#52440](https://github.com/kubernetes/kubernetes/pull/52440),[ @juanvallejo](https://github.com/juanvallejo))
+*   Kubectl now outputs <none> for columns specified by -o custom-columns but not found in object, rather than "xxx is not found" ([#51750](https://github.com/kubernetes/kubernetes/pull/51750),[ @jianhuiz](https://github.com/jianhuiz))
+*   `kubectl create pdb` no longer sets the min-available field by default. ([#53047](https://github.com/kubernetes/kubernetes/pull/53047),[ @yuexiao-wang](https://github.com/yuexiao-wang))
+*   The canonical pronunciation of kubectl is "cube control".
+*   Added --raw to kubectl create to POST using the normal transport. ([#54245](https://github.com/kubernetes/kubernetes/pull/54245),[ @deads2k](https://github.com/deads2k))
+*   Added kubectl `create priorityclass` subcommand ([#54858](https://github.com/kubernetes/kubernetes/pull/54858),[ @wackxu](https://github.com/wackxu))
+*   Fixed an issue where `kubectl set` commands occasionally encountered conversion errors for ReplicaSet and DaemonSet objects ([#53158](https://github.com/kubernetes/kubernetes/pull/53158),[ @liggitt](https://github.com/liggitt))
+
+### **Cluster Lifecycle**
+
+#### **API Server**
+
+*   [alpha] Added an `--endpoint-reconciler-type` command-line argument to select the endpoint reconciler to use. The default is to use the 'master-count' reconciler which is the default for 1.9 and in use prior to 1.9. The 'lease' reconciler stores endpoints within the storage api for better cleanup of deleted (or removed) API servers. The 'none' reconciler is a no-op reconciler, which can be used in self-hosted environments.   ([#51698](https://github.com/kubernetes/kubernetes/pull/51698), [@rphillips](https://github.com/rphillips))
+
+#### **Cloud Provider Integration**
+
+*   Added `cloud-controller-manager` to `hyperkube`. This is useful as a number of deployment tools run all of the kubernetes components from the `hyperkube `image/binary. It also makes testing easier as a single binary/image can be built and pushed quickly.  ([#54197](https://github.com/kubernetes/kubernetes/pull/54197),[ @colemickens](https://github.com/colemickens))
+*   Added the concurrent service sync flag to the Cloud Controller Manager to allow changing the number of workers. (`--concurrent-service-syncs`) ([#55561](https://github.com/kubernetes/kubernetes/pull/55561),[ @jhorwit2](https://github.com/jhorwit2))
+*   kubelet's --cloud-provider flag no longer defaults to "auto-detect". If you want cloud-provider support in kubelet, you must set a specific cloud-provider explicitly. ([#53573](https://github.com/kubernetes/kubernetes/pull/53573),[ @dims](https://github.com/dims))
+
+#### **Kubeadm**
+
+*   kubeadm health checks can now be skipped with `--ignore-preflight-errors`; the `--skip-preflight-checks` flag is now deprecated and will be removed in a future release. ([#56130](https://github.com/kubernetes/kubernetes/pull/56130),[ @anguslees](https://github.com/anguslees)) ([#56072](https://github.com/kubernetes/kubernetes/pull/56072),[ @kad](https://github.com/kad))
+*   You now have the option to use CoreDNS instead of KubeDNS. To install CoreDNS instead of kube-dns, set CLUSTER_DNS_CORE_DNS to 'true'. This support is experimental. ([#52501](https://github.com/kubernetes/kubernetes/pull/52501),[ @rajansandeep](https://github.com/rajansandeep)) ([#55728](https://github.com/kubernetes/kubernetes/pull/55728),[ @rajansandeep](https://github.com/rajansandeep))
+*   Added --print-join-command flag for kubeadm token create. ([#56185](https://github.com/kubernetes/kubernetes/pull/56185),[ @mattmoyer](https://github.com/mattmoyer))
+*   Added a new --etcd-upgrade keyword to kubeadm upgrade apply. When this keyword is specified, etcd's static pod gets upgraded to the etcd version officially recommended for a target kubernetes release. ([#55010](https://github.com/kubernetes/kubernetes/pull/55010),[ @sbezverk](https://github.com/sbezverk))
+*   Kubeadm now supports Kubelet Dynamic Configuration on an alpha level. ([#55803](https://github.com/kubernetes/kubernetes/pull/55803),[ @xiangpengzhao](https://github.com/xiangpengzhao))
+*   Added support for adding a Windows node ([#53553](https://github.com/kubernetes/kubernetes/pull/53553),[ @bsteciuk](https://github.com/bsteciuk))
+
+#### **Juju**
+
+*   Added support for SAN entries in the master node certificate. ([#54234](https://github.com/kubernetes/kubernetes/pull/54234),[ @hyperbolic2346](https://github.com/hyperbolic2346))
+*   Add extra-args configs for scheduler and controller-manager to kubernetes-master charm ([#55185](https://github.com/kubernetes/kubernetes/pull/55185),[ @Cynerva](https://github.com/Cynerva))
+*   Add support for RBAC ([#53820](https://github.com/kubernetes/kubernetes/pull/53820),[ @ktsakalozos](https://github.com/ktsakalozos))
+*   Fixed iptables FORWARD policy for Docker 1.13 in kubernetes-worker charm ([#54796](https://github.com/kubernetes/kubernetes/pull/54796),[ @Cynerva](https://github.com/Cynerva))
+*   Upgrading the kubernetes-master units now results in staged upgrades just like the kubernetes-worker nodes. Use the upgrade action in order to continue the upgrade process on each unit such as juju run-action kubernetes-master/0 upgrade ([#55990](https://github.com/kubernetes/kubernetes/pull/55990),[ @hyperbolic2346](https://github.com/hyperbolic2346))
+*   Added extra_sans config option to kubeapi-load-balancer charm. This allows the user to specify extra SAN entries on the certificate generated for the load balancer. ([#54947](https://github.com/kubernetes/kubernetes/pull/54947),[ @hyperbolic2346](https://github.com/hyperbolic2346))
+*   Added extra-args configs to kubernetes-worker charm ([#55334](https://github.com/kubernetes/kubernetes/pull/55334),[ @Cynerva](https://github.com/Cynerva))
+
+#### **Other**
+
+*   Base images have been bumped to Debian Stretch (9) ([#52744](https://github.com/kubernetes/kubernetes/pull/52744),[ @rphillips](https://github.com/rphillips))
+*   Upgraded to go1.9. ([#51375](https://github.com/kubernetes/kubernetes/pull/51375),[ @cblecker](https://github.com/cblecker))
+*   Add-on manager now supports HA masters. ([#55466](https://github.com/kubernetes/kubernetes/pull/55466),[ #55782](https://github.com/x13n),[ @x13n](https://github.com/x13n))
+*   Hyperkube can now run from a non-standard path. ([#54570](https://github.com/kubernetes/kubernetes/pull/54570))
+
+#### **GCP**
+
+*   The service account made available on your nodes is now configurable. ([#52868](https://github.com/kubernetes/kubernetes/pull/52868),[ @ihmccreery](https://github.com/ihmccreery))
+*   GCE nodes with NVIDIA GPUs attached now expose nvidia.com/gpu as a resource instead of alpha.kubernetes.io/nvidia-gpu. ([#54826](https://github.com/kubernetes/kubernetes/pull/54826),[ @mindprince](https://github.com/mindprince))
+*   Docker's live-restore on COS/ubuntu can now be disabled ([#55260](https://github.com/kubernetes/kubernetes/pull/55260),[ @yujuhong](https://github.com/yujuhong))
+*   Metadata concealment is now controlled by the ENABLE_METADATA_CONCEALMENT env var. See cluster/gce/config-default.sh for more info. ([#54150](https://github.com/kubernetes/kubernetes/pull/54150),[ @ihmccreery](https://github.com/ihmccreery))
+*   Masquerading rules are now added by default to GCE/GKE ([#55178](https://github.com/kubernetes/kubernetes/pull/55178),[ @dnardo](https://github.com/dnardo))
+*   Fixed master startup issues with concurrent iptables invocations. ([#55945](https://github.com/kubernetes/kubernetes/pull/55945),[ @x13n](https://github.com/x13n))
+*   Fixed issue deleting internal load balancers when the firewall resource may not exist. ([#53450](https://github.com/kubernetes/kubernetes/pull/53450),[ @nicksardo](https://github.com/nicksardo))
+
+### **Instrumentation**
+
+#### **Audit**
+
+*   Adjust batching audit webhook default parameters: increase queue size, batch size, and initial backoff. Add throttling to the batching audit webhook. Default rate limit is 10 QPS. ([#53417](https://github.com/kubernetes/kubernetes/pull/53417),[ @crassirostris](https://github.com/crassirostris))
+    *   These parameters are also now configurable. ([#56638](https://github.com/kubernetes/kubernetes/pull/56638), [@crassirostris](https://github.com/crassirostris))
+
+#### **Other**
+
+*   Fix a typo in prometheus-to-sd configuration, that drops some stackdriver metrics. ([#56473](https://github.com/kubernetes/kubernetes/pull/56473),[ @loburm](https://github.com/loburm))
+*   [fluentd-elasticsearch addon] Elasticsearch and Kibana are updated to version 5.6.4 ([#55400](https://github.com/kubernetes/kubernetes/pull/55400),[ @mrahbar](https://github.com/mrahbar))
+*   fluentd now supports CRI log format. ([#54777](https://github.com/kubernetes/kubernetes/pull/54777),[ @Random-Liu](https://github.com/Random-Liu))
+*   Bring all prom-to-sd container to the same image version ([#54583](https://github.com/kubernetes/kubernetes/pull/54583))
+    *   Reduce log noise produced by prometheus-to-sd, by bumping it to version 0.2.2. ([#54635](https://github.com/kubernetes/kubernetes/pull/54635),[ @loburm](https://github.com/loburm))
+*   [fluentd-elasticsearch addon] Elasticsearch service name can be overridden via env variable ELASTICSEARCH_SERVICE_NAME ([#54215](https://github.com/kubernetes/kubernetes/pull/54215),[ @mrahbar](https://github.com/mrahbar))
+
+### **Multicluster**
+
+#### **Federation**
+
+*   Kubefed init now supports --imagePullSecrets and --imagePullPolicy, making it possible to use private registries. ([#50740](https://github.com/kubernetes/kubernetes/pull/50740),[ @dixudx](https://github.com/dixudx))
+*   Updated cluster printer to enable --show-labels ([#53771](https://github.com/kubernetes/kubernetes/pull/53771),[ @dixudx](https://github.com/dixudx))
+*   Kubefed init now supports --nodeSelector, enabling you to determine on what node the controller will be installed. ([#50749](https://github.com/kubernetes/kubernetes/pull/50749),[ @dixudx](https://github.com/dixudx))
+
+### **Network**
+
+#### **IPv6**
+
+*   [alpha] IPv6 support has been added. Notable IPv6 support details include:
+    *   Support for IPv6-only Kubernetes cluster deployments. **<span style="text-decoration:underline;">Note:</span>** This feature does not provide dual-stack support.
+    *   Support for IPv6 Kubernetes control and data planes.
+    *   Support for Kubernetes IPv6 cluster deployments using kubeadm.
+    *   Support for the iptables kube-proxy backend using ip6tables.
+    *   Relies on CNI 0.6.0 binaries for IPv6 pod networking.
+    *   Adds IPv6 support for kube-dns using SRV records.
+    *   Caveats
+        *   Only the CNI bridge and local-ipam plugins have been tested for the alpha release, although other CNI plugins do support IPv6.
+        *   HostPorts are not supported.
+*   An IPv6 network mask for pod or cluster cidr network must be /66 or longer. For example: 2001:db1::/66, 2001:dead:beef::/76, 2001:cafe::/118 are supported. 2001:db1::/64 is not supported
+*   For details, see [the complete list of merged pull requests for IPv6 support](https://github.com/kubernetes/kubernetes/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Amerged+label%3Aarea%2Fipv6).
+
+#### **IPVS**
+
+*   You can now use the --cleanup-ipvs flag to tell kube-proxy whether to flush all existing ipvs rules in on startup ([#56036](https://github.com/kubernetes/kubernetes/pull/56036),[ @m1093782566](https://github.com/m1093782566))
+*   Graduate kube-proxy IPVS mode to beta. ([#56623](https://github.com/kubernetes/kubernetes/pull/56623), [@m1093782566](https://github.com/m1093782566))
+
+#### **Kube-Proxy**
+
+*   Added iptables rules to allow Pod traffic even when default iptables policy is to reject. ([#52569](https://github.com/kubernetes/kubernetes/pull/52569),[ @tmjd](https://github.com/tmjd))
+*   You can once again use 0 values for conntrack min, max, max per core, tcp close wait timeout, and tcp established timeout; this functionality was broken in 1.8. ([#55261](https://github.com/kubernetes/kubernetes/pull/55261),[ @ncdc](https://github.com/ncdc))
+
+#### **CoreDNS**
+
+*   You now have the option to use CoreDNS instead of KubeDNS. To install CoreDNS instead of kube-dns, set CLUSTER_DNS_CORE_DNS to 'true'. This support is experimental. ([#52501](https://github.com/kubernetes/kubernetes/pull/52501),[ @rajansandeep](https://github.com/rajansandeep)) ([#55728](https://github.com/kubernetes/kubernetes/pull/55728),[ @rajansandeep](https://github.com/rajansandeep))
+
+#### **Other**
+
+*   Pod addresses will now be removed from the list of endpoints when the pod is in graceful termination. ([#54828](https://github.com/kubernetes/kubernetes/pull/54828),[ @freehan](https://github.com/freehan))
+*   You can now use a new supported service annotation for AWS clusters, `service.beta.kubernetes.io/aws-load-balancer-ssl-negotiation-policy`, which lets you specify which [predefined AWS SSL policy](http://docs.aws.amazon.com/elasticloadbalancing/latest/classic/elb-security-policy-table.html) you would like to use. ([#54507](https://github.com/kubernetes/kubernetes/pull/54507),[ @micahhausler](https://github.com/micahhausler))
+*   Termination grace period for the calico/node add-on DaemonSet has been eliminated, reducing downtime during a rolling upgrade or deletion. ([#55015](https://github.com/kubernetes/kubernetes/pull/55015),[ @fasaxc](https://github.com/fasaxc))
+*   Fixed bad conversion in host port chain name generating func which led to some unreachable host ports. ([#55153](https://github.com/kubernetes/kubernetes/pull/55153),[ @chenchun](https://github.com/chenchun))
+*   Fixed IPVS availability check ([#51874](https://github.com/kubernetes/kubernetes/pull/51874),[ @vfreex](https://github.com/vfreex))
+*   The output for kubectl describe networkpolicy * has been enhanced to be more useful. ([#46951](https://github.com/kubernetes/kubernetes/pull/46951),[ @aanm](https://github.com/aanm))
+*   Kernel modules are now loaded automatically inside a kube-proxy pod ([#52003](https://github.com/kubernetes/kubernetes/pull/52003),[ @vfreex](https://github.com/vfreex))
+*   Improve resilience by annotating kube-dns addon with podAntiAffinity to prefer scheduling on different nodes. ([#52193](https://github.com/kubernetes/kubernetes/pull/52193),[ @StevenACoffman](https://github.com/StevenACoffman))
+*   [alpha] Added DNSConfig field to PodSpec. "None" mode for DNSPolicy is now supported. ([#55848](https://github.com/kubernetes/kubernetes/pull/55848),[ @MrHohn](https://github.com/MrHohn))
+*   You can now add "options" to the host's /etc/resolv.conf (or --resolv-conf), and they will be copied into pod's resolv.conf when dnsPolicy is Default. Being able to customize options is important because it is common to leverage options to fine-tune the behavior of DNS client. ([#54773](https://github.com/kubernetes/kubernetes/pull/54773),[ @phsiao](https://github.com/phsiao))
+*   Fixed a bug so that the service controller no longer retries if doNotRetry service update fails. ([#54184](https://github.com/kubernetes/kubernetes/pull/54184),[ @MrHohn](https://github.com/MrHohn))
+*   Added --no-negcache flag to kube-dns to prevent caching of NXDOMAIN responses. ([#53604](https://github.com/kubernetes/kubernetes/pull/53604),[ @cblecker](https://github.com/cblecker))
+
+### **Node**
+
+#### **Pod API**
+
+*   A single value in metadata.annotations/metadata.labels can now be passed into the containers via the Downward API. ([#55902](https://github.com/kubernetes/kubernetes/pull/55902),[ @yguo0905](https://github.com/yguo0905))
+*   Pods will no longer briefly transition to a "Pending" state during the deletion process. ([#54593](https://github.com/kubernetes/kubernetes/pull/54593),[ @dashpole](https://github.com/dashpole))
+*   Added pod-level local ephemeral storage metric to the Summary API. Pod-level ephemeral storage reports the total filesystem usage for the containers and emptyDir volumes in the measured Pod. ([#55447](https://github.com/kubernetes/kubernetes/pull/55447),[ @jingxu97](https://github.com/jingxu97))
+
+#### **Hardware Accelerators**
+
+*   Kubelet now exposes metrics for NVIDIA GPUs attached to the containers. ([#55188](https://github.com/kubernetes/kubernetes/pull/55188),[ @mindprince](https://github.com/mindprince))
+*   The device plugin Alpha API no longer supports returning artifacts per device as part of AllocateResponse. ([#53031](https://github.com/kubernetes/kubernetes/pull/53031),[ @vishh](https://github.com/vishh))
+*   Fix to ignore extended resources that are not registered with kubelet during container resource allocation. ([#53547](https://github.com/kubernetes/kubernetes/pull/53547),[ @jiayingz](https://github.com/jiayingz))
+
+
+#### **Container Runtime**
+*   [alpha] [cri-tools](https://github.com/kubernetes-incubator/cri-tools): CLI and validation tools for CRI is now v1.0.0-alpha.0. This release mainly focuses on UX improvements. [[@feiskyer](https://github.com/feiskyer)]
+    *   Make crictl command more user friendly and add more subcommands.
+    *   Integrate with CRI verbose option to provide extra debug information.
+    *   Update CRI to kubernetes v1.9.
+    *   Bug fixes in validation test suites.
+*   [beta] [cri-containerd](https://github.com/kubernetes-incubator/cri-containerd): CRI implementation for containerd is now v1.0.0-beta.0, [[@Random-Liu](https://github.com/Random-Liu)]
+    *   This release supports Kubernetes 1.9+ and containerd v1.0.0+.
+    *   Pass all Kubernetes 1.9 e2e test, node e2e test and CRI validation tests.
+    *   [Kube-up.sh integration](https://github.com/kubernetes-incubator/cri-containerd/blob/master/docs/kube-up.md).
+    *   [Full crictl integration including CRI verbose option.](https://github.com/kubernetes-incubator/cri-containerd/blob/master/docs/crictl.md)
+    *   Integration with cadvisor to provide better summary api support.
+*   [stable] [cri-o](https://github.com/kubernetes-incubator/cri-o): CRI implementation for OCI-based runtimes is now v1.9. [[@mrunalp](https://github.com/mrunalp)]
+    *   Pass all the Kubernetes 1.9 end-to-end test suites and now gating PRs as well
+    *   Pass all the CRI validation tests
+    *   Release has been focused on bug fixes, stability and performance with runc and Clear Containers
+    *   Minikube integration
+*   [stable] [frakti](https://github.com/kubernetes/frakti): CRI implementation for hypervisor-based runtimes is now v1.9. [[@resouer](https://github.com/resouer)]
+    *   Added ARM64 release. Upgraded to CNI 0.6.0, added block device as Pod volume mode. Fixed CNI plugin compatibility.
+    *   Passed all CRI validation conformance tests and node end-to-end conformance tests.
+*   [alpha] [rktlet](https://github.com/kubernetes-incubator/rktlet): CRI implementation for the rkt runtime is now v0.1.0. [[@iaguis](https://github.com/iaguis)]
+    *   This is the first release of rktlet and it implements support for the CRI including fetching images, running pods, CNI networking, logging and exec.
+This release passes 129/145 Kubernetes e2e conformance tests.
+*   Container Runtime Interface API change. [[@yujuhong](https://github.com/yujuhong)]
+    *   A new field is added to CRI container log format to support splitting a long log line into multiple lines. ([#55922](https://github.com/kubernetes/kubernetes/pull/55922), [@Random-Liu](https://github.com/Random-Liu))
+    *   CRI now supports debugging via a verbose option for status functions. ([#53965](https://github.com/kubernetes/kubernetes/pull/53965), [@Random-Liu](https://github.com/Random-Liu))
+    *   Kubelet can now provide full summary api support for the CRI container runtime, with the exception of container log stats. ([#55810](https://github.com/kubernetes/kubernetes/pull/55810), [@abhi](https://github.com/abhi))
+    *   CRI now uses the correct localhost seccomp path when provided with input in the format of localhost//profileRoot/profileName. ([#55450](https://github.com/kubernetes/kubernetes/pull/55450), [@feiskyer](https://github.com/feiskyer))
+
+
+#### **Kubelet**
+
+*   The EvictionHard, EvictionSoft, EvictionSoftGracePeriod, EvictionMinimumReclaim, SystemReserved, and KubeReserved fields in the KubeletConfiguration object (`kubeletconfig/v1alpha1`) are now of type map[string]string, which facilitates writing JSON and YAML files. ([#54823](https://github.com/kubernetes/kubernetes/pull/54823),[ @mtaufen](https://github.com/mtaufen))
+*   Relative paths in the Kubelet's local config files (`--init-config-dir`) will now be resolved relative to the location of the containing files. ([#55648](https://github.com/kubernetes/kubernetes/pull/55648),[ @mtaufen](https://github.com/mtaufen))
+*   It is now possible to set multiple manifest URL headers with the kubelet's `--manifest-url-header` flag. Multiple headers for the same key will be added in the order provided. The ManifestURLHeader field in KubeletConfiguration object (kubeletconfig/v1alpha1) is now a map[string][]string, which facilitates writing JSON and YAML files. ([#54643](https://github.com/kubernetes/kubernetes/pull/54643),[ @mtaufen](https://github.com/mtaufen))
+*   The Kubelet's feature gates are now specified as a map when provided via a JSON or YAML KubeletConfiguration, rather than as a string of key-value pairs, making them less awkward for users. ([#53025](https://github.com/kubernetes/kubernetes/pull/53025),[ @mtaufen](https://github.com/mtaufen))
+
+##### **Other**
+
+*   Fixed a performance issue ([#51899](https://github.com/kubernetes/kubernetes/pull/51899)) identified in large-scale clusters when deleting thousands of pods simultaneously across hundreds of nodes, by actively removing containers of deleted pods, rather than waiting for periodic garbage collection and batching resulting pod API deletion requests. ([#53233](https://github.com/kubernetes/kubernetes/pull/53233),[ @dashpole](https://github.com/dashpole))
+*   Problems deleting local static pods have been resolved. ([#48339](https://github.com/kubernetes/kubernetes/pull/48339),[ @dixudx](https://github.com/dixudx))
+*   CRI now only calls UpdateContainerResources when cpuset is set. ([#53122](https://github.com/kubernetes/kubernetes/pull/53122),[ @resouer](https://github.com/resouer))
+*   Containerd monitoring is now supported. ([#56109](https://github.com/kubernetes/kubernetes/pull/56109),[ @dashpole](https://github.com/dashpole))
+*   deviceplugin has been extended to more gracefully handle the full device plugin lifecycle, including: ([#55088](https://github.com/kubernetes/kubernetes/pull/55088),[ @jiayingz](https://github.com/jiayingz))
+    *   Kubelet now uses an explicit cm.GetDevicePluginResourceCapacity() function that makes it possible to more accurately determine what resources are inactive and return a more accurate view of available resources.
+    *   Extends the device plugin checkpoint data to record registered resources so that we can finish resource removing devices even upon kubelet restarts.
+    *   Passes sourcesReady from kubelet to the device plugin to avoid removing inactive pods during the grace period of kubelet restart.
+    *   Extends the gpu_device_plugin e2e_node test to verify that scheduled pods can continue to run even after a device plugin deletion and kubelet restart.
+*   The NodeController no longer supports kubelet 1.2. ([#48996](https://github.com/kubernetes/kubernetes/pull/48996),[ @k82cn](https://github.com/k82cn))
+*   Kubelet now provides more specific events via FailedSync when unable to sync a pod. ([#53857](https://github.com/kubernetes/kubernetes/pull/53857),[ @derekwaynecarr](https://github.com/derekwaynecarr))
+*   You can now disable AppArmor by setting the AppArmor profile to unconfined. ([#52395](https://github.com/kubernetes/kubernetes/pull/52395),[ @dixudx](https://github.com/dixudx))
+*   ImageGCManage now consumes ImageFS stats from StatsProvider rather than cadvisor. ([#53094](https://github.com/kubernetes/kubernetes/pull/53094),[ @yguo0905](https://github.com/yguo0905))
+*   Hyperkube now supports the support --experimental-dockershim kubelet flag. ([#54508](https://github.com/kubernetes/kubernetes/pull/54508),[ @ivan4th](https://github.com/ivan4th))
+*   Kubelet no longer removes default labels from Node API objects on startup ([#54073](https://github.com/kubernetes/kubernetes/pull/54073),[ @liggitt](https://github.com/liggitt))
+*   The overlay2 container disk metrics for Docker and CRI-O now work properly. ([#54827](https://github.com/kubernetes/kubernetes/pull/54827),[ @dashpole](https://github.com/dashpole))
+*   Removed docker dependency during kubelet start up. ([#54405](https://github.com/kubernetes/kubernetes/pull/54405),[ @resouer](https://github.com/resouer))
+*   Added Windows support to the system verification check. ([#53730](https://github.com/kubernetes/kubernetes/pull/53730),[ @bsteciuk](https://github.com/bsteciuk))
+*   Kubelet no longer removes unregistered extended resource capacities from node status; cluster admins will have to manually remove extended resources exposed via device plugins when they the remove plugins themselves. ([#53353](https://github.com/kubernetes/kubernetes/pull/53353),[ @jiayingz](https://github.com/jiayingz))
+*   The stats summary network value now takes into account multiple network interfaces, and not just eth0. ([#52144](https://github.com/kubernetes/kubernetes/pull/52144),[ @andyxning](https://github.com/andyxning))
+*   Base images have been bumped to Debian Stretch (9). ([#52744](https://github.com/kubernetes/kubernetes/pull/52744),[ @rphillips](https://github.com/rphillips))
+
+### **OpenStack**
+
+*   OpenStack Cinder support has been improved:
+    *   Cinder version detection now works properly. ([#53115](https://github.com/kubernetes/kubernetes/pull/53115),[ @FengyunPan](https://github.com/FengyunPan))
+    *   The OpenStack cloud provider now supports Cinder v3 API. ([#52910](https://github.com/kubernetes/kubernetes/pull/52910),[ @FengyunPan](https://github.com/FengyunPan))
+*   Load balancing is now more flexible:
+    *   The OpenStack LBaaS v2 Provider is now [configurable](https://kubernetes.io/docs/concepts/cluster-administration/cloud-providers/#openstack). ([#54176](https://github.com/kubernetes/kubernetes/pull/54176),[ @gonzolino](https://github.com/gonzolino))
+    *   OpenStack Octavia v2 is now supported as a load balancer provider in addition to the existing support for the Neutron LBaaS V2 implementation. Neutron LBaaS V1 support has been removed. ([#55393](https://github.com/kubernetes/kubernetes/pull/55393),[ @jamiehannaford](https://github.com/jamiehannaford))
+*   OpenStack security group support has been beefed up  ([#50836](https://github.com/kubernetes/kubernetes/pull/50836),[ @FengyunPan](https://github.com/FengyunPan)): 
+    *   Kubernetes will now automatically determine the security group for the node
+    *   Nodes can now belong to multiple security groups
+
+### **Scheduling**
+
+#### **Hardware Accelerators**
+
+*   Add ExtendedResourceToleration admission controller. This facilitates creation of dedicated nodes with extended resources. If operators want to create dedicated nodes with extended resources (such as GPUs, FPGAs, and so on), they are expected to taint the node with extended resource name as the key. This admission controller, if enabled, automatically adds tolerations for such taints to pods requesting extended resources, so users don't have to manually add these tolerations. ([#55839](https://github.com/kubernetes/kubernetes/pull/55839),[ @mindprince](https://github.com/mindprince))
+
+#### **Other**
+
+*   Scheduler cache ignores updates to an assumed pod if updates are limited to pod annotations.  ([#54008](https://github.com/kubernetes/kubernetes/pull/54008),[ @yguo0905](https://github.com/yguo0905))
+*   Issues with namespace deletion have been resolved. ([#53720](https://github.com/kubernetes/kubernetes/pull/53720),[ @shyamjvs](https://github.com/shyamjvs)) ([#53793](https://github.com/kubernetes/kubernetes/pull/53793),[ @wojtek-t](https://github.com/wojtek-t))
+*   Pod preemption has been improved.  
+    *   Now takes PodDisruptionBudget into account. ([#56178](https://github.com/kubernetes/kubernetes/pull/56178),[ @bsalamat](https://github.com/bsalamat))
+    *   Nominated pods are taken into account during scheduling to avoid starvation of higher priority pods. ([#55933](https://github.com/kubernetes/kubernetes/pull/55933),[ @bsalamat](https://github.com/bsalamat))
+*   Fixed 'Schedulercache is corrupted' error in kube-scheduler ([#55262](https://github.com/kubernetes/kubernetes/pull/55262),[ @liggitt](https://github.com/liggitt))
+*   The kube-scheduler command now supports a --config flag which is the location of a file containing a serialized scheduler configuration. Most other kube-scheduler flags are now deprecated. ([#52562](https://github.com/kubernetes/kubernetes/pull/52562),[ @ironcladlou](https://github.com/ironcladlou))
+*   A new scheduling queue helps schedule the highest priority pending pod first. ([#55109](https://github.com/kubernetes/kubernetes/pull/55109),[ @bsalamat](https://github.com/bsalamat))
+*   A Pod can now listen to the same port on multiple IP addresses.  ([#52421](https://github.com/kubernetes/kubernetes/pull/52421),[ @WIZARD-CXY](https://github.com/WIZARD-CXY))
+*   Object count quotas supported on all standard resources using count/<resource>.<group> syntax ([#54320](https://github.com/kubernetes/kubernetes/pull/54320),[ @derekwaynecarr](https://github.com/derekwaynecarr))
+*   Apply algorithm in scheduler by feature gates. ([#52723](https://github.com/kubernetes/kubernetes/pull/52723),[ @k82cn](https://github.com/k82cn))
+*   A new priority function ResourceLimitsPriorityMap (disabled by default and behind alpha feature gate and not part of the scheduler's default priority functions list) that assigns a lowest possible score of 1 to a node that satisfies one or both of input pod's cpu and memory limits, mainly to break ties between nodes with same scores. ([#55906](https://github.com/kubernetes/kubernetes/pull/55906),[ @aveshagarwal](https://github.com/aveshagarwal))
+*   Kubelet evictions now take pod priority into account ([#53542](https://github.com/kubernetes/kubernetes/pull/53542),[ @dashpole](https://github.com/dashpole))
+*   PodTolerationRestriction admisson plugin: if namespace level tolerations are empty, now they override cluster level tolerations. ([#54812](https://github.com/kubernetes/kubernetes/pull/54812),[ @aveshagarwal](https://github.com/aveshagarwal))
+
+### **Storage**
+
+*   [stable] `PersistentVolume` and `PersistentVolumeClaim` objects must now have a capacity greater than zero.
+*   [stable] Mutation of `PersistentVolumeSource` after creation is no longer allowed
+*   [alpha] Deletion of `PersistentVolumeClaim` objects that are in use by a pod no longer permitted (if alpha feature is enabled).
+*   [alpha] Container Storage Interface
+    *   New CSIVolumeSource enables Kubernetes to use external CSI drivers to provision, attach, and mount volumes.
+*   [alpha] Raw block volumes 
+    *   Support for surfacing volumes as raw block devices added to Kubernetes storage system.
+    *   Only Fibre Channel volume plugin supports exposes this functionality, in this release.
+*   [alpha] Volume resizing
+    *   Added file system resizing for the following volume plugins: GCE PD, Ceph RBD, AWS EBS, OpenStack Cinder
+*   [alpha] Topology Aware Volume Scheduling 
+    *   Improved volume scheduling for Local PersistentVolumes, by allowing the scheduler to make PersistentVolume binding decisions while respecting the Pod's scheduling requirements.
+    *   Dynamic provisioning is not supported with this feature yet.
+*   [alpha] Containerized mount utilities
+    *   Allow mount utilities, used to mount volumes, to run inside a container instead of on the host.
+*   Bug Fixes
+    *   ScaleIO volume plugin is no longer dependent on the drv_cfg binary, so a Kubernetes cluster can easily run a containerized kubelet. ([#54956](https://github.com/kubernetes/kubernetes/pull/54956),[ @vladimirvivien](https://github.com/vladimirvivien))
+    *   AWS EBS Volumes are detached from stopped AWS nodes. ([#55893](https://github.com/kubernetes/kubernetes/pull/55893),[ @gnufied](https://github.com/gnufied))
+    *   AWS EBS volumes are detached if attached to a different node than expected. ([#55491](https://github.com/kubernetes/kubernetes/pull/55491),[ @gnufied](https://github.com/gnufied))
+    *   PV Recycle now works in environments that use architectures other than x86. ([#53958](https://github.com/kubernetes/kubernetes/pull/53958),[ @dixudx](https://github.com/dixudx))
+    *   Pod Security Policy can now manage access to specific FlexVolume drivers.([#53179](https://github.com/kubernetes/kubernetes/pull/53179),[ @wanghaoran1988](https://github.com/wanghaoran1988))
+    *   To prevent unauthorized access to CHAP Secrets, you can now set the secretNamespace storage class parameters for the following volume types:
+        *   ScaleIO; StoragePool and ProtectionDomain attributes no longer default to the value default.  ([#54013](https://github.com/kubernetes/kubernetes/pull/54013),[ @vladimirvivien](https://github.com/vladimirvivien))
+        *   RBD Persistent Volume Sources ([#54302](https://github.com/kubernetes/kubernetes/pull/54302),[ @sbezverk](https://github.com/sbezverk))
+        *   iSCSI Persistent Volume Sources ([#51530](https://github.com/kubernetes/kubernetes/pull/51530),[ @rootfs](https://github.com/rootfs))
+    *   In GCE multizonal clusters, `PersistentVolume` objects will no longer be dynamically provisioned in zones without nodes. ([#52322](https://github.com/kubernetes/kubernetes/pull/52322),[ @davidz627](https://github.com/davidz627))
+    *   Multi Attach PVC errors and events are now more useful and less noisy. ([#53401](https://github.com/kubernetes/kubernetes/pull/53401),[ @gnufied](https://github.com/gnufied))
+    *   The compute-rw scope has been removed from GCE nodes ([#53266](https://github.com/kubernetes/kubernetes/pull/53266),[ @mikedanese](https://github.com/mikedanese))
+    *   Updated vSphere cloud provider to support k8s cluster spread across multiple vCenters ([#55845](https://github.com/kubernetes/kubernetes/pull/55845),[ @rohitjogvmw](https://github.com/rohitjogvmw))
+    *   vSphere: Fix disk is not getting detached when PV is provisioned on clustered datastore. ([#54438](https://github.com/kubernetes/kubernetes/pull/54438),[ @pshahzeb](https://github.com/pshahzeb))
+    *   If a non-absolute mountPath is passed to the kubelet, it must now be prefixed with the appropriate root path. ([#55665](https://github.com/kubernetes/kubernetes/pull/55665),[ @brendandburns](https://github.com/brendandburns))
+
+## External Dependencies
+
+*   The supported etcd server version is **3.1.10**, as compared to 3.0.17 in v1.8 ([#49393](https://github.com/kubernetes/kubernetes/pull/49393),[ @hongchaodeng](https://github.com/hongchaodeng))
+*   The validated docker versions are the same as for v1.8: **1.11.2 to 1.13.1 and 17.03.x**
+*   The Go version was upgraded from go1.8.3 to **go1.9.2** ([#51375](https://github.com/kubernetes/kubernetes/pull/51375),[ @cblecker](https://github.com/cblecker))
+    *   The minimum supported go version bumps to 1.9.1. ([#55301](https://github.com/kubernetes/kubernetes/pull/55301),[ @xiangpengzhao](https://github.com/xiangpengzhao))
+    *   Kubernetes has been upgraded to go1.9.2 ([#55420](https://github.com/kubernetes/kubernetes/pull/55420),[ @cblecker](https://github.com/cblecker))
+*   CNI was upgraded to **v0.6.0** ([#51250](https://github.com/kubernetes/kubernetes/pull/51250),[ @dixudx](https://github.com/dixudx))
+*   The dashboard add-on has been updated to [v1.8.0](https://github.com/kubernetes/dashboard/releases/tag/v1.8.0). ([#53046](https://github.com/kubernetes/kubernetes/pull/53046), [@maciaszczykm](https://github.com/maciaszczykm))
+*   Heapster has been updated to [v1.5.0](https://github.com/kubernetes/heapster/releases/tag/v1.5.0). ([#57046](https://github.com/kubernetes/kubernetes/pull/57046), [@piosz](https://github.com/piosz))
+*   Cluster Autoscaler has been updated to [v1.1.0](https://github.com/kubernetes/autoscaler/releases/tag/cluster-autoscaler-1.1.0). ([#56969](https://github.com/kubernetes/kubernetes/pull/56969), [@mwielgus](https://github.com/mwielgus))
+*   Update kube-dns 1.14.7 ([#54443](https://github.com/kubernetes/kubernetes/pull/54443),[ @bowei](https://github.com/bowei))
+*   Update influxdb to v1.3.3 and grafana to v4.4.3 ([#53319](https://github.com/kubernetes/kubernetes/pull/53319),[ @kairen](https://github.com/kairen))

--- a/releases/release-1.9/release_notes_discussion.md
+++ b/releases/release-1.9/release_notes_discussion.md
@@ -1,0 +1,49 @@
+# Release notes items to discuss (Radhika, Jennifer)
+
+## Gaps
+
+Much content does not indicate what changed in this release. Even detailed descriptions of features don't indicate reliably whether they are new, or changes to existing functionality. Missing also are explanations of why changes were made (or added), or any indication of a use case. Asking for use cases is probably reaching too far, especially at this late date, but some indication of how things changed is important.
+
+The writers propose to contact individual sig leads, or where known the original release note authors, to ask these questions one-on-one and expand the relevant release notes as we revise them. In some cases there's enough information in linked PRs or issues for us to investigate on our own, but we don't have time to go code diving.
+
+## Inconsistent terminology
+
+API changes especially are called out in various ways: they are promoted, graduated, advanced. We should standardize. (Note that none of these is a standard way to refer to version number increases.) The same goes for referring to API groups (themselves a confusing concept to outsiders). Radhika and Jennifer are working on this issue.
+
+## Information architecture
+
+Thinking about useful buckets (getting rid of sig org altogether?). Look at app developer user persona for ideas? (here: https://docs.google.com/document/d/1EdQ8acmuKGlzZy1agejLqmB7cLpTRBJKC0JYptJ-ylg/edit#heading=h.ylz4u4aax62y)
+
+One (example) option (details not final or guaranteed to be accurate):
+
+- Cluster config changes
+    - New Features
+    - API changes
+    - Known Issues
+- Node/pod changes
+    - New Features
+    - API changes
+    - Known Issues
+- Networking changes
+    - New Features
+    - API changes
+    - Known Issues
+- Auth changes
+    - New Features
+    - API changes
+    - Known Issues
+- Command-line tool changes (kubectl)
+    - New Features
+    - API changes
+    - Known Issues
+- Storage changes
+    - New Features
+    - API changes
+    - Known Issues
+
+
+Carrying over known issues from previous releases? (documenting fixes?)
+
+## Publishing process
+
+The release notes are published as part of the lengthy `changelog.md` file. Ideally, the release notes should be published along with the documentation on kubernetes.io. Considering the usability factors, release notes are not consumable in the current form.

--- a/releases/release-1.9/release_team.md
+++ b/releases/release-1.9/release_team.md
@@ -1,0 +1,14 @@
+|  **Role** | **Name** (**GitHub/Slack ID**)  | **Shadow Name(s) (GitHub/Slack ID), ...**
+|  ------ | ------ | ------ |
+|  Lead | Anthony Yeh ([@enisoc](https://github.com/enisoc)) | |
+|  Secondary | Jaice Singer DuMars ([@jdumars](https://github.com/jdumars)) | |
+|  Features | Ihor Dvoretskyi ([@idvoretskyi](https://github.com/idvoretskyi)) | |
+|  Branch Manager | David Ashpole ([@dashpole](https://github.com/dashpole)) | |
+|  Test Infra | Benjamin Elder ([@BenTheElder](https://github.com/BenTheElder)) | |
+|  Docs | Zach Corleissen ([@zacharysarah](https://github.com/zacharysarah)) | |
+|  Release Notes | Jennifer Rondeau ([@Bradamant3](https://github.com/Bradamant3)) | Nick Chase ([@nickchase](https://github.com/nickchase)), Peter Zhao ([@xiangpengzhao](https://github.com/xiangpengzhao)) |
+|  Bugs | Josh Berkus ([@jberkus](https://github.com/jberkus)) | |
+|  Upgrade Testing / CI Signal | Aaron Crickenberger ([@spiffxp](https://github.com/spiffxp)) | Jason DeTiberus ([@detiber](https://github.com/detiber)/@jdetiber) |
+|  Patch Release Manager | Mehdy Bohlool ([@mbohlool](https://github.com/mbohlool)) | |
+|  Marketing coordinator | Natasha Woods ([@nwoods3](https://github.com/nwoods3)) | Wendy Cartee ([@wcartee](https://github.com/wcartee)), Paris Pittman ([@parispittman](https://github.com/parispittman)) |
+

--- a/releases/release-1.9/scalability_validation_report.md
+++ b/releases/release-1.9/scalability_validation_report.md
@@ -1,0 +1,59 @@
+Scalability validation report for release-1.9
+=============================================
+
+Written as per [this template](https://github.com/kubernetes/community/blob/master/contributors/devel/release/scalability-validation.md#concretely-define-test-configuration).
+
+Large Cluster Performance
+-------------------------
+
+Validated under the following configuration:
+- Cloud-provider - GCE
+- No. of nodes - 5000
+- Node machine-type - n1-standard-1; OS - gci; Disk size - 50GB
+- Master machine-type - n1-standard-64 Intel Broadwell or better; OS - gci; Disk size - [auto-calculated]
+- Any non-default config used:
+  - `KUBE_ENABLE_CLUSTER_MONITORING=none`
+  - `KUBE_GCE_ENABLE_IP_ALIASES=true`
+  - `ENABLE_APISERVER_ADVANCED_AUDIT=false`
+  - `ENABLE_BIG_CLUSTER_SUBNETS=true`
+  - `PREPULL_E2E_IMAGES=false`
+  - `APISERVER_TEST_ARGS=--max-requests-inflight=3000 --max-mutating-requests-inflight=1000`
+  - `SCHEDULER_TEST_ARGS=--kube-api-qps=100`
+  - `CONTROLLER_MANAGER_TEST_ARGS=--kube-api-qps=100 --kube-api-burst=100`
+  - `TEST_CLUSTER_LOG_LEVEL=--v=1`
+  - `TEST_CLUSTER_RESYNC_PERIOD=--min-resync-period=12h`
+  - `TEST_CLUSTER_DELETE_COLLECTION_WORKERS=--delete-collection-workers=16`
+
+- Any important test details:
+  - Services disabled in load test
+  - SLO used for 99%ile for api call latency:
+    - For clusters with <= 500 nodes:
+      - <= 1s for all calls
+    - For clusters with > 500 nodes:
+      - <= 1s for non-list calls
+      - <= 5s for namespaced list calls
+      - <= 10s for cluster-scoped list calls
+- See the [output from the validating performance test job run](https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-scale-performance/79) for other specific details from the logs.
+
+Large cluster correctness
+-------------------------
+
+Validated under the following configuration:
+- Cloud-provider - GCE
+- No. of nodes - 5000
+- Node machine-type - g1-small; OS - gci; Disk size - 50GB
+- One special n1-standard-8 node (out of the 5k nodes) used for heapster
+- Master machine-type - n1-standard-64 Intel Broadwell or better; OS - gci; Disk size - [auto-calculated]
+- Any non-default config used:
+  - `KUBE_ENABLE_CLUSTER_MONITORING=standalone`
+  - `APISERVER_TEST_ARGS=--max-requests-inflight=1500 --max-mutating-requests-inflight=500`
+  - `CONTROLLER_MANAGER_TEST_ARGS=--kube-api-qps=100 --kube-api-burst=100 --concurrent-service-syncs=5`
+  - `PREPULL_E2E_IMAGES (default, true)`
+  - (rest same as above - performance test)
+- Any important test details:
+  - Several tests were disabled because they did not pass at scale and fixing
+    the related code was not feasible before the release:
+    - [Horizontal Pod Autoscaler](https://github.com/kubernetes/kubernetes/blob/7335c41ebe076b/test/e2e/autoscaling/horizontal_pod_autoscaling.go#L69): https://github.com/kubernetes/kubernetes/issues/55887
+    - [Advanced API call auditing](https://github.com/kubernetes/kubernetes/blob/7335c41ebe076b/test/e2e/auth/audit.go#L59): http://github.com/kubernetes/kubernetes/issues/53455
+    - [Changing type and ports of a Service](https://github.com/kubernetes/kubernetes/blob/7335c41ebe076b/test/e2e/network/service.go#L486): http://github.com/kubernetes/kubernetes/issues/52495
+- See the [output from the validating correcness test job run](https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-scale-correctness/46) for other specific details from the logs.


### PR DESCRIPTION
Kubernetes 1.3-1.9 releases info moved from the https://github.com/kubernetes/features repo (existing release-1.* directories from the features repo will be removed after this PR will be merged).

FYI @pwittrock @calebamiles @grodrigues3 @spiffxp @jdumars 