### PR TITLE
Removing "Secondary release manager" role (dup by the Lead Shadow)

### DIFF
--- a/releases/release-1.10/release_team.md
+++ b/releases/release-1.10/release_team.md
@@ -1,7 +1,6 @@
 | **Role** | **Name** (**GitHub/Slack ID**)  | **Shadow Name(s) (GitHub/Slack ID), ...** |
 | ------ | ------ | ------ |
 | Lead | | |
-| Secondary | | |
 | Features | | |
 | CI Signal | | |
 | Test Infra | | |


### PR DESCRIPTION
Removing the "Secondary release manager" role as it's duplicated by the Release Lead Shadow.