### PR TITLE
Add 1.13 patch releases info

### DIFF
--- a/releases/patch-releases.md
+++ b/releases/patch-releases.md
@@ -1,0 +1,55 @@
+# Kubernetes patch releases' schedule
+
+Schedule and team contact information for Kubernetes patch releases.
+
+For general information about Kubernetes release cycle, see https://github.com/kubernetes/community/blob/master/contributors/devel/release.md
+
+# 1.13
+
+## Patch Release Management Team
+
+To discuss a cherry-pick, schedule, or anything else related to 1.13 patch releases,
+contact any member of the team. You can just tag us on #sig-release Slack channel
+or message directly. Please give us a business day to respond - we may be in a different timezone!
+
+Cherry-picks are monitored on regular basis, so it's likely you'll hear
+from us on PRs to release-1.13 branch by the time the next patch release is due.
+
+| **Github username** | **Slack username** |
+| --- | --- |
+| @aleksandra-malinowska | @aleksandram |
+| @tpepper | @tpepper |
+
+## Timeline
+
+Next patch release is **1.13.2**.
+
+Frequency of releases is likely to be about every 2 weeks at least until Kubernetes 1.14.0
+is released. After that, it may slow down based on demand. However, it can be affected
+by other factors, such as critical security fixes or holiday season.
+
+Cherry-picks deadline is the end of day by which all pending PRs to release-1.13
+branch have to merge to be included in the patch release. Any PRs left pending past
+this point will either wait for the next patch release, or may in rare cases
+delay current release.
+
+Target date is the date on which the patch release is cut. Must be at least 2
+days after cherry-picks deadline to allow all release-blocking tests to run.
+
+| **Patch Release** | **Cherry-picks deadline** | **Target date** | **Owner** |
+| --- | --- | --- | --- |
+| 1.13.3 | TBA | 2019-01-24 | TBA |
+| 1.13.2 | 2019-01-08 | 2019-01-10 | @tpepper |
+| 1.13.1 | 2018-12-11 | 2018-12-13 | @aleksandra-malinowska |
+
+# 1.12
+
+TODO(@feiskyer)
+
+# 1.11
+
+TODO(@foxish)
+
+# 1.10 and older
+
+These releases are no longer supported.


### PR DESCRIPTION
Quick draft w/ information about 1.13 patch release schedule proposed in #427. It's not meant to be perfect/include everything - I suspect we may have to iterate on it to find out what's most useful.

/kind documentation
/cc @tpepper @spiffxp 
