### PR TITLE
Add Stable Branch Management Team

### DIFF
--- a/releases/release-1.14/release_team.md
+++ b/releases/release-1.14/release_team.md
@@ -9,4 +9,4 @@
 | Docs | Jim Angel ([@jimangel](https://github.com/jimangel)) |  |
 | Release Notes | Dave Strebel ([@dstrebel](https://github.com/dstrebel)) |  |
 | Communications | Natasha Woods ([@nwoods3](https://github.com/nwoods3)) |  Kaitlyn Barnard ([@kbarnard10](https://github.com/kbarnard10)) |
-| Patch Release Managers | | |
+| Stable Branch Management Team  | Aleksandra Malinowska ([@aleksandra-malinowska](https://github.com/aleksandra-malinowska)), Tim Pepper ([@tpepper](https://github.com/tpepper)) | Abubakr-Sadik Nii Nai Davis ([@ttousai](https://github.com/ttousai)) |


### PR DESCRIPTION
This PR adds a Stable Branch Management Team (two leads and shadows) which replaces the Patch Release Manager role. 

This seems like a natural progression from the historically one patch manager zero shadows to two leads (a.k.a team) no shadows and now a team of lead + shadows.

cc @tpepper @aleksandra-malinowska