### PR TITLE
Add issue template for cutting a release

### DIFF
--- a/.github/ISSUE_TEMPLATE/cut-release.md
+++ b/.github/ISSUE_TEMPLATE/cut-release.md
@@ -1,0 +1,18 @@
+---
+name: Cut 1.x.y-{alpha,beta,rc}.z release
+---
+/assign <!-- @ the release branch manager or the person who cuts the release -->
+
+Scheduled to happen <!-- Tue, 2019-02-26 -->
+
+Any bumps or issues encountered along the way, post here. /close when the release has been cut.
+
+<!-- add & remove items of the checklist as you see fit -->
+- [ ] screen shot master's (unhealthy) testgrid boards and add them as a comment
+- [ ] stage & release
+  - [ ] collect metrics, links, ... and add them as a comment <!-- example: https://github.com/kubernetes/sig-release/issues/506#issuecomment-465202113 -->
+- [ ] build & publish packages (debs & rpms)
+- [ ] send notification mail
+
+/milestone <!-- v1.14 -->
+/area release-team

--- a/.github/ISSUE_TEMPLATE/cut-release.md
+++ b/.github/ISSUE_TEMPLATE/cut-release.md
@@ -15,4 +15,5 @@ Any bumps or issues encountered along the way, post here. /close when the releas
 - [ ] send notification mail
 
 /milestone <!-- v1.14 -->
+/sig release
 /area release-team


### PR DESCRIPTION
Based on the issues we used in `v1.14` and the comments from @tpepper over at [#sig-release](https://kubernetes.slack.com/archives/C2C40FMNF/p1550859116017200?thread_ts=1550784819.010800&cid=C2C40FMNF).

/cc @tpepper @spiffxp 

/area release-team
/kind documentation
