### PR TITLE
Test-Infra handbook updates.

### DIFF
--- a/release-team/role-handbooks/test-infra/README.md
+++ b/release-team/role-handbooks/test-infra/README.md
@@ -1,21 +1,18 @@
-# Test Infra Lead Playbook
+# Test Infra Lead Handbook
 
 Note: Currently, the test-infra lead has to be someone from Google GKE Engprod Team, in order to gain access to the prow cluster. This
 will change once we migrate our testing infrastructure under CNCF account. (xref kubernetes/test-infra#5085)
 
 There are three major area that test-infra lead need to take care during the release cycle, which are:
 
-1. [Create CI/Presubmit jobs for the new release, and populate the testgrid dashboard](#create-cipresubmit-jobs-for-the-new-release)
+1. [Create CI/Presubmit jobs for the new release, and populate the Testgrid dashboard](#create-cipresubmit-jobs-for-the-new-release)
 
 1. [Configure merge automation for code slush, freeze, and thaw](#configure-merge-automation-for-code-slush-freeze-and-thaw)
 
 1. [Watch for test infra status, make sure test infra is stable, react to test infra related issues and notify Release Lead and CI Signal Lead of issue status changes](#ensure-the-stability-of-test-infra)
 
-It's important to ensure the stability of our test infra during the release cycle, so that we can get reliable testing signals throughout the release cycle.
-
-You can also work with @kubernetes/test-infra-maintainers or [test infra oncall](https://go.k8s.io/oncall) if you are blocked by anything.
-
-Also feel free to ping #sig-testing and #testing-ops to reach out for help.
+You can work with @kubernetes/test-infra-maintainers or [test infra oncall](https://go.k8s.io/oncall) if you are blocked by anything.
+Also feel free to ping the `#sig-testing` and `#testing-ops` Kubernetes Slack channels to reach out for help.
 
 ## Create CI/Presubmit jobs for the new release
 
@@ -31,11 +28,11 @@ Note that this section reflects the status of the world today, we are actively l
 
 1. Update release version in the [image bump script](https://github.com/kubernetes/test-infra/blob/master/experiment/bump_e2e_image.sh) and push new kubekins images by running the script. (Note that the runner need to have access to [k8s-testimages](https://pantheon.corp.google.com/home/dashboard?project=k8s-testimages) gcp project)
 
-1. Similarly, make a new Dockerfile for [kubekins-test](https://github.com/kubernetes/test-infra/tree/master/images/kubekins-test) image, this is the image we used for our integration and verify jobs. Also bump the image tags in the [kuberketes_verify scenario](https://github.com/kubernetes/test-infra/blob/master/scenarios/kubernetes_verify.py)
+1. Similarly, make a new Dockerfile for [kubekins-test](https://github.com/kubernetes/test-infra/tree/master/images/kubekins-test) image, this is the image we used for our integration and verify jobs. Also bump the image tags in the [kubernetes_verify scenario](https://github.com/kubernetes/test-infra/blob/master/scenarios/kubernetes_verify.py)
 
 1. grep for `manual-release-bump-required` under [test-infra](https://github.com/kubernetes/test-infra), those are the jobs that need to be manually bumped per release cycle, remap them to the up-to-date branches. Similar to 2, Fork a new version of kubernetes/kubernetes presubmit job, and remove references to the older branches.
 
-1. Okay, now let's update the testgrid config. It's a manual work now, basically you want to find dashboard tabs for release-1.x, and bump that, and the jobs inside, to release-1.(x+1)
+1. Okay, now let's update the Testgrid config. It's a manual work now, basically you want to find dashboard tabs for release-1.x, and bump that, and the jobs inside, to release-1.(x+1)
 
 1. Finally, update the [release target section](https://github.com/kubernetes/test-infra#release-branch-jobs--image-validation-jobs)
 
@@ -164,10 +161,9 @@ During the release cycle, especially inside the code freeze, the test infra lead
 
 1. If the presubmit/CI is failing due to test infra issues (do some initial triage with CI Signal Lead)
 
-1. If PRs are merging into master/release branches
+1. If Tide is merging PRs into the master and release branches
 
-We record test-infra commit SHAs in each testgrid tab, and if CI starts to fail between two test-infra commits,
-test infra lead can diff the SHAs to triage if the failure is caused by a test-infra change.  
+We record test-infra commit SHAs in each Testgrid tab, and if CI starts to fail between two test-infra commits, test infra lead can diff the SHAs to triage if the failure is caused by a test-infra change.
 
 The [velodrome monitoring dashboard](http://velodrome.k8s.io/dashboard/db/monitoring?orgId=1) will be your good friends.
 
@@ -177,6 +173,11 @@ It is important to monitor Tide after config changes are made for code slush, fr
 
 Until the CNCF infra migration is complete, a member of Google's gke-engprod team will need to monitor Tide logs.
 However, most of Tide's behavior can be monitored without access to the cluster. The [Tide dashboard](https://prow.k8s.io/tide) and [Velodrome monitoring dashboard](http://velodrome.k8s.io/dashboard/db/monitoring?orgId=1) provide insight into what Tide is currently doing, how much load it is handling, and how it is performing.
+
+### Test-Infra 'Code Freeze'
+
+The stability of our test infra is critical to getting reliable testing signals throughout the release cycle, but the signal is most important at the end of the release cycle during code slush and freeze. While the `kubernetes/test-infra` repo does not enforce additional merge restrictions related to the release cycle, we do try to limit the changes that are merged. Specifically, during slush and freeze, changes to test-infra should be limited to important fixes and work that doesn't impact critical infrastructure. Large changes should be delayed if possible.
+In particular, bumping the kubekins-e2e images should be avoided unless a critical fix in necessary.
 
 ## Useful Links
 


### PR DESCRIPTION
I addressed some of the follow up requested on https://github.com/kubernetes/sig-release/pull/313. 
I didn't add examples for all the CI job updates as we will now be doing things differently from last release (creating new jobs for every branch instead of reusing some jobs for multiple branches).
I'll update the docs and add examples as we figure out the details for that.

/assign @AishSundar 
/cc @krzyzacy @amwat @imkin 