### PR TITLE
add short url for 1.12 release info

### DIFF
--- a/releases/release-1.12/release-1.12.md
+++ b/releases/release-1.12/release-1.12.md
@@ -2,6 +2,8 @@
 
 *Handy Links*
 
+* This document via short url:
+  [http://bit.ly/k8s112-release-info](http://bit.ly/k8s112-release-info)
 * [Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.12/release_team.md)
 * Zoom: join Google Group to receive meeting invite
 * [Slack](https://kubernetes.slack.com/messages/sig-release/)


### PR DESCRIPTION
Discussion in SIG ContribEx slack indicated info on the current release
isn't easy enough to find.  It doesn't help that links to the release
specific info in this repo are long.  So here's a shortened url for 1.12
and easier sharing to point people at it.

Signed-off-by: Tim Pepper <tpepper@vmware.com>