### PR TITLE
Add a RC2 date on 1.13 release calendar

### DIFF
--- a/releases/release-1.13/README.md
+++ b/releases/release-1.13/README.md
@@ -63,6 +63,7 @@
 | PRs for v1.13.0 must be cherry picked to release-1.13 | Branch Manager | | 28 | | | | |
 | Notify kubernetes-dev of lifting code freeze | Lead | | 28 | | | | |
 | cherry pick deadline (EOD PST) | Branch Manager | | 30 | | | | |
+| 1.13.0-rc.2 released from branch | Branch Manager | | 30 | | | | [1.13-blocking], [master-blocking], [master-upgrade] |
 | v1.13.0 | Branch Manager | | | 3 | |week 10 | [1.13-blocking] |
 | Release retrospective | Community | | | 6? | | | | |
 | Contributor Summit + Kubecon Seattle 2018 | Community event | | | 9 - 13 | | week 11 | |


### PR DESCRIPTION
Following up on the comments from 1.12 Retro to have 2 RC builds during the release cycle. I thought we had in on the schedule, but looks like I confused this with the 2 Beta cuts.

/assign @dims 

/cc @spiffxp @dougm 

