### PR TITLE
remove 'none' line

### DIFF
--- a/releases/release-1.14/release-notes-draft.md
+++ b/releases/release-1.14/release-notes-draft.md
@@ -6,7 +6,6 @@
 
 ## New Features
 
-- none ([#74182](https://github.com/kubernetes/kubernetes/pull/74182), [@andyzhangx](https://github.com/andyzhangx)) Courtesy of SIG Azure, and SIG Cloud Provider
 - vSphere cloud provider correctly retrieves the VM's UUID when running on Windows ([#71147](https://github.com/kubernetes/kubernetes/pull/71147), [@benmoss](https://github.com/benmoss)) Courtesy of SIG Cloud Provider, SIG VMWare, and SIG Windows
 - kubelet now accepts `pid=<number>` in the `--system-reserved` and `--kube-reserved` options to ensure that the specified number of process IDs will be reserved for the system as a whole and for Kubernetes system daemons respectively.  Please reference `Kube Reserved` and `System Reserved` in `Reserve Compute Resources for System Daemons` in the Kubernetes documentation for general discussion of resource reservation.  To utilize this functionality, you must set the feature gate `SupportNodePidsLimit=true` ([#73651](https://github.com/kubernetes/kubernetes/pull/73651), [@RobertKrawitz](https://github.com/RobertKrawitz)) Courtesy of SIG Architecture, SIG Node, and SIG Testing
 - `kubectl auth reconcile` now outputs details about what changes are being made ([#71564](https://github.com/kubernetes/kubernetes/pull/71564), [@liggitt](https://github.com/liggitt)) Courtesy of SIG Auth, and SIG CLI


### PR DESCRIPTION
seems that when `/release-note none` is applied to a kind/feature PR, it is fetched as 'none' in the release notes.

https://github.com/kubernetes/kubernetes/pull/74182#issuecomment-464554714