### PR TITLE
Add @marpaia to 1.12 release team

### DIFF
--- a/releases/release-1.12/OWNERS
+++ b/releases/release-1.12/OWNERS
@@ -5,5 +5,6 @@ approvers:
   - AishSundar
   - justaugustus
   - nickchase
+  - marpaia
   - sig-release-leads
   - release-team-leads

--- a/releases/release-1.12/release_team.md
+++ b/releases/release-1.12/release_team.md
@@ -7,7 +7,7 @@
 | Bug Triage | Guinevere Saenger ([@guineveresaenger](https://github.com/guineveresaenger)/ @gsaenger on Slack) | Jeremy Rickard ([@jeremyrickard](https://github.com/jeremyrickard)), Arnaud Meukam ([@ameukam](https://github.com/ameukam)), Anubhuti Manohar ([@amanohar](https://github.com/amanohar)), Niko Penteridis ([@dogopupper](https://github.com/dogopupper)) |
 | Branch Manager | Doug MacEachern ([@dougm](https://github.com/dougm)) | Etienne Coutaud ([@etiennecoutaud](https://github.com/etiennecoutaud)), Yang Li ([@idealhack](https://github.com/idealhack)), Hannes Hoerl ([@hoegaarden](https://github.com/hoegaarden)), Travis Rhoden ([@codenrhoden](https://github.com/codenrhoden)) |
 | Docs | Zach Arnold ([@zparnold](https://github.com/zparnold)) | Samuel Tauil ([@samueltauil](https://github.com/samueltauil)), Jim Angel ([@jimangel](https://github.com/jimangel)), Tim Fogarty ([@tfogo](https://github.com/tfogo)) |
-| Release Notes | Nick Chase ([@nickchase](https://github.com/nickchase)) | Dave Strebel ([@dstrebel](https://github.com/dstrebel)), Lindsey Tulloch ([@onyiny-ang](https://github.com/onyiny-ang)) |
+| Release Notes | Nick Chase ([@nickchase](https://github.com/nickchase)) | Dave Strebel ([@dstrebel](https://github.com/dstrebel)), Lindsey Tulloch ([@onyiny-ang](https://github.com/onyiny-ang)), Mike Arpaia ([@marpaia](https://github.com/marpaia)) |
 | Communications | Kaitlyn Barnard ([@kbarnard10](https://github.com/kbarnard10)) | Keri Dell ([@kerilynndell](https://github.com/kerilynndell)), Kristen Evans ([@kristenevans](https://github.com/kristenevans)) |
 | Patch Release Manager | Pengfei Ni ([@feiskyer](https://github.com/feiskyer)) ||
 | Approval Notifier | k8s-ci-robot ([@k8s-ci-robot](https://github.com/k8s-ci-robot)) ||


### PR DESCRIPTION
I added myself as a Release Notes Shadow for 1.12 again as I'd like to continue working on release note generation tooling for this release (see https://github.com/kubernetes/release/pull/575 for some initial work so far) and it would be useful to be on the release team distribution lists when possible.

I also added myself to the `OWNERS` so that I can help approve commits to the release notes drafts.