### PR TITLE
Add `sig/release` label to OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -5,3 +5,5 @@ approvers:
   - jdumars
   - sig-release-leads
   - release-team-lead-role
+labels:
+  - sig/release


### PR DESCRIPTION
Everything in this repo is governed under SIG Release, issues / PRs such be tagged as such.
This adds automatically labels issues / PRs opened with `sig/release`

/sig release