### PR TITLE
README: update meeting notes link

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 - [Google group](https://groups.google.com/forum/#!forum/kubernetes-sig-release)
 - [Slack channel](https://kubernetes.slack.com/messages/C2C40FMNF/)
 - [Events and meetings calendar](https://calendar.google.com/calendar/embed?src=coreos.com_regcvcrgvq98lua2ikijg1g1uk%40group.calendar.google.com&ctz=America/Los_Angeles)
-- [Meeting agenda and notes](https://docs.google.com/document/d/1Q6Ux-vsiRuiXhXSkVqGr9FUZifqVGRdCWkzVI1UT4l0/edit?usp=sharing) ([read-only archive](https://docs.google.com/a/google.com/document/d/e/2PACX-1vRsGZTlmggTI5T4ysYGlaJiaW3vgnrc_dlv-B1nnt69gU2Xt6vzRpZDMm-7driIj14T1DraicGzkAHr/pub))
+- [Meeting agenda and notes](https://docs.google.com/document/d/1Fu6HxXQu8wl6TwloGUEOXVzZ1rwZ72IAhglnaAMCPqA/edit) ([read-only archive](https://docs.google.com/a/google.com/document/d/e/2PACX-1vRsGZTlmggTI5T4ysYGlaJiaW3vgnrc_dlv-B1nnt69gU2Xt6vzRpZDMm-7driIj14T1DraicGzkAHr/pub))
 
 ## Responsibilities
 - Ensuring high quality Kubernetes releases


### PR DESCRIPTION
The [current link](https://docs.google.com/document/d/1Q6Ux-vsiRuiXhXSkVqGr9FUZifqVGRdCWkzVI1UT4l0/edit#heading=h.gjdgxs) points to a document which has notes only from the 2017 meetings.

The [new link](https://docs.google.com/document/d/1Fu6HxXQu8wl6TwloGUEOXVzZ1rwZ72IAhglnaAMCPqA/edit) has 2018 meeting notes as well. This link was taken from https://github.com/kubernetes/community/blob/master/sig-release/README.md.

/assign tpepper 