### PR TITLE
Add dirs for RelEng and Licensing subprojects

### DIFF
--- a/licensing/OWNERS
+++ b/licensing/OWNERS
@@ -1,0 +1,7 @@
+approvers:
+  - dims
+  - justaugustus
+  - nikhita
+  - swinslow
+labels:
+  - area/licensing

--- a/licensing/README.md
+++ b/licensing/README.md
@@ -1,0 +1,3 @@
+# Licensing
+
+Placeholder for Licensing subproject

--- a/release-engineering/OWNERS
+++ b/release-engineering/OWNERS
@@ -1,0 +1,11 @@
+approvers:
+  - aleksandra-malinowska
+  - calebamiles
+  - tpepper
+reviewers:
+  - hoegaarden
+  - sumitranr
+  - branch-manager-role
+  - patch-release-manager-role
+labels:
+  - area/release-eng

--- a/release-engineering/README.md
+++ b/release-engineering/README.md
@@ -1,0 +1,3 @@
+# Release Engineering
+
+Placeholder for Release Engineering subproject


### PR DESCRIPTION
Placeholders and initial OWNERS for RelEng and Licensing subprojects
Labels will be in place once kubernetes/test-infra#10852 merges.
sigs.yaml update in kubernetes/community#3119

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/assign @calebamiles @tpepper @spiffxp @nikhita 