### PR TITLE
Update OWNERS (1.15 Edition)

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -3,6 +3,7 @@
 approvers:
   - sig-release-leads
 reviewers:
+  - release-team
   - release-team-lead-role
   - idvoretskyi
   - jdumars

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -14,53 +14,60 @@ aliases:
     - ixdy
     - mikedanese
     - tpepper
+  release-team:
+    - aishsundar
+    - jberkus
+    - justaugustus
+    - spiffxp
+    - tpepper
   release-team-lead-role:
-    - jberkus # 1.11
     - tpepper # 1.12
     - aishsundar # 1.13
     - spiffxp # 1.14
+    - claurence # 1.15
   patch-release-manager-role:
     - foxish # 1.11
     - feiskyer # 1.12
     - aleksandra-malinowska # 1.13
     - tpepper # 1.13
   ci-signal-role:
-    - aishsundar # 1.11
     - mohammedzee1000 # 1.12
     - jberkus # 1.13
     - mariantalla # 1.14
+    - alejandrox1 # 1.15
   enhancements-role:
-    - idvoretskyi # 1.11
     - justaugustus # 1.12
-    - kacole2 # 1.13
+    - kacole2 # 1.15 / 1.13
     - claurence # 1.14
   test-infra-role:
-    - bentheelder # 1.11
     - cjwagner # 1.13 / 1.12
     - amwat # 1.14
+    - imkin # 1.15
   bug-triage-role:
-    - tpepper # 1.11
     - guineveresaenger # 1.12
-    - nikopen # 1.13 / 1.14
+    - nikopen # 1.14 / 1.13
+    - soggiest # 1.15
   branch-manager-role:
-    - calebamiles # 1.11
     - dougm # 1.13 / 1.12
     - hoegaarden # 1.14
+    - bubblemelon # 1.15
   docs-role:
-    - misty # 1.11
     - zparnold # 1.12
     - tfogo # 1.13
     - jimangel # 1.14
+    - MAKOSCAFEE # 1.15
   release-notes-role:
     - nickchase # 1.12 / 1.11
     - marpaia # 1.13
-    - dstrebel # 1.10
+    - dstrebel # 1.14
+    - onyiny-ang # 1.15
   communications-role:
     - kbarnard10 # 1.13 / 1.12 / 1.11
     - nwoods3 # 1.14
-  product-security-committee:
+    - castrojo # 1.15
+  committee-product-security:
     - philips
-    - jessfraz
     - cjcullen
     - tallclair
     - liggitt
+    - joelsmith

--- a/releases/OWNERS
+++ b/releases/OWNERS
@@ -5,3 +5,4 @@ approvers:
   - release-team-lead-role
 labels:
   - area/release-team
+

--- a/releases/release-1.15/OWNERS
+++ b/releases/release-1.15/OWNERS
@@ -1,0 +1,18 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - claurence    # Release Team Lead
+  - lachie83     # Lead Shadow
+  - nikopen      # Lead Shadow
+  - tpepper      # Lead Shadow
+
+reviewers:
+  - kacole2      # Enhancements
+  - alejandrox1  # CI Signal
+  - imkin        # Test Infra
+  - soggiest     # Bug Triage
+  - bubblemelon  # Branch Manager
+  - MAKOSCAFEE   # Docs
+  - onyiny-ang   # Release Notes
+  - castrojo     # Communications
+

--- a/security-release-process-documentation/OWNERS
+++ b/security-release-process-documentation/OWNERS
@@ -1,6 +1,6 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
-  - product-security-committee
+  - committee-product-security
 approvers:
-  - product-security-committee
+  - committee-product-security


### PR DESCRIPTION
- Define Release Team subproject owners
- Add 1.15 Release Team role leads

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/assign @calebamiles @tpepper @AishSundar @jberkus @spiffxp
/area release-team