### PR TITLE
Update OWNERS for 1.12 Release

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,4 +1,4 @@
-# See the OWNERS docs: https://git.k8s.io/community/contributors/devel/owners.md
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
 
 approvers:
   - idvoretskyi

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,4 +1,4 @@
-# See the OWNERS docs: https://git.k8s.io/community/contributors/devel/owners.md
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
 
 aliases:
   sig-release-leads:

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -14,6 +14,7 @@ aliases:
     - pwittrock
     - saad-ali
     - jberkus
+    - tpepper
   patch-release-managers:
     - enisoc
     - fabioy

--- a/releases/release-1.11/OWNERS
+++ b/releases/release-1.11/OWNERS
@@ -1,4 +1,4 @@
-# See the OWNERS docs: https://git.k8s.io/community/contributors/devel/owners.md
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
 
 approvers:
   - idvoretskyi

--- a/releases/release-1.12/OWNERS
+++ b/releases/release-1.12/OWNERS
@@ -1,0 +1,9 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+approvers:
+  - tpepper
+  - AishSundar
+  - justaugustus
+  - nickchase
+  - sig-release-leads
+  - release-team-leads


### PR DESCRIPTION
* updates OWNERS docs links
* adds Tim Pepper to top-level `release-team-leads` alias
* adds OWNERS for 1.12 Release

/assign @tpepper 