### PR TITLE
Add @jeefy as release notes shadow

### DIFF
--- a/releases/release-1.15/release_team.md
+++ b/releases/release-1.15/release_team.md
@@ -7,7 +7,7 @@
 | Bug Triage | Nicholas Lane ([@soggiest](https://github.com/soggiest) / Slack: `@soggy`) | |
 | Branch Manager | Cheryl Fong ([@bubblemelon](https://github.com/bubblemelon) / Slack: `@cherylfong`) | |
 | Docs | Barnabas Makonda ([@MAKOSCAFEE](https://github.com/MAKOSCAFEE) / Slack: `@barnie`) | |
-| Release Notes | Lindsey Tulloch ([@onyiny-ang](https://github.com/onyiny-ang)) | |
+| Release Notes | Lindsey Tulloch ([@onyiny-ang](https://github.com/onyiny-ang)) | Jeff Sica ([@jeefy](https://github.com/jeefy))|
 | Communications | Jorge Castro ([@castrojo](https://github.com/castrojo)) | |
 
 


### PR DESCRIPTION
Further to #529 @jeefy will also be joining the 1.15 release team as a release notes shadow.