### PR TITLE
Update RT OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,9 +1,9 @@
 approvers:
   - sig-release-leads
 reviewers:
-  - idvoretskyi
-  - spiffxp
-  - jdumars
   - release-team-lead-role
+  - idvoretskyi
+  - jdumars
+  - spiffxp
 labels:
   - sig/release

--- a/release-team/OWNERS
+++ b/release-team/OWNERS
@@ -1,0 +1,11 @@
+reviewers:
+  - release-team-lead-role
+  - patch-release-manager-role
+  - ci-signal-role
+  - enhancements-role
+  - test-infra-role
+  - bug-triage-role
+  - branch-manager-role
+  - docs-role
+  - release-notes-role
+  - communications-role

--- a/releases/release-1.11/OWNERS
+++ b/releases/release-1.11/OWNERS
@@ -1,11 +1,10 @@
 approvers:
+  - jberkus # RT Lead
+reviewers:
   - idvoretskyi
   - spiffxp
   - calebamiles
   - jdumars
-  - jberkus
   - tpepper
   - nickchase
   - AishSundar
-  - sig-release-leads
-  - release-team-lead-role

--- a/releases/release-1.12/OWNERS
+++ b/releases/release-1.12/OWNERS
@@ -1,8 +1,7 @@
 approvers:
-  - tpepper
-  - AishSundar
+  - tpepper # RT Lead
+  - AishSundar # RT Lead Shadow
+reviewers:
   - justaugustus
   - nickchase
   - marpaia
-  - sig-release-leads
-  - release-team-lead-role

--- a/releases/release-1.13/OWNERS
+++ b/releases/release-1.13/OWNERS
@@ -1,11 +1,10 @@
 approvers:
-  - AishSundar
-  - spiffxp
+  - AishSundar # RT Lead
+  - spiffxp # RT Lead Shadow
+reviewers:
   - kacole2
   - jberkus
   - dougm
   - tfogo
   - marpaia
   - nikopen
-  - sig-release-leads
-  - release-team-lead-role


### PR DESCRIPTION
- Alphabetize top-level OWNERS
- Add `release-team/OWNERS`
- Add `reviewers` section for `releases/release-x.yy/OWNERS`

Two notes here:
- `sig-release-leads` and `release-team-lead-role` are top-level reviewers, so they have been removed from the individual `release-x.yy/OWNERS`
- Adding a `release-team/OWNERS` allows for reviews / `/lgtm`s from recent RT members, but note that approval for top-level changes is restricted to SIG Release Chairs (because of the inherent ephemeral nature of the Release Team)

Signed-off-by: Stephen Augustus <foo@agst.us>