### PR TITLE
Add communications shadows for 1.15 release.

### DIFF
--- a/releases/release-1.15/release_team.md
+++ b/releases/release-1.15/release_team.md
@@ -8,7 +8,7 @@
 | Branch Manager | Cheryl Fong ([@bubblemelon](https://github.com/bubblemelon) / Slack: `@cherylfong`) | |
 | Docs | Barnabas Makonda ([@MAKOSCAFEE](https://github.com/MAKOSCAFEE) / Slack: `@barnie`) | |
 | Release Notes | Lindsey Tulloch ([@onyiny-ang](https://github.com/onyiny-ang)) | Jeff Sica ([@jeefy](https://github.com/jeefy))|
-| Communications | Jorge Castro ([@castrojo](https://github.com/castrojo)) | |
+| Communications | Jorge Castro ([@castrojo](https://github.com/castrojo)) | Taylor Dolezal ([@onlydole](https://github.com/onlydole))|                                                                                          
 
 
 

--- a/releases/release-1.15/release_team.md
+++ b/releases/release-1.15/release_team.md
@@ -8,7 +8,7 @@
 | Branch Manager | Cheryl Fong ([@bubblemelon](https://github.com/bubblemelon) / Slack: `@cherylfong`) | |
 | Docs | Barnabas Makonda ([@MAKOSCAFEE](https://github.com/MAKOSCAFEE) / Slack: `@barnie`) | |
 | Release Notes | Lindsey Tulloch ([@onyiny-ang](https://github.com/onyiny-ang)) | Jeff Sica ([@jeefy](https://github.com/jeefy))|
-| Communications | Jorge Castro ([@castrojo](https://github.com/castrojo)) | Kaitlyn Barnard ([@kbarnard10](https://github.com/kbarnard10)), Natasha Woods ([@nwoods3](https://github.com/nwoods3)), Taylor Dolezal ([@onlydole](https://github.com/onlydole)) |
+| Communications | Jorge Castro ([@castrojo](https://github.com/castrojo)) | Taylor Dolezal ([@onlydole](https://github.com/onlydole)) |
 
 
 

--- a/releases/release-1.15/release_team.md
+++ b/releases/release-1.15/release_team.md
@@ -8,7 +8,7 @@
 | Branch Manager | Cheryl Fong ([@bubblemelon](https://github.com/bubblemelon) / Slack: `@cherylfong`) | |
 | Docs | Barnabas Makonda ([@MAKOSCAFEE](https://github.com/MAKOSCAFEE) / Slack: `@barnie`) | |
 | Release Notes | Lindsey Tulloch ([@onyiny-ang](https://github.com/onyiny-ang)) | Jeff Sica ([@jeefy](https://github.com/jeefy))|
-| Communications | Jorge Castro ([@castrojo](https://github.com/castrojo)) | Taylor Dolezal ([@onlydole](https://github.com/onlydole))|                                                                                          
+| Communications | Jorge Castro ([@castrojo](https://github.com/castrojo)) | Kaitlyn Barnard ([@kbarnard10](https://github.com/kbarnard10)), Natasha Woods ([@nwoods3](https://github.com/nwoods3)), Taylor Dolezal ([@onlydole](https://github.com/onlydole)) |
 
 
 


### PR DESCRIPTION
Add the following members as communications shadows for the 1.15 release:

* Taylor Dolezal
* [Open Slot]