### PR TITLE
Change from "marketing" to "communications"

### DIFF
--- a/releases/release-1.10/release_team.md
+++ b/releases/release-1.10/release_team.md
@@ -8,6 +8,6 @@
 | Branch Manager | | |
 | Docs | Jennifer Rondeau ([@Bradamant3](https://github.com/Bradamant3)) | Jessica Yao ([@abiogenesis-now](https://github.com/abiogenesis-now)) |
 | Release Notes | Nick Chase ([@nickchase](https://github.com/nickchase)) | |
-| Marketing | Natasha Woods @nwoods  | Caitlyn O'Connell |
+| Communications | Natasha Woods (@nwoods)  | Caitlyn O'Connell |
 | Patch Release Manager | Shyam JVS ([@shyamjvs](https://github.com/shyamjvs)) | |
 | Approval Notifier | 	k8s-ci-robot ([@k8s-ci-robot](https://github.com/k8s-ci-robot)) | |


### PR DESCRIPTION
In the process of documenting this role (PR soon!), it became clear that this is not a "marketing" role, but instead a communications coordinator position between CNCF, media, PM, and the release team.  There is an assumption that the CNCF will have a person dedicated to their marketing efforts already.