### PR TITLE
Remove top-level branch mgr table and redirect to `/releases`

### DIFF
--- a/release-managers.md
+++ b/release-managers.md
@@ -1,26 +1,6 @@
-# Release Managers
+Branch Managers, past and present, can now be found in the [releases directory](/releases) within `release-x.y/release_team.md`.
+Example: [1.12 Release Team](/releases/release-1.12/release_team.md)
 
-| Releases  | Primary | Secondary | Initial Release | Final Release |
-| ---------- | ------- | --------- | --------- | --------- |
-| 1.2 minor (up to 1.2.0) | Brian Grant [@bgrant0607](https://github.com/bgrant0607) | - | - | - |
-| 1.2 patch (post 1.2.0)  | Robert Bailey [@roberthbailey](https://github.com/roberthbailey) | [@zmerlynn](https://github.com/zmerlynn) | - | - | 
-| 1.3 minor (up to 1.3.0) | Eric Tune [@erictune](https://github.com/erictune) | - | - | - |
-| 1.3 patch (post 1.3.0)  | Fabio Yeon [@fabioy](https://github.com/fabioy) | [@timstclair](https://github.com/timstclair) | - | - | 
-| 1.4 minor (up to 1.4.0) | Phillip Wittrock [@pwittrock](https://github.com/pwittrock)  | - | - | - |
-| 1.4 patch (post 1.4.0) | Jess Frazelle [@jessfraz](https://github.com/jessfraz) | - | - | - |
-| 1.5 minor (up to 1.5.0) | Saad Ali [@saad-ali](https://github.com/saad-ali) | - | - | - |
-| 1.5 patch (post 1.5.0) | Saad Ali [@saad-ali](https://github.com/saad-ali) until 1.5.3<br/><br/>Marcin Wielgus [@mwielgus](https://github.com/mwielgus) after 1.5.3 | Saad Ali [@saad-ali](https://github.com/saad-ali) | - | - | 
-| 1.6 minor (up to 1.6.0) | Dan Gillespie [@ethernetdan](https://github.com/ethernetdan) | Anthony Yeh [@enisoc](https://github.com/enisoc) | - | - | 
-| 1.6 patch (post 1.6.0) | Anthony Yeh [@enisoc](https://github.com/enisoc) | - | - | - |
-| 1.7 minor (up to 1.7.0) | Dawn Chen [@dchen1107](https://github.com/dchen1107) | Caleb Miles [@calebamiles](https://github.com/calebamiles) | - | - | 
-| 1.7 patch (post 1.7.0) | Wojciech Tyczynski [@wojtek-t](https://github.com/wojtek-t) | - | - | - |
-| 1.8 minor (up to 1.8.0) | Jaice Singer DuMars [@jdumars](https://github.com/jdumars) | Caleb Miles [@calebamiles](https://github.com/calebamiles) | - | - |
-| 1.8 patch (post 1.8.0) | Joe Betz [@jpbetz](https://github.com/jpbetz) | - | - | - |
-| 1.9 minor (up to 1.9.0) | Anthony Yeh [@enisoc](https://github.com/enisoc) | Jaice Singer DuMars [@jdumars](https://github.com/jdumars) | - | - |
-| 1.9 patch (post 1.9.0) | Mehdy Bohlool [@mbohlool](https://github.com/mbohlool) | - | - | - |
-| 1.10 minor (up to 1.10.0) | Jaice Singer DuMars [@jdumars](https://github.com/jdumars) | - | - | - |
-| 1.10 patch (post 1.10.0) | Maciek Pytel [@MaciekPytel](https://github.com/MaciekPytel) | - | - | - |
-| 1.11 minor (up to 1.11.0) | Josh Berkus ([@jberkus](https://github.com/jberkus)) | - | - | - |
-| 1.11 patch (post 1.11.0) | Anirudh Ramanathan ([@foxish](https://github.com/foxish)) | - | - | - |
-| 1.12 minor (up to 1.12.0) | Tim Pepper ([@tpepper](https://github.com/tpepper)) | - | - | - |
-| 1.12 patch (post 1.12.0) | Pengfei Ni ([@feisky](https://github.com/feiskyer)) | - | - | - |
+<!--
+This file is a placeholder to preserve links.  Please remove after 3 months or the release of kubernetes 1.13, whichever comes first.
+-->


### PR DESCRIPTION
Fixes: #285 
/sig release
/assign @philips @tpepper 

Signed-off-by: Stephen Augustus <foo@agst.us>