### PR TITLE
Add OWNERS for PST docs

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -23,3 +23,9 @@ aliases:
     - roberthbailey
     - saad-ali
     - wojtek-t
+  product-security-team:
+    - philips
+    - jessfraz
+    - cjcullen
+    - tallclair
+    - liggitt

--- a/security-release-process-documentation/OWNERS
+++ b/security-release-process-documentation/OWNERS
@@ -1,0 +1,6 @@
+# See the OWNERS docs: https://git.k8s.io/community/docs/devel/owners.md
+
+reviewers:
+  - product-security-team
+approvers:
+  - product-security-team

--- a/security-release-process-documentation/security-release-process.md
+++ b/security-release-process-documentation/security-release-process.md
@@ -10,11 +10,11 @@ The Product Security Team (PST) is responsible for organizing the entire respons
 
 The initial Product Security Team will consist of four volunteers subscribed to the private [Kubernetes Security](https://groups.google.com/forum/#!forum/kubernetes-security) list. These are the people who have been involved in the initial discussion and volunteered:
 
-- Brandon Philips `<brandon.philips@coreos.com>` [4096R/154343260542DF34]
-- Jess Frazelle `<jess@linux.com>` [4096R/0x18F3685C0022BFF3]
-- CJ Cullen `<cjcullen@google.com>`
-- Tim Allclair `<tallclair@google.com>` [4096R/0x5E6F2E2DA760AF51]
-- Jordan Liggitt `<jliggitt@redhat.com>` [4096R/0x39928704103C7229]
+- Brandon Philips (**[@philips](https://github.com/philips)**) `<brandon.philips@coreos.com>` [4096R/154343260542DF34]
+- Jess Frazelle (**[@jessfraz](https://github.com/jessfraz)**) `<jess@linux.com>` [4096R/0x18F3685C0022BFF3]
+- CJ Cullen (**[@cjcullen](https://github.com/cjcullen)**) `<cjcullen@google.com>`
+- Tim Allclair (**[@tallclair](https://github.com/tallclair)**) `<tallclair@google.com>` [4096R/0x5E6F2E2DA760AF51]
+- Jordan Liggitt (**[@liggitt](https://github.com/liggitt)**) `<jliggitt@redhat.com>` [4096R/0x39928704103C7229]
 
 **Known issues**
 


### PR DESCRIPTION
Adds OWNERS file for PST documentation, and github usernames to the docs itself.