### PR TITLE
Add discuss.k8s.io announce to security announcement template

### DIFF
--- a/security-release-process-documentation/email-templates.md
+++ b/security-release-process-documentation/email-templates.md
@@ -5,7 +5,7 @@ This is a collection of email templates to handle various situations the PST nee
 ## Security Fix Announcement
 
 Subject: [ANNOUNCE] Security release of $COMPONENT $VERSION - $CVE
-To: kubernetes-dev@googlegroups.com, kubernetes-security-announce@googlegroups.com, kubernetes-security-discuss@googlegroups.com
+To: kubernetes-dev@googlegroups.com, kubernetes-security-announce@googlegroups.com, kubernetes-security-discuss@googlegroups.com, kubernetes+announcements@discoursemail.com
 
 Hello Kubernetes Community-
 


### PR DESCRIPTION
Adds the email address associated with the Discuss [Announcements Category](https://discuss.kubernetes.io/c/announcements) to the security fix announcement template.

/cc @castrojo 