### PR TITLE
Add status/ prefix to approved-for-milestone label

### DIFF
--- a/release-process-documentation/release-team-guides/release-lead.md
+++ b/release-process-documentation/release-team-guides/release-lead.md
@@ -154,7 +154,7 @@ A guiding principle for the lead is be an arbiter of decisions, and not the prim
   </tr>
   <tr>
     <td>8</td>
-    <td><p>- Code slush begins.  SIGs will need to ensure all work moving forward is carefully curated with labels, especially approved-for-milestone that acts as an acceptance by the SIG of the work being targeted for the release
+    <td><p>- Code slush begins.  SIGs will need to ensure all work moving forward is carefully curated with labels, especially `status/approved-for-milestone` that acts as an acceptance by the SIG of the work being targeted for the release
 <p>- The code exception process is now in effect, meaning you will likely have to assemble decision makers on specific pending PRs to assess whether the risk of inclusion is acceptable or not. Remember this is not you making a decision, it’s you helping SIGs follow the process, and ensuring there’s consensus. In the event of a contentious PR, you should err on the side of risk aversion. In extreme cases, you can defer to the steering committee, but that is extremely unlikely.
 <p>- Focus after this point will be on ensuring the release branch is healthy, stable, and passing tests consistently.  
 <p>- Check in on the blog post draft

--- a/releases/release-1.10/release-1.10.md
+++ b/releases/release-1.10/release-1.10.md
@@ -373,13 +373,13 @@ All features going into the release must have an associated issue in the feature
 
 ### Code Slush
 
-Starting on Tuesday, February 20th, only PRs labeled by their owner SIGs with "[approved-for-milestone](https://github.com/kubernetes/community/blob/master/contributors/devel/release/issues.md)" will be allowed to merge into the master branch. All others will be deferred until the end of Code Freeze, when master opens back up for the next release cycle. If necessary, the release team can add the approved-for-milestone label in cases where the SIG approvers do not have permissions to do so.
+Starting on Tuesday, February 20th, only PRs labeled by their owner SIGs with [`status/approved-for-milestone`](/ephemera/issues.md)will be allowed to merge into the master branch. All others will be deferred until the end of Code Freeze, when master opens back up for the next release cycle. If necessary, the release team can add the `status/approved-for-milestone` label in cases where the SIG approvers do not have permissions to do so.
 
 Code Slush begins prior to Code Freeze to help reduce noise from miscellaneous changes that aren't related to issues that SIGs have approved for the milestone. Feature work is still allowed at this point, but it must follow the process to get approved for the milestone. SIGs are the gatekeepers of this label, not the release team.
 
 #### Exceptions
 
-Starting at Code Slush, the release team will solicit and rule on [exception requests](https://github.com/kubernetes/features/blob/master/EXCEPTIONS.md) for feature and test work that is unlikely to be done by Code Freeze. As with the approved-for-milestone label, the exception approval is the responsibility of the SIG or SIGs labeled in the pull request. The release team may intervene or deny the request only if it poses a risk to release quality, or could negatively impact the overall timeline. Changes introduced at this point should be well-tested, well-understood, limited in architectural scope, and low risk.  All of those factors should be considered in the approval process.
+Starting at Code Slush, the release team will solicit and rule on [exception requests](https://github.com/kubernetes/features/blob/master/EXCEPTIONS.md) for feature and test work that is unlikely to be done by Code Freeze. As with the `status/approved-for-milestone` label, the exception approval is the responsibility of the SIG or SIGs labeled in the pull request. The release team may intervene or deny the request only if it poses a risk to release quality, or could negatively impact the overall timeline. Changes introduced at this point should be well-tested, well-understood, limited in architectural scope, and low risk.  All of those factors should be considered in the approval process.
 
 ### Code Freeze
 


### PR DESCRIPTION
The unprefixed label is deprecated and will be removed at some point