### PR TITLE
Fix issue template for release cuts

### DIFF
--- a/.github/ISSUE_TEMPLATE/cut-release.md
+++ b/.github/ISSUE_TEMPLATE/cut-release.md
@@ -1,5 +1,7 @@
 ---
-name: Cut 1.x.y-{alpha,beta,rc}.z release
+name: Cut a release
+about: Create a tracking issue for a release cut
+title: Cut 1.x.y-{alpha,beta,rc}.z release
 ---
 /assign <!-- @ the release branch manager or the person who cuts the release -->
 


### PR DESCRIPTION
Bug fix for https://github.com/kubernetes/sig-release/pull/519 -- with a wrong header GitHub won't show it as a template.

/cc @tpepper @spiffxp
/assign @justaugustus 

/area release-team
/kind documentation