### PR TITLE
Add role-handbooks README

### DIFF
--- a/release-team/role-handbooks/README.md
+++ b/release-team/role-handbooks/README.md
@@ -1,0 +1,6 @@
+# role-handbooks
+
+These handbooks are maintained by current and previous contributors who have
+staffed these roles. They are intended to be living documents that evolve as
+the roles and project evolves. Do not treat them as rules set in stone, but
+guidelines to be re-examined.


### PR DESCRIPTION
Presently github is displaying the docs/README.md in the UI whenever
users visit the role-handbooks directory. I am hoping an actual
README.md in role-handbooks' root will override that.

/kind documentation