### PR TITLE
Add Kristen Evans as Communications Shadow

### DIFF
--- a/releases/release-1.12/release_team.md
+++ b/releases/release-1.12/release_team.md
@@ -8,6 +8,6 @@
 | Branch Manager | Doug MacEachern ([@dougm](https://github.com/dougm)) | Etienne Coutaud ([@etiennecoutaud](https://github.com/etiennecoutaud)), Yang Li ([@idealhack](https://github.com/idealhack)), Hannes Hoerl ([@hoegaarden](https://github.com/hoegaarden)), Travis Rhoden ([@codenrhoden](https://github.com/codenrhoden)) |
 | Docs | Zach Arnold ([@zparnold](https://github.com/zparnold)) | Samuel Tauil ([@samueltauil](https://github.com/samueltauil)), Jim Angel ([@jimangel](https://github.com/jimangel)), Tim Fogarty ([@tfogo](https://github.com/tfogo)) |
 | Release Notes | Nick Chase ([@nickchase](https://github.com/nickchase)) | Dave Strebel ([@dstrebel](https://github.com/dstrebel)), Lindsey Tulloch ([@onyiny-ang](https://github.com/onyiny-ang)) |
-| Communications | Kaitlyn Barnard ([@kbarnard10](https://github.com/kbarnard10)) | Keri Dell ([@kerilynndell](https://github.com/kerilynndell)) |
+| Communications | Kaitlyn Barnard ([@kbarnard10](https://github.com/kbarnard10)) | Keri Dell ([@kerilynndell](https://github.com/kerilynndell)), Kristen Evans ([@kristenevans](https://github.com/kristenevans)) |
 | Patch Release Manager | Pengfei Ni ([@feiskyer](https://github.com/feiskyer)) ||
 | Approval Notifier | k8s-ci-robot ([@k8s-ci-robot](https://github.com/k8s-ci-robot)) ||


### PR DESCRIPTION
Kristen will be running point on PR / media briefings for the 1.12 release, as she did for 1.11. I'd like to add her as an official shadow so she can be closer to the release process and learn the role.