### PR TITLE
update alpha cadence

### DIFF
--- a/releases/release-1.12/release-1.12.md
+++ b/releases/release-1.12/release-1.12.md
@@ -38,11 +38,11 @@
 | Finalize Release Team | Lead | 13 | | | | | |
 | Start Release Notes Draft | Release Notes Lead | 17 | || | week 3 | |
 | Clean up features repo | Features Lead | 17 | | | | | |
-| 1.12.0-alpha.1 release | Branch Manager | 18 | || | |master-blocking, master-upgrade |
 | "Feature Freeze" begins (EOD PST) | Features Lead | 31 | || | week 4 | |
-| 1.12.0-alpha.2 release | Branch Manager | 31 | | | | week 5 | master-blocking, master-upgrade |
+| 1.12.0-alpha.1 release | Branch Manager | 31 | | | | week 5 | master-blocking, master-upgrade |
 | Blog post: what we're working on for 1.12 | Communications | | 9 | | | week 6 | |
 | Create 'release-1.12' branch and begin daily branch | Branch Manager | |14 | | | | |
+| v1.13.0-alpha.0 | Branch Manager | | 14 | | | | |
 | 1.12.0-beta.0 released from branch | Branch Manager | | 14 | | | week 7 | master-blocking, master-upgrade |
 | All release branch CI jobs created | Test Infra Lead | |17 | | | | |
 | Docs deadline - Open placeholder PRs | Docs Lead | |21 | | | | |
@@ -64,7 +64,6 @@
 | cherry pick deadline | Branch Manager | | | 21 | | | |
 | v1.12.0 | Branch Manager | | | 25 | |week 13 | 1.12-blocking |
 | Release retrospective | Community | | | 27? | | | | |
-| v1.12.0-alpha.1 | Branch Manager | | | | 1 | | |
 | 1.13 Release Cycle Begins | Next Lead | | | | 1 | | |
 
 ## Details


### PR DESCRIPTION
As it's been explained to me, the first alpha (alpha.0) is autocreated
at the time of the prior release's branch creation.  For...reasons?

That leaves the second alpha (alpha.1) as the first point where the
current release team builds an alpha release and the new release branch
manager gets to work out any process and permissions kinks.

Looking back it appears there's been legacy copy/pasted info implying
the first alpha was .1 and happened in week 2, but that hasn't been the
case.  This commit brings the calendar for 1.12 in line with what
happened on prior releases and is happening for 1.12.

Signed-off-by: Tim Pepper <tpepper@vmware.com>