### PR TITLE
Request an additional alpha release

### DIFF
--- a/releases/release-1.13/README.md
+++ b/releases/release-1.13/README.md
@@ -36,10 +36,11 @@
 | Begin collecting planned work from SIGs | Lead, Enhancements Lead | 8| | | | week 2 | |
 | Begin weekly status reports at Community | Lead, Shadow | 11 | | | | | |
 | Finalize Release Team | Lead | 12 | | | | | |
+| 1.13.0-alpha.1 release | Branch Manager | 12 | | | | | |
 | Start Release Notes Draft | Release Notes Lead | 16 | || | week 3 | |
 | Clean up enhancements repo | Enhancements Lead | 16 | | | | | |
 | "Enhancements Freeze" begins (EOD PST) | Enhancements Lead | 23 | || | week 4 | |
-| 1.13.0-alpha.1 release | Branch Manager | 23 | | | | | [master-blocking], [master-upgrade] |
+| 1.13.0-alpha.2 release | Branch Manager | 23 | | | | | [master-blocking], [master-upgrade] |
 | Begin MWF Burndown meetings | Lead | | 5 | | | week 6 | |
 | All release-1.9 CI jobs/testgrid removed | Test Infra Lead | | 6 | | | | |
 | Create 'release-1.13' branch and begin daily branch | Branch Manager | | 6 | | | | |


### PR DESCRIPTION
Why do we need an extra alpha release?

- In v1.12, towards the end we did not have proper tags in the repositories published by publish bot from staging/ as we ran into different issues. So to exercise the tools earlier in the cycle, both both and release tooling will be helpful for the patch branch manager and shadows as well the folks manning the bots.
- Different teams (for example https://github.com/kubernetes-incubator/external-storage) depend on the tags we publish, so more times we cut the tag, the easier it will be for folks to keep up with master and keep things up-to-date. (Example i am dealing with right now is that pkg/util/version moved into apimachinery and if we don't cut an extra alpha, it will be 2 weeks before any consumers can sync with the changes going on in k/k master)

I don't know if the alpha.1 has any other connotation/meaning in the larger scheme of the release process. Hope i have made my case :)

cc @AishSundar @tpepper @calebamiles