### PR TITLE
Add subproject aliases and update releng OWNERS

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -3,6 +3,17 @@ aliases:
     - calebamiles
     - justaugustus
     - tpepper
+  licensing:
+    - dims
+    - justaugustus
+    - nikhita
+    - swinslow
+  release-engineering:
+    - aleksandra-malinowska
+    - calebamiles
+    - ixdy
+    - mikedanese
+    - tpepper
   release-team-lead-role:
     - jberkus # 1.11
     - tpepper # 1.12

--- a/licensing/OWNERS
+++ b/licensing/OWNERS
@@ -1,9 +1,6 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-  - dims
-  - justaugustus
-  - nikhita
-  - swinslow
+  - licensing
 labels:
   - area/licensing

--- a/release-engineering/OWNERS
+++ b/release-engineering/OWNERS
@@ -1,9 +1,7 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-  - aleksandra-malinowska
-  - calebamiles
-  - tpepper
+  - release-engineering
 reviewers:
   - hoegaarden
   - sumitranr


### PR DESCRIPTION
Add aliases for subprojects:
- licensing
- release-engineering

Update release-engineering OWNERS:
- sync the current [OWNERS of k/release](https://github.com/kubernetes/release/blob/master/OWNERS_ALIASES#L8-L13) with the subproject OWNERS.

(This is mostly to bolster OWNERS, but release engineering should feel free to update/remove as appropriate once this merges.)

(Updated the commit message to reflect.)

Signed-off-by: Stephen Augustus <saugustus@vmware.com>