### PR TITLE
v1.11 release team - add colemickens as shadow bug triage

### DIFF
--- a/releases/release-1.11/release_team.md
+++ b/releases/release-1.11/release_team.md
@@ -4,7 +4,7 @@
 | Features | Ihor Dvoretskyi ([@idvoretskyi](https://github.com/idvoretskyi)) |  |
 | CI Signal | Aishwarya Sundar ([@AishSundar](https://github.com/AishSundar)) | |
 | Test Infra | Benjamin Elder ([@BenTheElder](https://github.com/BenTheElder)) | Cole Wagner ([@cjwagner](https://github.com/cjwagner)/cjwagner) |
-| Bug Triage | Tim Pepper ([@tpepper](https://github.com/tpepper)) | |
+| Bug Triage | Tim Pepper ([@tpepper](https://github.com/tpepper)) | Cole Mickens ([@colemickens](https://github.com/colemickens)) |
 | Branch Manager | Caleb Miles ([@calebamiles](https://github.com/calebamiles)) | Sen Lu ([@krzyzacy](https://github.com/krzyzacy)) |
 | Docs | Zach Corliesson ([@zacharysarah](https://github.com/zacharysarah)) | |
 | Release Notes | Nick Chase ([@nickchase](https://github.com/nickchase)) | |


### PR DESCRIPTION
Hello. I'd like to volunteer to do `Bug Triage` for the v1.11 release cycle. (I skimmed the README, but didn't see a formal process for this, hopefully this is sufficient.)