### PR TITLE
branch and patch release manager role handbooks update

### DIFF
--- a/release-team/role-handbooks/branch-manager/README.md
+++ b/release-team/role-handbooks/branch-manager/README.md
@@ -47,8 +47,6 @@
 Run the following command to affirm your release repo checkout is in a good state, your development client is fully configured, and your user identity is authorized for the builds:
 * `./gcbmgr`
    * should run successfully and even show some green colored "OK" words
-* `./gcbmgr --project kubernetes-release-test builds list`
-   * should show a list of containers builds and results
 * `./gcbmgr list`
    * should see for example: 1.9, 1.10, 1.11 builds
 
@@ -114,15 +112,16 @@ Adding the --rc flag switches behavior on to building release candidates.  Again
 * `./gcbmgr stage release-1.12 --official --build-at-head --nomock`
 
 ## Debs and RPMs
-These require an additional layer of build and publish, which is currently still done by a Googler.  After building, but before release notification, ping @mbohlool on slack indicating for which build (for example: 1.12.0-beta.1) Debs and RPMs are required.
+These require an additional layer of build and publish, which is currently still done by a Googler.  After building, but before release notification, ping @sumi on Slack indicating for which build (for example: 1.12.0) Debs and RPMs are required.
 
-These build relatively quickly and should be available ahead of sending the release notification, especially for the official release when the worldwide community will attempt to get the new artifacts.
+These build relatively quickly and should be available ahead of sending the release notification, especially for the official release when the worldwide community will attempt to get the new artifacts.  Since they build from the release tag, the first release step below is a pre-requisite for initiating the package builds.
 
-TODO: How do we automate this?  And in the meantime how do we insure it is not bottlenecked on a one-on-one ping of a single Google employee (@jpbetz or @mbohlool)?  And these should not just be made but also validated prior to the release-notify phase.
+TODO: How do we automate this?  And in the meantime how do we insure it is not bottlenecked on a one-on-one ping of a single Google employee (currently @sumi)?  And these should not just be made but also validated prior to the release-notify phase.
 
 ## Release
 Releasing has multiple phases.  In the first phase the non-public build artifacts are published.  In the second phase the email notification goes out to the community.
 * `./gcbmgr release master --buildversion=${{VERSIONID}} --nomock`
+* ...interface with Google staffing to complete Debs and RPMs build, as per the prior section...
 * `./release-notify v1.12.0-alpha.1`
 * `./release-notify v1.12.0-alpha.1 --nomock --mailto=${{YOUREMAILADDRESS}}[a][b]`
 

--- a/release-team/role-handbooks/patch-release-manager/README.md
+++ b/release-team/role-handbooks/patch-release-manager/README.md
@@ -1,41 +1,99 @@
 # Patch Release Manager Playbook
 
-This is a playbook intended to guide new patch release managers.
-It consists of opinions and recommendations from former patch release managers.
+As the name implies, Patch Release Managers are responsible for
+managing patches against Kubernetes release branches and making the
+1.X.Y patch releases during the support period after each 1.X minor
+release.  Kubernetes 1.X releases receive approximately 9 months
+of support in terms of patches for bugfixes and ongoing CI insuring
+the branch's health and the ability to update from 1.X.Y to 1.(X+1).Y,
+for the newest Y on each of those two branches.
 
-Note that patch release managers are ultimately responsible for carrying out
-their [duties](https://github.com/kubernetes/sig-release#patch-release-manager)
-in whatever manner they deem best for the project.
-The playbook is more what you call "guidelines" than actual rules.
+Specific duties of the Patch Release Manager include:
+
+- Ensuring the release branch (e.g. `release-1.13`) remains in a
+  healthy state as measured by the branch version specific release-blocking
+  CI (e.g. for version 1.13 it is [testgrid sig-release-1.13-blocking
+  board](https://testgrid.k8s.io/sig-release-1.13-blocking). If the
+  build breaks or any CI for the release branch becomes unhealthy due
+  to a bad merge or infrastructure issue, ensure that actions are
+  taken ASAP to bring it back to a healthy state.
+- Reviewing and approving [cherry
+  picks](https://git.k8s.io/community/contributors/devel/cherry-picks.md) to
+  the release branch.
+  - Patch releases should not contain new features, so ensure that
+    cherry-picks are for bug/security fixes only.
+  - Cherry picks should not destabilize the branch, so ensure that
+    either the PR has had time to stabilize in master or will have
+    time to stabilize in the release branch before the next patch
+    release is cut.
+- Setting the [schedule and cadence for patch
+  releases](/releases/patch-releases.md) and cutting the
+  [releases](https://github.com/kubernetes/kubernetes/releases).
+
+While this playbook is intended to guide Patch Release Managers,
+it largely consists of opinions and recommendations from former
+patch release managers.  Each Patch Release Managers is ultimately
+responsible for carrying out their duties in the manner they deem
+best for the project.  The playbook then is more what you might
+call "guidelines" than actual hard rules.  Still each Patch Release
+Manager should endeavor to keep this document up to date, improve
+its content, and improve the overall process of patch management
+for the project.
 
 ## Getting started
 
-* Add yourself to the [Release Manager table](/release-managers.md)
-  so the community knows you're the point of contact.
-* Ask a maintainer to add you to the [kubernetes-release-managers](https://github.com/orgs/kubernetes/teams/kubernetes-release-managers/members)
-  team so you have write access to the main repository.
-* Ask to be added to the [security-release-team](https://groups.google.com/a/kubernetes.io/forum/#!forum/security-release-team)
-  mailing list.
-* Ask to be given access to post to the [kubernetes-announce](https://groups.google.com/forum/#!forum/kubernetes-announce)
-  and [kubernetes-dev-announce](https://groups.google.com/forum/#!forum/kubernetes-dev-announce)
-  mailing lists.
-* Sync up with the outgoing release branch manager to take ownership of any
-  lingering issues on the branch.
-* Run [anago](https://github.com/kubernetes/release) in mock mode to get prompts
-  for setting up your environment, and familiarize yourself with the tool.
+You're here because you've volunteered and have been selected to
+contribute to patch release management for one or more branches.
+You will need to make yourself known to the community and gain
+access to multiple build and release tools:
+
+* Add your name and contact info, and if applicable a new section
+  for the current release, to the [Patch Releases landing
+  page](/releases/patch-release.md) so the community knows you're the
+  point of contact.  If your work is specific to one particular
+  release, add your name to that release's release team in the patch
+  release manager row, for example [here for
+  1.13](https://git.k8s.io/sig-release/releases/release-1.13/release_team.md).
+* Peribolos is used for GitHub team membership.  You need to be a member of the
+  [kubernetes-release-managers](https://github.com/orgs/kubernetes/teams/kubernetes-release-managers/members)
+  team to have write access to the main repository.  Send a pull request
+  against the [sig-release teams configuration](https://git.k8s.io/org/config/kubernetes/sig-release/teams.yaml)
+  adding your userid to the kubernetes-release-managers member list.
+* Ask the list owner(s) to add you to the
+  [security-release-team](https://groups.google.com/a/kubernetes.io/forum/#!forum/security-release-team)
+  via the owner contact form [here](https://groups.google.com/forum/#!contactowner/kubernetes-dev).
+* Ask the list owner(s) to give you access to post to these mailing lists:
+   * [kubernetes-announce](https://groups.google.com/forum/#!forum/kubernetes-announce) via owner contact form [here](https://groups.google.com/forum/#!contactowner/kubernetes-announce)
+   * [kubernetes-dev-announce](https://groups.google.com/forum/#!forum/kubernetes-dev-announce) via owner contact form [here](https://groups.google.com/forum/#!contactowner/kubernetes-dev-announce)
+* If applicable, sync up with the outgoing release branch manager
+  to take ownership of any lingering issues on the branch.
+* Review the [Branch Manager
+  Handbook](/release-team/role-handbooks/patch-release-manager/README.md) as
+  much of the tooling and process used by the branch manager pre-release
+  relates to the post-release duties of Patch Release management.
+  Pay close attention to the
+  [Pre-requirements](/release-team/role-handbooks/branch-manager#pre-requirements),
+  [Safety Check](/release-team/role-handbooks/branch-manager#safety-check), and
+  [Build and Release](/release-team/role-handbooks/branch-manager#build-and-release)
+  sections.  This outlines current requirements for running `gcbmgr` to do
+  builds.
 
 ## Cherry-pick requests
 
 As a patch release manager, you are responsible for reviewing
-[cherry-picks](https://github.com/kubernetes/community/blob/master/contributors/devel/cherry-picks.md)
+[cherry-picks](https://git.k8s.io/community/contributors/devel/cherry-picks.md)
 on your release branch.
 
 **Finding outstanding cherry-picks**
 
-Use a GitHub search such as [`is:pr is:open label:do-not-merge/cherry-pick-not-approved base:release-1.12`](https://github.com/kubernetes/kubernetes/pulls?utf8=%E2%9C%93&q=is%3Aopen+is%3Apr+base%3Arelease-1.12+label%3Ado-not-merge%2Fcherry-pick-not-approved+) to find all untriaged cherry-pick PRs for a branch.
+Use a GitHub search such as [`is:pr is:open
+label:do-not-merge/cherry-pick-not-approved
+base:release-1.13`](https://github.com/kubernetes/kubernetes/pulls?utf8=%E2%9C%93&q=is%3Aopen+is%3Apr+base%3Arelease-1.13+label%3Ado-not-merge%2Fcherry-pick-not-approved+)
+to find all un-triaged cherry-pick PRs for a branch.
 
-As an example of the kind of load to expect, there were about 100 cherry-pick PRs
-against the 1.11 milestone.
+As an example of the kind of load to expect, there were close to
+300 cherry-pick PRs against the 1.10 milestone during its approximately
+9 month lifetime.
 
 For each cherry-pick request:
 
@@ -105,8 +163,11 @@ For each cherry-pick request:
     Ask the PR author for context if it's not clear to you what the release note
     should say.
 
-    Lastly, make sure the release note is located where the [relnotes](https://github.com/kubernetes/release/blob/master/relnotes)
-    script will find it:
+    Lastly, make sure the release note is located where the
+    [relnotes](https://git.k8s.io/release/relnotes) script will
+    find it.  You'll know it was not in such a place if the PR is
+    labelled as `do-not-merge/release-note-label-needed`.  This can be
+    resolved by either of:
 
     * If the cherry-pick PR comes from a branch called `automated-cherry-pick-of-*`,
       then the release notes are taken from each parent PR (possibly more than one)
@@ -129,13 +190,15 @@ For each cherry-pick request:
 1.  **Approve for Cherry-pick**
 
     PRs on release branches follow a different review process than those on the
-    `master` branch.
-    Patch release managers review every PR on the release branch,
+    `master` branch.  Patch release managers review every PR on the release branch,
     but the focus is just on ensuring the above criteria are met.
-    The code itself was already reviewed, assuming it's copied from `master`.
+    The code itself was already reviewed, assuming it's copied from `master`, and
+    should have `/lgtm` and `/approve` from the relevant reviewers and
+    approvers in the code's associated OWNERS file.
 
     * For an *automated cherry-pick* (created with `hack/cherry_pick_pull.sh`),
       first make sure the parent PR has merged into master.
+
       If the parent PR hasn't merged yet, leave a comment explaining that you
       will wait for it before approving the cherry-pick.
       We don't want the release branch to get out of sync if the parent PR changes.
@@ -146,6 +209,7 @@ For each cherry-pick request:
       For cherry-picks that are clearly justified and low risk in your judgment,
       you can directly apply the `approved` label as long as the parent PR was
       approved and merged into `master`.
+
       If you lack sufficient context or have any doubts, leave a comment
       explaining that the PR needs to get an `/approve` from relevant OWNERS
       to ensure that the change is appropriate for a cherry-pick.
@@ -157,16 +221,20 @@ For each cherry-pick request:
       You don't need to do anything special to fall back to this process.
       The bot will suggest reviewers and approvers just like on `master`.
 
-    Finally, apply the `cherry-pick-approved` label and remove the `do-not-merge`
-    label to tell the bot that this PR is allowed to merge into a release
-    branch.
+    Compared to non-cherry-pick PR's, a cherry-pick PR has one
+    additional merge criteria:  The Patch Release Manager(s) are
+    entrusted with applying the `cherry-pick-approved` label.  This
+    is done manually directly through the GitHub UI, not through a
+    Prow command.  In response, the bot will remove the
+    `do-not-merge/cherry-pick-not-approved` label.
 
-    Note that the PR will not actually merge until it meets the usual criteria
+    Note that the PR will not actually merge until it meets all usual criteria
     enforced by the merge bot (`lgtm` + `approved` labels, required presubmits,
     etc.) and makes its way through the submit queue.
-    To give cherry-pick PRs priority over other PRs in the submit queue,
-    make sure the PR is in the `vX.Y` release milestone, and that the milestone
-    has a due date.
+
+    Tide has pools per active branch, so release branch cherry-pick
+    PRs pending merge will be visible as rows distinct from the master
+    branch in the [Tide Status](https://prow.k8s.io/tide).
 
 ## Branch health
 
@@ -175,8 +243,10 @@ on presubmits that are failing across the whole branch.
 Also periodically check the [testgrid](https://k8s-testgrid.appspot.com)
 dashboard for your release branch to make sure the continuous jobs are healthy.
 
-Escalate to test owners or [sig-testing](https://github.com/kubernetes/community/tree/master/sig-testing)/[test-infra](https://github.com/kubernetes/test-infra)
-as needed to diagnose failures.
+Escalate to test owners,
+[sig-testing](https://git.k8s.io/community/sig-testing), and
+[test-infra](https://git.k8s.io/test-infra) as needed to diagnose
+failures.
 
 ## Release timing
 
@@ -193,17 +263,35 @@ account input from cherry-pick PR authors and SIGs.
 For example, some bugs may be serious enough, and have a clear enough fix,
 to trigger a new patch release immediately.
 
-You should attend the [sig-release](https://github.com/kubernetes/community/tree/master/sig-release)
-meetings whenever possible to give updates on activity in your release branch
+As a 1.X minor release is getting towards its final weeks pre-release, it
+is beneficial to begin tracking that release team's meetings to get an
+early idea of bugs for which the fix may need delays to the 1.X.1 first
+patch release and insure a smooth hand off from the release team into the
+post-release patch support phase.
+
+You should attend the [Kubernetes Community Meeting](http://bit.ly/k8scommunity)
+whenever possible to give updates on activity in your release branch
 (bugs, tests, cherry-picks, etc.) and discuss release timing.
 
 When you have a plan for the next patch release, send an announcement
-([example](https://groups.google.com/forum/#!topic/kubernetes-dev-announce/HGYsjOFtcdU))
-to [kubernetes-dev@googlegroups.com](https://groups.google.com/forum/#!forum/kubernetes-dev)
-(and *BCC* [kubernetes-dev-announce@googlegroups.com](https://groups.google.com/forum/#!forum/kubernetes-dev-announce))
-several working days in advance.
-You can generate a preview of the release notes with the [relnotes](https://github.com/kubernetes/release/blob/master/relnotes)
-script ([example usage](https://gist.github.com/enisoc/058bf0feddf6bffd8e25aa72f9dc38d6)).
+([example](https://groups.google.com/forum/#!topic/kubernetes-dev-announce/HGYsjOFtcdU)):
+
+* TO: [kubernetes-dev@googlegroups.com](https://groups.google.com/forum/#!forum/kubernetes-dev)
+* *BCC*: [kubernetes-dev-announce@googlegroups.com](https://groups.google.com/forum/#!forum/kubernetes-dev-announce)
+
+several working days in advance, including a release notes preview.
+You generate the preview with the [relnotes](https://git.k8s.io/release/relnotes)
+script, run against a local checkout of the release branch, and querying
+GitHub via an API token associated with your GitHub identity.  For example:
+
+```bash
+~$ cd src/k8s.io/kubernetes
+~/src/k8s.io/kubernetes$ git checkout release-1.13
+~/src/k8s.io/kubernetes$ ../release/relnotes --htmlize-md \
+		--markdown-file=~/tmp/relnotes.md \
+		--html-file=~/tmp/relnotes.html \
+		--preview
+```
 
 ## Release cut
 
@@ -225,9 +313,32 @@ The freeze serves several purposes:
 1.  It allows slow test jobs like "serial", which has a period of many hours,
     to run several times at `HEAD` to ensure they pass consistently.
 
-On the day before the planned release, run a mock build with `anago` to make
-sure the tooling is ready.
-If the mock goes well and the tests are healthy, run the real cut the next day.
+On the day before the planned release, run a mock build with `gcbmgr`
+to make sure the tooling is ready as per the [Branch Manager
+Handbook](/release-team/role-handbooks/patch-release-manager/README.md).
+Also give the Google Debs/RPMs build staff notification that their
+help will be needed the next day.  Once you've done the mock build, you can
+also do a mock release and notify, sending the release notification email
+to yourself to visual confirm its content:
+
+```bash
+~$ cd src/k8s.io/release
+~$ ./release-notify v1.13.2 --nomock --mailto=you@somewhere.com
+```
+
+If the mock build and release goes well and CI tests show the branch
+is healthy, run the real cut the next day by repeating the build
+and release process with the `--nomock` argument in the commands.
+Collaborate with the Google Debs/RPMs build staff to insure the
+packages are successfully published.  Then announce the release:
+
+```bash
+~$ cd src/k8s.io/release
+~$ ./release-notify v1.13.2 --nomock
+```
+
+This will automatically send the formatted announcement to the
+kubernetes-dev and kubernetes-announce mailing lists.
 
 After the release cut, reapply the `cherry-pick-approved` label to any PRs that
 had it before the freeze, and go through the backlog of new cherry-picks.
@@ -242,7 +353,7 @@ For example, we may need to fix a severe bug quickly without taking on the added
 risk of allowing other changes in.
 
 In this case, you would create a new, three-part branch of the form
-`release-X.Y.Z`, which [branches from a tag](https://github.com/kubernetes/release/blob/master/docs/branching.md#branching-from-a-tag)
+`release-X.Y.Z`, which [branches from a tag](https://git.k8s.io/release/docs/branching.md#branching-from-a-tag)
 called `vX.Y.Z`.
 You would then use the normal cherry-pick PR flow, except that you target PRs at
 the `release-X.Y.Z` branch instead of `release-X.Y`.
@@ -255,11 +366,12 @@ next patch release.
 
 ### Security release
 
-The Product Security Team (PST) will contact you if a security release is needed
-on your branch.
-In contrast to a normal release, you should not make any public announcements
+The Product Security Team (PST) will contact you if a security
+releases are needed on branches.
+
+In contrast to a normal release, you must not make any public announcements
 or push tags or release artifacts to public repositories until the PST tells you to.
 
-See the [Security Release Process](https://github.com/kubernetes/sig-release/blob/master/security-release-process-documentation/security-release-process.md)
+See the [Security Release Process](https://git.k8s.io/sig-release/security-release-process-documentation/security-release-process.md)
 doc for more details.
 


### PR DESCRIPTION
Running through the 1.13.2 patch release process I found a number of places where the documentation had gotten stale or was lacking on clarity.  This PR has two commits to separate some small cleaning of the branch manager role handbook from a partial rewrite of the patch manager handbook.