### PR TITLE
Add mostly empty release team directory for 1.11

### DIFF
--- a/releases/release-1.11/release_team.md
+++ b/releases/release-1.11/release_team.md
@@ -1,0 +1,17 @@
+| **Role** | **Name** (**GitHub/Slack ID**)  | **Shadow Name(s) (GitHub/Slack ID), ...** |
+| ------ | ------ | ------ |
+| Lead | Josh Berkus ([@jberkus](https://github.com/jberkus))  |  |
+| Features | Ihor Dvoretskyi ([@idvoretskyi](https://github.com/idvoretskyi)) |  |
+| CI Signal | | |
+| Test Infra |  | Benjamin Elder ([@BenTheElder](https://github.com/BenTheElder)) |
+| Bug Triage | | |
+| Branch Manager | | |
+| Docs | | |
+| Release Notes | | |
+| Communications | | |
+| Patch Release Manager | | |
+| Approval Notifier | k8s-ci-robot ([@k8s-ci-robot](https://github.com/k8s-ci-robot)) | | |
+
+Special thanks:
+
+-


### PR DESCRIPTION
...but note that Josh is our Release Team Lead and Ihor will likely lead features again. The idea is to merge this skeleton quickly and then add the rest of the release info as it's available