### PR TITLE
RT Lead language fix

### DIFF
--- a/release-team/role-handbooks/release-team-lead/README.md
+++ b/release-team/role-handbooks/release-team-lead/README.md
@@ -2,11 +2,11 @@
 
 ## Overview:
 
-The release team leader role is responsible for coordinating release activities, assembling the release team, taking ultimate accountability for all release tasks to be completed on time, and ensuring a retrospective happens. The lead is also responsible for ensuring a successor is selected and trained for future release cycles.
+The release team leader role is responsible for coordinating release activities, assembling the release team, taking ultimate accountability for all release tasks to be completed on time, and ensuring that a retrospective happens. The lead is also responsible for ensuring a successor is selected and trained for future release cycles.
 
 ## Authority and Responsibility:
 
-A guiding principle for the lead is to be an arbiter of decisions, and not the primary decision-maker. A lead should constantly search for the best-qualified people or SIGs to guide the decision, not "go it alone" unless it is a very specific concern within the release process itself. When decisions are made they must be weighted in favor of community concerns over those of individuals or specific companies. Leads must also relinquish any favoritism for the company they work for. If there is a conflict of interest, the lead must refuse themselves from that decision. Above all, the release lead is a servant leader to the team and the community.
+The Release Team Lead should be an arbiter of decisions, and not the primary decision-maker. A lead should constantly search for the best-qualified people or SIGs to guide the decision, not "go it alone", unless it is a very specific concern within the release process itself. When decisions are made they must be weighted in favor of community concerns over those of individuals or specific companies. Leads must also relinquish any favoritism for the company they work for. If there is a conflict of interest, the lead must recuse themselves from that decision. Above all, the release lead is a servant leader to the team and the community.
 
 ## Skills and Experience Required:
 


### PR DESCRIPTION
Signed-off-by: Stephen Augustus <foo@agst.us>

I saw #338 fly by and I wanted to un-fix the fix.
- `s/A guiding principle for the lead is to be an arbiter of decisions/The Release Team Lead should be an arbiter of decisions` (the former has weird mouth feel)
- `s/refuse/recuse` (this was already correct prior to the PR)