### PR TITLE
Adds release-notes role to role-handbooks

### DIFF
--- a/release-team/role-handbooks/release-notes/OWNERS
+++ b/release-team/role-handbooks/release-notes/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+  - release-notes-role
+reviewers:
+  - release-notes-role

--- a/release-team/role-handbooks/release-notes/README.md
+++ b/release-team/role-handbooks/release-notes/README.md
@@ -34,6 +34,19 @@ in completing the notes
 - [Release notes tool](https://github.com/marpaia/release-notes)
 - [Hackmd](https://hackmd.io/)
 
+
+## Todos
+
+Update this section at the end of each release for the next team
+
+### Post 1.12 todos
+
+- Create new tool to process language in generated release notes file (or incorporate into the release notes tool)
+    Goals:
+    - Generate uniform style across release notes (ie. past tense, formatting)
+    - Decrease copy editing time
+
+
 ## Release Milestone Activities:
 
 <table>

--- a/release-team/role-handbooks/release-notes/README.md
+++ b/release-team/role-handbooks/release-notes/README.md
@@ -29,6 +29,10 @@ in completing the notes
 - The confirmed upon notes are cleaned up and copy edited by the release team to ensure uniform language/style is used.
 - Kubernetes is released with the completed notes!
 
+## Tools
+
+- [Release notes tool](https://github.com/marpaia/release-notes)
+- [Hackmd](https://hackmd.io/)
 
 ## Release Milestone Activities:
 
@@ -39,19 +43,18 @@ in completing the notes
   </tr>
   <tr>
     <td>1</td>
-    <td>- Former Release Notes lead helps identify new leads and shadows
-<br>- Help finalize release-notes milestones in the release timeline
-<br>- ? </td>
+<td>- Begin running release-notes script for ongoing collection of release notes
+<br>- Begin attending release team meetings
+<br>- Informal intro meeting with release notes team to discuss contact information and logistics </td>
   </tr>
   <tr>
     <td>2</td>
-    <td>- Begin attending release team meetings
-<br>- Finalize lead and shadow rolesi
-<br>- ?</td>
+<td>- ?</td>
   </tr>
   <tr>
     <td>3</td>
-    <td>- ?</td>
+    <td>- Begin attending burndown meetings
+    <br>- ?</td>
   </tr>
   <tr>
     <td>4</td>
@@ -75,12 +78,13 @@ in completing the notes
   </tr>
   <tr>
     <td>9</td>
-    <td>- Begin attending burndown meetings
+    <td>- Former Release Notes lead helps identify new leads and shadows
 <br>- ?</td>
   </tr>
   <tr>
     <td>10</td>
-    <td>- ?</td>
+    <td>- Finalize lead and shadow roles
+    <br>- ?</td>
   </tr>
   <tr>
     <td>11</td>

--- a/release-team/role-handbooks/release-notes/README.md
+++ b/release-team/role-handbooks/release-notes/README.md
@@ -79,26 +79,25 @@ in completing the notes
   <tr>
     <td>9</td>
     <td>- Former Release Notes lead helps identify new leads and shadows
-<br>- ?</td>
+<br>- Start determining major themes for release notes template to send to sig-leads </td>
   </tr>
   <tr>
     <td>10</td>
-    <td>- Finalize lead and shadow roles
-    <br>- ?</td>
+    <td>- Finalize lead and shadow roles for subsequent release
+    <br>- Work with sig-leads to finalize major themes for release-notes
+    <br>- Copy edit notes for spelling, grammar and uniform style</td>
   </tr>
   <tr>
     <td>11</td>
-    <td>- ?</td>
+    <td>- Repeat previous tasks until final copy is complete</td>
   </tr>
   <tr>
     <td>12</td>
     <td>- Release day
-<br>- Continue managing release timing in case of delay
-<br>- ?</td>
+<br>- Final version of release notes submitted for release </td>
   </tr>
   <tr>
     <td>13</td>
-    <td>- Release retrospective participation
-<br>- ? </td>
+    <td>- Release retrospective participation</td>
   </tr>
 </table>

--- a/release-team/role-handbooks/release-notes/README.md
+++ b/release-team/role-handbooks/release-notes/README.md
@@ -1,0 +1,82 @@
+# Kubernetes Release Team: Release Notes
+
+## Overview:
+
+The Release Notes role is responsible for collecting and fine-tuning release-notes from the many contributions to kubernetes between release cycles.
+
+## Skills and Experience Required:
+
+* Strong written and verbal communications skills
+
+* A working knowledge of Kubernetes concepts
+
+* Project management experience is helpful
+
+## Release Milestone Activities:
+
+<table>
+  <tr>
+    <td>RELEASE WEEK</td>
+    <td>ACTIVITIES</td>
+  </tr>
+  <tr>
+    <td>1</td>
+    <td>- Former Release Notes lead helps identify new leads and shadows
+<br>- Help finalize release-notes milestones in the release timeline
+<br>- ? </td>
+  </tr>
+  <tr>
+    <td>2</td>
+    <td>- Begin attending release team meetings
+<br>- Finalize lead and shadow rolesi
+<br>- ?</td>
+  </tr>
+  <tr>
+    <td>3</td>
+    <td>- ?</td>
+  </tr>
+  <tr>
+    <td>4</td>
+    <td>- ?</td>
+  </tr>
+  <tr>
+    <td>5</td>
+    <td>- ?</td>
+  </tr>
+  <tr>
+    <td>6</td>
+    <td>- ?</td>
+  </tr>
+  <tr>
+    <td>7</td>
+    <td>- ?</td>
+  </tr>
+  <tr>
+    <td>8</td>
+    <td>- ?</td>
+  </tr>
+  <tr>
+    <td>9</td>
+    <td>- Begin attending burndown meetings
+<br>- ?</td>
+  </tr>
+  <tr>
+    <td>10</td>
+    <td>- ?</td>
+  </tr>
+  <tr>
+    <td>11</td>
+    <td>- ?</td>
+  </tr>
+  <tr>
+    <td>12</td>
+    <td>- Release day
+<br>- Continue managing release timing in case of delay
+<br>- ?</td>
+  </tr>
+  <tr>
+    <td>13</td>
+    <td>- Release retrospective participation
+<br>- ? </td>
+  </tr>
+</table>

--- a/release-team/role-handbooks/release-notes/README.md
+++ b/release-team/role-handbooks/release-notes/README.md
@@ -53,72 +53,46 @@ Update this section at the end of each release for the next team
 
 ## Release Milestone Activities:
 
-<table>
-  <tr>
-    <td>RELEASE WEEK</td>
-    <td>ACTIVITIES</td>
-  </tr>
-  <tr>
-    <td>1</td>
-<td>- Begin running release-notes script for ongoing collection of release notes
-<br>- Begin attending release team meetings
-<br>- Informal intro meeting with release notes team to discuss contact information and logistics </td>
-  </tr>
-  <tr>
-    <td>2</td>
-<td>- Same as above</td>
-  </tr>
-  <tr>
-    <td>3</td>
-    <td>- Begin attending burndown meetings
-    <br>- Same as above</td>
-  </tr>
-  <tr>
-    <td>4</td>
-    <td>- Same as above</td>
-  </tr>
-  <tr>
-    <td>5</td>
-    <td>- Same as above</td>
-  </tr>
-  <tr>
-    <td>6</td>
-    <td>- Same as above</td>
-  </tr>
-  <tr>
-    <td>7</td>
-    <td>- Same as above</td>
-  </tr>
-  <tr>
-    <td>8</td>
-    <td>- Same as above</td>
-  </tr>
-  <tr>
-    <td>9</td>
-    <td>- Former Release Notes lead helps identify new leads and shadows
-    <br>- Create Google Doc for generated release notes and share with release-notes team
-    <br>- Share created doc with release-team
-<br>- Start determining major themes for release notes template to send to sig-leads </td>
-  </tr>
-  <tr>
-    <td>10</td>
-    <td>- Finalize lead and shadow roles for subsequent release
-    <br>- Work with sig-leads to finalize major themes for release-notes
-    <br>- Copy edit notes for spelling, grammar and uniform style</td>
-  </tr>
-  <tr>
-    <td>11</td>
-    <td>- Repeat previous tasks until final copy is complete
-    <br>- Ensure "known issues" section is incorporated into final document</td>
-  </tr>
-  <tr>
-    <td>12</td>
-    <td>- Release day
-<br>- Copy notes from Google Doc to HackMD in markdown
-<br>- Final version of release notes committed for release </td>
-  </tr>
-  <tr>
-    <td>13</td>
-    <td>- Release retrospective participation</td>
-  </tr>
-</table>
+### Week 1 - 2
+
+- Begin running release-notes script for ongoing collection of release notes
+- Begin attending release team meetings
+- Informal intro meeting with release notes team to discuss contact information and logistics
+
+
+### Weeks 3 - 8
+
+- Begin attending burndown meetings
+- Same as above
+
+
+### Week 9
+
+- Former Release Notes lead helps identify new leads and shadows
+- Create Google Doc for generated release notes and share with release-notes team
+- Share created doc with release-team
+- Start determining major themes for release notes template to send to sig-leads
+
+
+### Week 10
+
+- Finalize lead and shadow roles for subsequent release
+- Work with sig-leads to finalize major themes for release-notes
+- Copy edit notes for spelling, grammar and uniform style
+
+
+### Week 11
+
+- Repeat previous tasks until final copy is complete
+- Ensure "known issues" section is incorporated into final document
+
+### Week 12
+
+- Release day
+- Copy notes from Google Doc to HackMD in markdown
+- Final version of release notes committed for release
+
+### Week13
+
+- Release retrospective participation
+

--- a/release-team/role-handbooks/release-notes/README.md
+++ b/release-team/role-handbooks/release-notes/README.md
@@ -3,6 +3,8 @@
 ## Overview:
 
 The Release Notes role is responsible for collecting and fine-tuning release-notes from the many contributions to kubernetes between release cycles.
+This role is likely to find that work during the first several weeks of the release cycle is very laid back with the bulk of the tasks being
+completed at the end, once the release is firmed up.
 
 ## Skills and Experience Required:
 
@@ -11,6 +13,22 @@ The Release Notes role is responsible for collecting and fine-tuning release-not
 * A working knowledge of Kubernetes concepts
 
 * Project management experience is helpful
+
+## Tasks
+
+- The Release notes lead and shadows attend burn down meetings, sig-release meetings and follow the sig-release slack chat for relevant
+information throughout the release cycle to keep up with relevant release specific information.
+- One member of the release notes team should be responsible for setting up and running the [release notes tool](https://github.com/marpaia/release-notes)
+to collect generated drafts of all release-notes identified in the current release -- improvements to the tool are always welcome!
+- Drafts produced by the tool are copied to Hackmd and shared with the rest of the release team (there is currently no automated way to keep the generated
+release-notes and the hackmd file concurrent. Some tool to automate this process would be a good task for the 1.13 release team)
+- Closer to the release date, major themes are collected from the release notes draft and the release notes team creates a draft in markdown of
+the identified major themes to send to sig-leads for feedback/confirmation
+- If gentle nudging of sig leads is not effective in retrieving feedback/confirmation, the release-notes team can use a reasonable amount of creative liberity
+in completing the notes
+- The confirmed upon notes are cleaned up and copy edited by the release team to ensure uniform language/style is used.
+- Kubernetes is released with the completed notes!
+
 
 ## Release Milestone Activities:
 

--- a/release-team/role-handbooks/release-notes/README.md
+++ b/release-team/role-handbooks/release-notes/README.md
@@ -16,17 +16,21 @@ completed at the end, once the release is firmed up.
 
 ## Tasks
 
-- The Release notes lead and shadows attend burn down meetings, sig-release meetings and follow the sig-release slack chat for relevant
-information throughout the release cycle to keep up with relevant release specific information.
+- The Release notes lead and shadows attend burn down meetings, sig-release meetings and follow the sig-release
+slack chat for relevant information throughout the release cycle.
 - One member of the release notes team should be responsible for setting up and running the [release notes tool](https://github.com/marpaia/release-notes)
-to collect generated drafts of all release-notes identified in the current release -- improvements to the tool are always welcome!
-- Drafts produced by the tool are copied to Hackmd and shared with the rest of the release team (there is currently no automated way to keep the generated
-release-notes and the hackmd file concurrent. Some tool to automate this process would be a good task for the 1.13 release team)
-- Closer to the release date, major themes are collected from the release notes draft and the release notes team creates a draft in markdown of
-the identified major themes to send to sig-leads for feedback/confirmation
-- If gentle nudging of sig leads is not effective in retrieving feedback/confirmation, the release-notes team can use a reasonable amount of creative liberity
-in completing the notes
-- The confirmed upon notes are cleaned up and copy edited by the release team to ensure uniform language/style is used.
+to collect generated drafts of all release-notes identified in the current release -- improvements to the tool are
+always welcome!
+- Drafts produced by the tool are copied to a Google Document that gives editing privleges to each member of the
+release-notes team (there is currently no automated way to keep the generated release-notes and the google doc
+concurrent. Some tool to automate this process would be a good task for the 1.13 release team)
+- Closer to the release date, major themes are collected from the release notes draft and the release notes team
+creates a draft in markdown of the identified major themes to send to sig-leads for feedback/confirmation
+- If gentle nudging of sig leads is not effective in retrieving feedback/confirmation, the release-notes team can
+use a reasonable amount of creative liberity in completing the notes
+- A "Known Issues" section will also be created in a github issue to be added to the release notes before release date
+- The confirmed upon notes are cleaned up and copy edited by the release-notes team to ensure uniform language/style
+is used.
 - Kubernetes is released with the completed notes!
 
 ## Tools
@@ -41,11 +45,11 @@ Update this section at the end of each release for the next team
 
 ### Post 1.12 todos
 
-- Create new tool to process language in generated release notes file (or incorporate into the release notes tool)
-    Goals:
+- Implement new functionality in release-notes tool to process language in generated release notes file
+
+  Goals:
     - Generate uniform style across release notes (ie. past tense, formatting)
     - Decrease copy editing time
-
 
 ## Release Milestone Activities:
 
@@ -62,36 +66,38 @@ Update this section at the end of each release for the next team
   </tr>
   <tr>
     <td>2</td>
-<td>- ?</td>
+<td>- Same as above</td>
   </tr>
   <tr>
     <td>3</td>
     <td>- Begin attending burndown meetings
-    <br>- ?</td>
+    <br>- Same as above</td>
   </tr>
   <tr>
     <td>4</td>
-    <td>- ?</td>
+    <td>- Same as above</td>
   </tr>
   <tr>
     <td>5</td>
-    <td>- ?</td>
+    <td>- Same as above</td>
   </tr>
   <tr>
     <td>6</td>
-    <td>- ?</td>
+    <td>- Same as above</td>
   </tr>
   <tr>
     <td>7</td>
-    <td>- ?</td>
+    <td>- Same as above</td>
   </tr>
   <tr>
     <td>8</td>
-    <td>- ?</td>
+    <td>- Same as above</td>
   </tr>
   <tr>
     <td>9</td>
     <td>- Former Release Notes lead helps identify new leads and shadows
+    <br>- Create Google Doc for generated release notes and share with release-notes team
+    <br>- Share created doc with release-team
 <br>- Start determining major themes for release notes template to send to sig-leads </td>
   </tr>
   <tr>
@@ -102,12 +108,14 @@ Update this section at the end of each release for the next team
   </tr>
   <tr>
     <td>11</td>
-    <td>- Repeat previous tasks until final copy is complete</td>
+    <td>- Repeat previous tasks until final copy is complete
+    <br>- Ensure "known issues" section is incorporated into final document</td>
   </tr>
   <tr>
     <td>12</td>
     <td>- Release day
-<br>- Final version of release notes submitted for release </td>
+<br>- Copy notes from Google Doc to HackMD in markdown
+<br>- Final version of release notes committed for release </td>
   </tr>
   <tr>
     <td>13</td>


### PR DESCRIPTION
This PR adds documentation for the release-notes lead and shadows.

