### PR TITLE
Update release team to reflect participation

### DIFF
--- a/releases/release-1.10/release_team.md
+++ b/releases/release-1.10/release_team.md
@@ -6,7 +6,7 @@
 | Test Infra | Cole Wagner ([@cjwagner](https://github.com/cjwagner)) | Benjamin Elder ([@BenTheElder](https://github.com/BenTheElder)) |
 | Bug Triage | Josh Berkus ([@jberkus](https://github.com/jberkus))| Tim Pepper ([@tpepper](https://github.com/tpepper))|
 | Branch Manager | Caleb Miles ([@calebamiles](https://github.com/calebamiles)) | |
-| Docs | Jennifer Rondeau ([@Bradamant3](https://github.com/Bradamant3)) | Jessica Yao ([@abiogenesis-now](https://github.com/abiogenesis-now)) |
+| Docs | Jennifer Rondeau ([@Bradamant3](https://github.com/Bradamant3)) | |
 | Release Notes | Nick Chase ([@nickchase](https://github.com/nickchase)) | Noah Abrahams ([@qedrakmar](https://github.com/qedrakmar)) |
 | Communications | Natasha Woods (@nwoods)  | Caitlyn O'Connell |
 | Patch Release Manager | Maciek Pytel ([@MaciekPytel](https://github.com/MaciekPytel)) | |

--- a/releases/release-1.10/release_team.md
+++ b/releases/release-1.10/release_team.md
@@ -1,7 +1,7 @@
 | **Role** | **Name** (**GitHub/Slack ID**)  | **Shadow Name(s) (GitHub/Slack ID), ...** |
 | ------ | ------ | ------ |
-| Lead | Jaice Singer DuMars ([@jdumars](https://github.com/jdumars)) | Steven Wade ([@swade1987](https://github.com/swade1987)) |
-| Features | Ihor Dvoretskyi ([@idvoretskyi](https://github.com/idvoretskyi)) | 	Weiwei Jiang ([@wjiangjay](https://github.com/wjiangjay)) |
+| Lead | Jaice Singer DuMars ([@jdumars](https://github.com/jdumars)) |  |
+| Features | Ihor Dvoretskyi ([@idvoretskyi](https://github.com/idvoretskyi)) |  |
 | CI Signal | Sen Lu ([@krzyzacy](https://github.com/krzyzacy)) | |
 | Test Infra | Cole Wagner ([@cjwagner](https://github.com/cjwagner)) | Benjamin Elder ([@BenTheElder](https://github.com/BenTheElder)) |
 | Bug Triage | Josh Berkus ([@jberkus](https://github.com/jberkus))| Tim Pepper ([@tpepper](https://github.com/tpepper))|
@@ -11,3 +11,5 @@
 | Communications | Natasha Woods (@nwoods)  | Caitlyn O'Connell |
 | Patch Release Manager | Maciek Pytel ([@MaciekPytel](https://github.com/MaciekPytel)) | |
 | Approval Notifier | 	k8s-ci-robot ([@k8s-ci-robot](https://github.com/k8s-ci-robot)) | |
+
+Special thanks: Jordan Liggitt ([@liggitt](https://github.com/liggitt)), Davanum Srinivas ([@dims](https://github.com/dims)), Cristoph Blecker ([@cblecker](https://github.com/cblecker))


### PR DESCRIPTION
Over the course of the release, things change. This reflects the reality of who has participated. This needs to be accurate because some roles require verified experience in the team in order to assume.  I added a section at the bottom to thank people who played long-term, undocumented support roles.  Without them, the release would not be possible.