### PR TITLE
security-release-process: add Micah Hausler associate

### DIFF
--- a/security-release-process-documentation/security-release-process.md
+++ b/security-release-process-documentation/security-release-process.md
@@ -83,6 +83,7 @@ The initial Product Security Team will consist of volunteers subscribed to the p
 
 [Associate](#Associate) members include:
 
+- Micah Hausler (**[@micahhausler](https://github.com/micahhausler)**) `<mhausler@amazon.com>`
 - Jonathan Pulsifer (**[@jonpulsifer](https://github.com/jonpulsifer)**) `<jonathan@pulsifer.ca>`
 - Joel Smith (**[@joelsmith](https://github.com/joelsmith)**) `<joelsmith@redhat.com>`
 


### PR DESCRIPTION
Micah has been helping with testing security-related fixes (specifically for https://github.com/kubernetes/kubernetes/issues/71411 and https://github.com/kubernetes/kubernetes/pull/71980) and is a member of the amazon engineering team

cc @kubernetes/product-security-team