### PR TITLE
Branch Manager Handbook: Add note to request mailing list access

### DIFF
--- a/release-team/role-handbooks/branch-manager/README.md
+++ b/release-team/role-handbooks/branch-manager/README.md
@@ -33,6 +33,8 @@
    * TODO: should the release lead also request some type of read access here for themselves?
    * TODO: should the branch manager shadows also get at least read access at the beginning?  If a shadow is going to exercise the process on behalf of the lead, they will need full read/write access ahead of time.
    * TODO: can the group name be identified here in a clear/transparent way?
+* Ask the list owner(s) to give you access to **post** to these mailing lists:
+   * [kubernetes-announce][k-announce-list] via owner contact form [here][k-announce-request]
 * Development client machine setup:
    * Linux.  MacOS/Windows are not supported by the scripting today.
    * ssh configuration set up for GitHub (either static .ssh/config or ssh agent works)
@@ -42,6 +44,9 @@
    * ability to run `sendmail` from local Unix command line (BUG: should release-notify script be sending from GCB instead of the local machine, and can it?)
    * branchff: requires ability for your user to write /usr/local/ directory (BUG),
      sudo priv's, and membership in https://github.com/orgs/kubernetes/teams/kubernetes-release-managers
+
+[k-announce-list]: https://groups.google.com/forum/#!forum/kubernetes-announce
+[k-announce-request]: https://groups.google.com/forum/#!contactowner/kubernetes-announce
 
 # Safety Check
 Run the following command to affirm your release repo checkout is in a good state, your development client is fully configured, and your user identity is authorized for the builds:


### PR DESCRIPTION
When cutting v1.14.0-alpha.2 I noticed that my mails show up on kubernetes-dev@ but not on kubernetes-announce@ list.

/cc @tpepper @spiffxp @kubernetes/sig-release 