### PR TITLE
Track containers not rebased to distroless

### DIFF
--- a/release-engineering/baseimage-exception-list.md
+++ b/release-engineering/baseimage-exception-list.md
@@ -1,0 +1,5 @@
+# Base Image Exception List
+
+| Component Name        |           Base Image         |        Reasons    |
+| --------------------- | :---------------------------:|:------------------:|
+| 		kube-proxy      |  [k8s.gcr.io/debian-iptable](https://github.com/kubernetes/kubernetes/blob/1b9d0c1094d31f851a5ec6e277fbf0b7382196cf/build/common.sh#L101)   | Requires iptable  |


### PR DESCRIPTION
As part of the effort on sig-release KEP "[Rebase k8s images to distroless](https://github.com/kubernetes/enhancements/pull/900/files#)", we allow certain kinds of images rebasing to k8s.gcr.io/debian-base instead of distroless for now. This list is used to track containers not rebased to distroless in v1.15.