### PR TITLE
Initial draft of the 1.14 release schedule

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -4,47 +4,49 @@ aliases:
     - justaugustus
     - tpepper
   release-team-lead-role:
-    - jdumars # 1.10
     - jberkus # 1.11
     - tpepper # 1.12
     - aishsundar # 1.13
+    - spiffxp # 1.14
   patch-release-manager-role:
-    - MaciekPytel # 1.10
     - foxish # 1.11
     - feiskyer # 1.12
     - aleksandra-malinowska # 1.13
     - tpepper # 1.13
   ci-signal-role:
-    - krzyzacy # 1.10
     - aishsundar # 1.11
     - mohammedzee1000 # 1.12
     - jberkus # 1.13
+    - mariantalla # 1.14
   enhancements-role:
     - idvoretskyi # 1.11
     - justaugustus # 1.12
     - kacole2 # 1.13
+    - claurence # 1.14
   test-infra-role:
     - bentheelder # 1.11
-    - cjwagner # 1.13 / 1.12 / 1.10
+    - cjwagner # 1.13 / 1.12
+    - amwat # 1.14
   bug-triage-role:
-    - jberkus # 1.10
     - tpepper # 1.11
     - guineveresaenger # 1.12
-    - nikopen # 1.13
+    - nikopen # 1.13 / 1.14
   branch-manager-role:
-    - calebamiles # 1.11 / 1.10
+    - calebamiles # 1.11
     - dougm # 1.13 / 1.12
+    - hoegaarden # 1.14
   docs-role:
-    - bradamant3 # 1.10
     - misty # 1.11
     - zparnold # 1.12
     - tfogo # 1.13
+    - jimangel # 1.14
   release-notes-role:
-    - nickchase # 1.12 / 1.11 / 1.10
+    - nickchase # 1.12 / 1.11
     - marpaia # 1.13
+    - dstrebel # 1.10
   communications-role:
-    - nwoods # 1.10
     - kbarnard10 # 1.13 / 1.12 / 1.11
+    - nwoods3 # 1.14
   product-security-team:
     - philips
     - jessfraz

--- a/releases/release-1.14/README.md
+++ b/releases/release-1.14/README.md
@@ -42,7 +42,7 @@ The 1.14 release cycle is proposed as follows:
 
 
 | **What** | **Who** | **Jan** | **Feb** | **Mar** | **WEEK** | **CI SIGNAL** |
-| --- | --- | --- | --- | --- | --- | --- | --- |
+| --- | --- | --- | --- | --- | --- | --- |
 | Start of Release Cycle | Lead | Mon 7 | | | week 1 | [master-blocking] |
 | Schedule finalized | Lead | Fri 11 | | | | |
 | Team finalized | Lead | Tue 15 | | | week 2 | |

--- a/releases/release-1.14/README.md
+++ b/releases/release-1.14/README.md
@@ -1,0 +1,146 @@
+# Kubernetes 1.14
+
+#### Links
+
+* [This document](https://git.k8s.io/sig-release/releases/release-1.14/README.md)
+* [Release Team](https://git.k8s.io/sig-release/releases/release-1.14/release_team.md)
+* [Meeting Minutes](http://bit.ly/k8s114-minutes) (join [kubernetes-milestone-burndown@] to receive meeting invites)
+* Contact: [#sig-release] on slack, [kubernetes-sig-release@] on e-mail
+
+#### Tracking docs
+
+* TODO: [Enhancements Tracking Sheet](http://bit.ly/k8s114-enhancements)
+* TODO: [Bug Triage Tracking Sheet](http://bit.ly/k8s114-bugtriage)
+* TODO: [CI Signal Report](http://bit.ly/k8s114-cisignal)
+* [Retrospective Document](http://bit.ly/k8s114-retro)
+
+#### Guides
+
+* [Targeting Issues and PRs to This Milestone](https://git.k8s.io/community/contributors/devel/release.md)
+* [Triaging and Escalating Test Failures](https://git.k8s.io/sig-release/ephemera/testing.md) (TODO: this guide should live elsewhere, ref: [kubernetes/sig-release#428](https://github.com/kubernetes/sig-release/issues/428))
+
+## tl;dr
+
+The 1.14 release cycle is proposed as follows:
+
+- **Monday, January 07**: Week 1 - Release cycle begins
+- **Tuesday, January 29**: Week 4 - [Enhancements Freeze]
+- **Thursday, March 07**: Week 9* - [Code Freeze]
+- **Monday, March 25**: Week 12 - Kubernetes v1.14.0 released
+
+
+## What Will We Do Differently This Release?
+
+* All proposed Enhancements for this release must have an associated KEP.
+  * There is no grandfathering; if the enhancement had no associated KEP before, it must have one now.
+  * The KEP must have a checklist of requirements necessary for a feature to land as alpha, beta, or stable.  That checklist must have at a minimum a test plan, and an upgrade/downgrade plan.
+* There will be no Code Slush.
+  * Previous release teams have said the only value of Code Slush was a clear one week warning that Code Freeze is coming
+  * Use the start of [Burndown] meetings as that date if you need it
+
+## Timeline
+
+
+| **What** | **Who** | **Jan** | **Feb** | **Mar** | **WEEK** | **CI SIGNAL** |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| Start of Release Cycle | Lead | Mon 7 | | | week 1 | [master-blocking] |
+| Schedule finalized | Lead | Fri 11 | | | | |
+| Team finalized | Lead | Tue 15 | | | week 2 | |
+| 1.14.0-alpha.1 released | Branch Manager | Tue 15 | | | | |
+| Start Release Notes Draft | Release Notes Lead | Tue 22 | | | week 3 | |
+| **Begin [Enhancements Freeze]** (EOD PST) | Enhancements Lead | Tue 29 | | | week 4 | [master-blocking], [master-upgrade] |
+| 1.14.0-alpha.2 released | Branch Manager | Tue 29 | | | | |
+| 1.14.0-alpha.3 released | Branch Manager | | Tue 12 | | week 6 | |
+| release-1.14 branch created | Branch Manager | | Tue 19 | | week 7 | |
+| 1.14.0-beta.0 released | Branch Manager | | Tue 19 | | | |
+| **Begin [Burndown]** (MWF meetings) | Lead | | Mon 25 | | week 8 | |
+| **Call for [Exceptions]** | Lead | | Mon 25 | | week 8 | |
+| 1.14.0-beta.1 released | Branch Manager | | Tue 26 | | | |
+| Brace Yourself, Code Freeze is Coming | Comms | | Tue 26 | | | |
+| **Begin [Code Freeze]** (EOD PST) | Test Infra | | | Tue 5 | week 9 | [1.14-blocking], [master-blocking], [master-upgrade] |
+| Daily Burndown Meetings | Lead | | | Mon 11 | week 10 | |
+| 1.14.0-beta.2 released | Branch Manager | | | Tue 12 | | |
+| **Begin [Code Thaw]** (EOD PST) | Test Infra | | | Tue 19 | week 11 | [1.14-blocking] |
+| 1.14.0-rc.1 released | Branch Manager | | | Tue 19 | | |
+| **Cherry Pick Deadline** (EOD PST) | Branch Manager | | | Thu 21 | week 11 | |
+| **v1.14.0 released** | Branch Manager | | | Mon 25 | week 12 | |
+| Release retrospective | Community | | | Thu 28 | | | | |
+
+## Phases
+
+### Enhancements Freeze
+
+All enhancements going into the release must have an associated issue in the enhancements repo by ***Tuesday, January 29, 2019***. That issue must be in the 1.14 milestone.  SIG "themes" should also be in the release notes draft at this time to prepare for blog posts and release marketing.  Any work the SIG wants publicized needs to be called out to the Enhancements Lead so the Release Team communications lead can work with SIG-PM and the CNCF.
+
+### Burndown
+
+One week prior to Code Freeze, we increase the cadence of release team meetings to begin tracking work more closely.  We call this Burndown, because at this point we have a list of outstanding issues and PRs, and are actively working to burn that list down.  SIG representatives are asked to attend if their SIG has specific outstanding issues that are blocking the release.
+
+Join [kubernetes-milestone-burndown@] to get a calendar invite.  This meeting may conflict with other community meetings, please prioritize this meeting if a member of the release team asks you to attend.
+
+The intent of these meetings is to:
+
+* Focus on fixing bugs, eliminating test flakes and general release stabilization.
+* Ensure docs and release notes are written and accurate.
+* Identify all enhancement going into the release, and make sure alpha, beta, GA is marked in enhancements repo.
+* Provide a [one-stop view of release progress](https://bit.ly/k8s114-minutes) including relevant release metrics.
+
+### Code Freeze
+
+All enhancements going into the release must be code-complete, **including tests**, and have docs PRs open by ***Thursday, March 7th, 2018***.
+
+The docs PRs don't have to be ready to merge, but it should be clear what the topic will be and who is responsible for writing it. This person will become the primary contact for the documentation lead. It’s incredibly important that documentation work gets completed as quickly as possible.
+
+After this point, only release-blocking issues and PRs will be allowed in the milestone.
+
+### Code Thaw
+
+One week prior to release, it is expected that all but a handful of outstanding PRs for kubernetes v1.14.0 have landed in the release-1.14 branch.  Assuming the release team agrees, Code Freeze will be lifted, and we enter Code Thaw.
+
+From this point forward, any PRs intended for v1.14 must be cherry picked to the release-1.14 branch.
+
+## Processes
+
+### Exceptions
+
+Starting at [Burndown] the release team will solicit and rule on [exception requests] for enhancements and test work that is unlikely to be done by Code Freeze. The exception approval is the responsibility of the SIG or SIGs labeled in the pull request. The release team may intervene or deny the request only if it poses a risk to release quality, or could negatively impact the overall timeline. Changes introduced at this point should be well-tested, well-understood, limited in architectural scope, and low risk.  All of those factors should be considered in the approval process.  Enhancements on an feature branch with documentation, test cases, and passing CI are more likely to be accepted.
+
+### Pruning
+
+Enhancements that are partially implemented and/or lack sufficient tests may be considered for pruning beginning after [Code Freeze], unless they've been granted [Exceptions]
+
+The release team will work with SIGs and enhancements owners to evaluate each case, but for example, pruning could include actions such as:
+
+* Disabling the use of a new API or field
+* Switching the default value of a flag or field
+* Moving a new API or field behind an Alpha Enhancements gate
+* Reverting commits or deleting code
+
+This should occur before 1.14.0-beta.1 is cut so we have time to gather signal on whether the system is stable in this state. These are considered drastic measures, so the release team will strive to coordinate at-risk work with SIGs before this time. The goal is to make code freeze, and overall project transparency, enforceable despite the lack of a consistently used feature branch process.
+
+### Docs
+
+If an enhancement needs documentation, enter "Yes" in the enhancement tracking spreadsheet and add a link to the documentation PR. You can open documentation PRs in the [kubernetes/website] repository. If you have questions, the release documentation lead, or representatives from SIG-Docs will be happy to assist you.
+
+For documentation PRs:
+
+* Open PRs against the release-1.14 branch based off of the 1.14 release PR. The documentation workflow uses feature branches for release documentation, rather than basing from master. **Be sure to open your PR against the release branch**.
+* Add your PR to the 1.14 Release milestone.
+
+[Enhancements Freeze]: #enhancements-freeze
+[Burndown]: #burndown
+[Code Freeze]: #code-freeze
+[Code Thaw]: #code-thaw
+[Exceptions]: #exceptions
+
+[kubernetes-milestone-burndown@]: https://groups.google.com/forum/#!forum/kubernetes-milestone-burndown
+[kubernetes-sig-release@]: https://groups.google.com/forum/#!forum/kubernetes-sig-release
+[#sig-release]: https://kubernetes.slack.com/messages/sig-release/
+
+[kubernetes/website]: https://github.com/kubernetes/website
+
+[master-blocking]: https://testgrid.k8s.io/sig-release-master-blocking#Summary
+[master-upgrade]: https://testgrid.k8s.io/sig-release-master-upgrade#Summary
+[1.14-blocking]:https://testgrid.k8s.io/sig-release-1.14-blocking#Summary
+
+[exception requests]: https://github.com/kubernetes/enhancements/blob/master/EXCEPTIONS.md

--- a/releases/release-1.14/README.md
+++ b/releases/release-1.14/README.md
@@ -45,7 +45,7 @@ The 1.14 release cycle is proposed as follows:
 | --- | --- | --- | --- | --- | --- | --- |
 | Start of Release Cycle | Lead | Mon 7 | | | week 1 | [master-blocking] |
 | Schedule finalized | Lead | Fri 11 | | | | |
-| Team finalized | Lead | Tue 15 | | | week 2 | |
+| Team finalized | Lead | Fri 18 | | | week 2 | |
 | Start Enhancements Tracking | Enhancements Lead | Tue 15 | | | | |
 | 1.14.0-alpha.1 released | Branch Manager | Tue 15 | | | | |
 | Start Release Notes Draft | Release Notes Lead | Tue 22 | | | week 3 | |

--- a/releases/release-1.14/README.md
+++ b/releases/release-1.14/README.md
@@ -46,19 +46,22 @@ The 1.14 release cycle is proposed as follows:
 | Start of Release Cycle | Lead | Mon 7 | | | week 1 | [master-blocking] |
 | Schedule finalized | Lead | Fri 11 | | | | |
 | Team finalized | Lead | Tue 15 | | | week 2 | |
+| Start Enhancements Tracking | Enhancements Lead | Tue 15 | | | | |
 | 1.14.0-alpha.1 released | Branch Manager | Tue 15 | | | | |
 | Start Release Notes Draft | Release Notes Lead | Tue 22 | | | week 3 | |
 | **Begin [Enhancements Freeze]** (EOD PST) | Enhancements Lead | Tue 29 | | | week 4 | [master-blocking], [master-upgrade] |
 | 1.14.0-alpha.2 released | Branch Manager | Tue 29 | | | | |
 | 1.14.0-alpha.3 released | Branch Manager | | Tue 12 | | week 6 | |
+| release-1.10 jobs removed | Test Infra Lead | | Tue 12 | | | |
 | release-1.14 branch created | Branch Manager | | Tue 19 | | week 7 | |
 | 1.14.0-beta.0 released | Branch Manager | | Tue 19 | | | |
-| **Begin [Burndown]** (MWF meetings) | Lead | | Mon 25 | | week 8 | |
-| **Call for [Exceptions]** | Lead | | Mon 25 | | week 8 | |
+| release-1.14 jobs created| Test Infra Lead | | Tue 19 | | | |
+| **Begin [Burndown]** (MWF meetings) | Lead | | Mon 25 | | week 8 | [1.14-blocking], [master-blocking], [master-upgrade] |
+| **Call for [Exceptions]** | Lead | | Mon 25 | | | |
+| Brace Yourself, Code Freeze is Coming | Comms | | Mon 25 | | | |
 | 1.14.0-beta.1 released | Branch Manager | | Tue 26 | | | |
-| Brace Yourself, Code Freeze is Coming | Comms | | Tue 26 | | | |
-| **Begin [Code Freeze]** (EOD PST) | Test Infra | | | Tue 5 | week 9 | [1.14-blocking], [master-blocking], [master-upgrade] |
-| Daily Burndown Meetings | Lead | | | Mon 11 | week 10 | |
+| **Begin [Code Freeze]** (EOD PST) | Test Infra | | | Thu 7 | week 9 | |
+| Burndown Meetings daily| Lead | | | Mon 11 | week 10 | |
 | 1.14.0-beta.2 released | Branch Manager | | | Tue 12 | | |
 | **Begin [Code Thaw]** (EOD PST) | Test Infra | | | Tue 19 | week 11 | [1.14-blocking] |
 | 1.14.0-rc.1 released | Branch Manager | | | Tue 19 | | |


### PR DESCRIPTION
There are some role-specific things I forgot to add to the schedule, and I'd like to take a fresh pass at some of the detailed paragraphs.

I'm trying to tackle https://github.com/kubernetes/sig-release/issues/319 while I'm here by providing linkable descriptions of what I interpret as the different phases of the release