### PR TITLE
Update OWNERS for release-team

### DIFF
--- a/release-team/OWNERS
+++ b/release-team/OWNERS
@@ -1,11 +1,5 @@
-reviewers:
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - sig-release-leads
   - release-team-lead-role
-  - patch-release-manager-role
-  - ci-signal-role
-  - enhancements-role
-  - test-infra-role
-  - bug-triage-role
-  - branch-manager-role
-  - docs-role
-  - release-notes-role
-  - communications-role


### PR DESCRIPTION
This mildly conflates two concerns:
- I think the OWNERS of the release-team subproject should be distinct from the SIG Release Chairs
- I think the current and former release-team leads should have /approve access to release-team playbooks

I'm opting to addres the second concern here. We can replace aliases with specific people once we've had a chance to discuss at SIG Release