### PR TITLE
Update OWNERS*

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,9 +1,9 @@
 approvers:
+  - sig-release-leads
+reviewers:
   - idvoretskyi
   - spiffxp
-  - calebamiles
   - jdumars
-  - sig-release-leads
   - release-team-lead-role
 labels:
   - sig/release

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,7 +1,8 @@
 aliases:
   sig-release-leads:
     - calebamiles
-    - jdumars
+    - justaugustus
+    - tpepper
   release-team-lead-role:
     - jdumars # 1.10
     - jberkus # 1.11


### PR DESCRIPTION
- Update SIG Release Leads
- Rescope `approvers`, so only SIG Release Leads are top-level approvers

Signed-off-by: Stephen Augustus <foo@agst.us>

/assign @calebamiles @jdumars @tpepper 