### PR TITLE
Update release notes to bump Cluster Autoscaler to 1.13.0 from 1.13.0-rc2

### DIFF
--- a/releases/release-1.13/release-notes-draft.md
+++ b/releases/release-1.13/release-notes-draft.md
@@ -280,7 +280,7 @@ SIG Windows focused on improving reliability for Windows and Kubernetes support
 
 ### SIG Autoscaling
 
-- Updated Cluster Autoscaler version to 1.13.0-rc.2. See the [Release Notes](https://github.com/kubernetes/autoscaler/releases/tag/cluster-autoscaler-1.13.0-rc.2) for more information. ([#71452](https://github.com/kubernetes/kubernetes/pull/71452), [@losipiuk](https://github.com/losipiuk))
+- Updated Cluster Autoscaler version to 1.13.0. See the [Release Notes](https://github.com/kubernetes/autoscaler/releases/tag/cluster-autoscaler-1.13.0) for more information. ([#71513](https://github.com/kubernetes/kubernetes/pull/71513), [@losipiuk](https://github.com/losipiuk))
 
 ### SIG AWS
 


### PR DESCRIPTION
Now that freeze was lifted by @AishSundar, this PR contains a final scrape of the latest notes from k/k. There was just one note since yesterday: Cluster Autoscaler was bumped from 1.13.0-rc2 to 1.13.0. All in all, the 1.13 release note document was generated from `ad58349` to `9c50dd0`.

/assign @AishSundar 