### PR TITLE
Update CI Signal role in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,8 +200,8 @@ be familiar with the release process and remain ready to discharge the responsib
   finding manual testing volunteers, and ensuring any issues discovered are communicated widely and fixed quickly
 
 ### CI Signal Lead
-- Ensures that all non-upgrade test CI provides a clear go/no-go signal for the release
-- Tracks and finds owners to fix any issues with any (non-upgrade) tests
+- Ensures that all test (master-blocking, master-upgrade and 1.y-blocking) CI provides a clear go/no-go signal for the release
+- Tracks and finds owners to fix any issues with any tests
 
 ### Release Team Shadow
 Any Release Team member may select one or more mentees to shadow the release process in order to help fulfill future

--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@
    - [Features Lead](#features-lead)
    - [Bug Triage Lead](#bug-triage-lead)
    - [Test Infra Lead](#test-infra-lead)
-   - [Upgrade Testing Lead](#upgrade-testing-lead)
    - [CI Signal Lead](#ci-signal-lead)
    - [Release Team Shadow](#release-team-shadow)
    - [Individual Contributors](#individual-contributors)
@@ -191,13 +190,6 @@ be familiar with the release process and remain ready to discharge the responsib
 
 ### Test Infra Lead
 - Sets up and maintains all CI for the release branch
-
-### Upgrade Testing Lead
-- Ensures that automated upgrade tests provide a clear go/no-go signal for the release
-- Tracks and finds owners for all issues with automated upgrade tests
-- Ensures that any gaps in automated upgrade testing are covered by manual upgrade testing
-- Organizes the manual upgrade testing efforts, including setting up instructions for manual testing,
-  finding manual testing volunteers, and ensuring any issues discovered are communicated widely and fixed quickly
 
 ### CI Signal Lead
 - Ensures that all test (master-blocking, master-upgrade and 1.y-blocking) CI provides a clear go/no-go signal for the release


### PR DESCRIPTION
From my understanding and past history, the CI Signal lead also monitors and tracks issues with the Upgrade / downgrade tests as well. Modifying the README to reflect this.