### PR TITLE
Add templates and update links for release-notes role-handbook

### DIFF
--- a/release-team/role-handbooks/release-notes/README.md
+++ b/release-team/role-handbooks/release-notes/README.md
@@ -13,11 +13,11 @@ The Release Notes role is responsible for collecting and fine-tuning release-not
 ## Tasks
 
 - The Release Notes Lead and Shadows attend burn down meetings, SIG Release meetings and follow the [#sig-release](https://kubernetes.slack.com/messages/C2C40FMNF) Slack channel for relevant information throughout the release cycle.
-- One member of the Release Notes Team should be responsible for setting up and running the [`release-notes` tool](https://github.com/marpaia/release-notes) to collect generated drafts of all release-notes identified in the current release -- improvements to the tool are always welcome!
-- Drafts produced by the tool are copied to a file called `release-notes-draft.md` in the release folder for the current release in the `sig-release` repo.
-- Before the beginning of Code Freeze, the Release Notes Team will copy the latest draft into a Google Doc and start reaching out to SIG Leads in an effort to have them fill in a prose paragraph of "Major Themes" that outlines what their SIG has been working on throughout the lifecycle.
+- One member of the Release Notes Team should be responsible for setting up and running the [`release-notes` tool](https://github.com/kubernetes/release/tree/master/toolbox/relnotes) to collect generated drafts of all release-notes identified in the current release -- improvements to the tool are always welcome!
+- Drafts produced by the tool are copied to a file called `release-notes-draft.md` in the [releases folder](../../../releases) for the current release in the `sig-release` repo.
+- Before the beginning of Code Freeze, the Release Notes Team will copy the latest draft into a Google Doc and start [reaching out to SIG Leads](sig-leads-email.md) in an effort to have them fill in a prose paragraph of "Major Themes" that outlines what their SIG has been working on throughout the lifecycle.
 - If gentle nudging of SIG Leads is not effective in retrieving feedback/confirmation, the Release Notes Team can use a reasonable amount of creative liberity in completing the notes
-- A "Known Issues" section will also be created in a GitHub issue to be added to the release notes before release date.
+- A ["Known Issues"](known-issues) section will also be created in a GitHub issue to be added to the release notes before release date.
 - The confirmed upon notes are cleaned up and copy edited by the release-notes team to ensure uniform language/style is used.
 - An "External Dependencies" section should be currated which outlines how external depdendency versions have changed since the last release
   - See [the 1.12 release notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.12.md#external-dependencies) for an example
@@ -34,7 +34,7 @@ The Release Notes role is responsible for collecting and fine-tuning release-not
 
 ## Tools
 
-- [Release notes tool](https://github.com/marpaia/release-notes)
+- [Release notes tool](https://github.com/kubernetes/release/tree/master/toolbox/relnotes)
 - [Hackmd](https://hackmd.io/)
 - [LWKD](http://lwkd.info) *(consider contributing to LWKD as part of your role)*
 
@@ -68,7 +68,9 @@ Update this section at the end of each release for the next Release Notes Team.
 ### Week 9
 
 - Create Google Doc for generated release notes and share with release-notes team
+- Create [known issues issue](known-issues-bucket.md) in `kubernetes/kubernetes` to capture known issues for the release
 - Share created doc with release-team
+- Send [an email to sig leads](sig-leads-email) to capture major themes from their sig
 - Start determining major themes for release notes template to send to sig-leads
 
 

--- a/release-team/role-handbooks/release-notes/README.md
+++ b/release-team/role-handbooks/release-notes/README.md
@@ -13,11 +13,11 @@ The Release Notes role is responsible for collecting and fine-tuning release-not
 ## Tasks
 
 - The Release Notes Lead and Shadows attend burn down meetings, SIG Release meetings and follow the [#sig-release](https://kubernetes.slack.com/messages/C2C40FMNF) Slack channel for relevant information throughout the release cycle.
-- One member of the Release Notes Team should be responsible for setting up and running the [`release-notes` tool](https://github.com/kubernetes/release/tree/master/toolbox/relnotes) to collect generated drafts of all release-notes identified in the current release -- improvements to the tool are always welcome!
+- One member of the Release Notes Team should be responsible for setting up and running the [release-notes tool](https://github.com/kubernetes/release/tree/master/cmd/release-notes) to collect generated drafts of all release-notes identified in the current release -- improvements to the tool are always welcome!
 - Drafts produced by the tool are copied to a file called `release-notes-draft.md` in the [releases folder](../../../releases) for the current release in the `sig-release` repo.
 - Before the beginning of Code Freeze, the Release Notes Team will copy the latest draft into a Google Doc and start [reaching out to SIG Leads](sig-leads-email.md) in an effort to have them fill in a prose paragraph of "Major Themes" that outlines what their SIG has been working on throughout the lifecycle.
 - If gentle nudging of SIG Leads is not effective in retrieving feedback/confirmation, the Release Notes Team can use a reasonable amount of creative liberity in completing the notes
-- A ["Known Issues"](known-issues) section will also be created in a GitHub issue to be added to the release notes before release date.
+- A ["Known Issues"](known-issues-bucket.md) section will also be created in a GitHub issue to be added to the release notes before release date.
 - The confirmed upon notes are cleaned up and copy edited by the release-notes team to ensure uniform language/style is used.
 - An "External Dependencies" section should be currated which outlines how external depdendency versions have changed since the last release
   - See [the 1.12 release notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.12.md#external-dependencies) for an example
@@ -34,7 +34,7 @@ The Release Notes role is responsible for collecting and fine-tuning release-not
 
 ## Tools
 
-- [Release notes tool](https://github.com/kubernetes/release/tree/master/toolbox/relnotes)
+- [Release notes tool](https://github.com/kubernetes/release/tree/master/cmd/release-notes)
 - [Hackmd](https://hackmd.io/)
 - [LWKD](http://lwkd.info) *(consider contributing to LWKD as part of your role)*
 
@@ -70,7 +70,7 @@ Update this section at the end of each release for the next Release Notes Team.
 - Create Google Doc for generated release notes and share with release-notes team
 - Create [known issues issue](known-issues-bucket.md) in `kubernetes/kubernetes` to capture known issues for the release
 - Share created doc with release-team
-- Send [an email to sig leads](sig-leads-email) to capture major themes from their sig
+- Send [an email to sig leads](sig-leads-email.md) to capture major themes from their sig
 - Start determining major themes for release notes template to send to sig-leads
 
 

--- a/release-team/role-handbooks/release-notes/known-issues-bucket.md
+++ b/release-team/role-handbooks/release-notes/known-issues-bucket.md
@@ -1,0 +1,24 @@
+First search in [Kubernetes
+issues](https://github.com/kubernetes/kubernetes/issues) to ensure that an
+issue hasn't already been created for `known issues` in the current release. Create a regular issue in
+[kubernetes/kubernetes](https://github.com/kubernetes/kubernetes/issues/new)
+with a title such as:
+
+```
+<RELEASE NUMBER> Release Notes: "Known Issues"
+
+```
+
+And a body such as:
+
+```
+This issue is a bucket placeholder for collaborating on the "Known Issues" additions for the 1.13 Release Notes. If you know of issues or API changes that are going out in 1.13, please comment here so that we can coordinate incorporating information about these changes in the Release Notes.
+
+/assign @<RELEASE NOTES TEAM MEMBERS>
+
+/sig release
+/milestone v<RELEASE NUMBER>
+```
+
+Note: You need to be part of `kubernetes/kubernetes-milestone-maintainers` to
+use the `/milestone` label. If this does not currently apply to you, send a message to the release notes lead or release lead to set the milestone.

--- a/release-team/role-handbooks/release-notes/sig-leads-email.md
+++ b/release-team/role-handbooks/release-notes/sig-leads-email.md
@@ -1,0 +1,39 @@
+Hey Sig-Leads,
+
+<Brief intro>, I'm on the Release Notes Team for the <RELEASE NUMBER> release.
+We've put together a draft of the release notes document so far, but we need
+your help filling in the Major Themes section for your SIG. Please check out
+the release notes draft document <LAZY LINK> ASAP and:
+
+
+CTRL-F your SIG. For example, if you're the SIG lead of SIG CLI, then search
+for "SIG CLI". This will show release notes that were contributed by your SIG
+as well as release notes for features that were a collaboration between your
+SIG and other SIGs.
+
+Get a feel for what has been contributed by your SIG over the course of the
+<RELEASE NUMBER> release cycle.
+
+Find your SIGs sub-section in the "Major Themes" section of the document and
+write 1-2 paragraphs of prose which outlines the high-level direction that your
+SIG was moving in this release.
+
+
+Additionally, if you know of anything that should appear in the "Known Issues"
+section of the Release Notes, please leave a comment with the issue and a draft
+of the note text on this GitHub Issue:
+[<LINK TO GITHUB ISSUE>](known-issue-bucket.md)
+
+If you have some more time and want to help shape your SIG's sections of the
+release notes for <RELEASE NUMBER>, there are a few more things you can do as well!
+
+
+In the sections for your SIG, feel free to copy-edit notes that may contain
+what you know to be technical inaccuracies, grammar inconsistencies, etc.
+
+In the sections where notes are attributed to multiple SIGs (including yours),
+leave a comment if the note is more related to your SIG or one of the other
+SIGs. We can then use this to further categorize the notes!
+
+
+Please try to get your initial notes and themes into the draft by <DATE>. Thank you so much for helping put together release notes for your SIG, we know you're busy and appreciate your support of the <RELEASE NUMBER> release!


### PR DESCRIPTION
- Added templates and respective links for:
  - email message to sig leads for major theme input
  - creating bucket issue for release `known issues` in `kubernetes/kubernetes`

- Updates links to release notes tool which now lives in `kubernetes/release`