### PR TITLE
security-release-process: require certified Kubernetes distributions

### DIFF
--- a/security-release-process-documentation/email-templates.md
+++ b/security-release-process-documentation/email-templates.md
@@ -1,0 +1,24 @@
+# Kubernetes Security Process Email Templates
+
+This is a collection of email templates to handle various situations the PST needs to handle.
+
+## Distributor List Removal
+
+Subject: Kubernetes Disclosure List Removal Due to Uncertified Status
+
+Hello $MEMBER-
+
+The [Kubernetes Product Security Team][pst] has removed $EMAIL from the kubernetes-distributors-announce Google Group.
+
+This is because $PRODUCT is no longer a [certified Kubernetes Distribution][conformance], a requirement for membership to this list.
+
+If $PRODUCT recertifies, and meets all other criteria, please submit a [request to re-join using the normal process][join-process].
+
+Thank You,
+
+$PERSON on behalf of the Kubernetes
+
+[pst]: https://github.com/kubernetes/sig-release/blob/master/security-release-process-documentation/security-release-process.md#product-security-team-pst
+[conformance]: https://www.cncf.io/certification/software-conformance/
+[criteria]: https://github.com/kubernetes/sig-release/blob/master/security-release-process-documentation/security-release-process.md#membership-criteria
+[join-process]: https://github.com/kubernetes/sig-release/blob/master/security-release-process-documentation/security-release-process.md#private-distributors-list

--- a/security-release-process-documentation/security-release-process.md
+++ b/security-release-process-documentation/security-release-process.md
@@ -250,7 +250,9 @@ could be in the form of the following:
 To be eligible for the kubernetes-distributors-announce mailing list, your
 distribution should:
 
-1. Be an actively maintained distribution of kubernetes components.
+0. Have an actively monitored security email alias for our project.
+1. Be an actively maintained and [CNCF certified distribution of
+   Kubernetes][conformance] components.
 2. Have a user base not limited to your own organization.
 3. Have a publicly verifiable track record up to present day of fixing security
    issues.
@@ -260,6 +262,11 @@ distribution should:
 7. Be willing to [contribute back](#contributing-back) as outlined above.
 8. Have someone already on the list vouch for the person requesting membership
    on behalf of your distribution.
+
+[conformance]: https://www.cncf.io/certification/software-conformance/
+
+**Removal**: If your distribution stops meeting one or more of these criteria
+after joining the list then you will be unsubscribed.
 
 ### Requesting to Join
 
@@ -275,6 +282,11 @@ To: kubernetes-security@googlegroups.com
 Subject: Seven-Corp Membership to kubernetes-distributors-announce
 
 Below are each criterion and why I think we, Seven-Corp, qualify.
+
+> 0. Have an actively monitored security alias email for our project.
+
+Yes, please subscribe kubernetes-security-team@example.com to the distributor's
+announce list.
 
 > 1. Be an actively maintained distribution of kubernetes components.
 


### PR DESCRIPTION
Certification creates a clean cut decision process for the PST to decide
whether a person or organization can join the list. It beats the
alternative which is the PST trying to make a judgement call on their
own.

Further clarify that you will be removed from the list if your project
stops meeting criteria and encourage use of email aliases.