### PR TITLE
Change to cite CNCF Whitelist Policy by reference

### DIFF
--- a/licensing/README.md
+++ b/licensing/README.md
@@ -4,63 +4,10 @@ This documents the Licensing subproject under SIG Release.
 The subproject is responsible for analyzing, reporting and remediating
 licensing concerns within the Kubernetes project orgs.
 
-## Licenses for Dependencies
-
-Dependencies that are licensed under Apache-2.0 do not require further license
-review or approval, since they are under the same license as Kubernetes itself.
-
-The IP policy in the [CNCF Charter], section 11, allows the CNCF Governing Board
-to review and approve other non-Apache-2.0 licenses on an exception basis.
-
-To streamline this process, licenses for some components are whitelisted as per
-the CNCF Whitelist Policy (adopted by the CNCF Governing Board on 2018-05-01).
-This whitelisting policy is described below.
-
-Components that are not under Apache-2.0, and that do not satisfy the Whitelist
-Policy, remain subject to review and exception approval by the Governing Board.
+Licenses for dependencies are specified by the CNCF [Whitelist Policy].
 
 In case of questions or concerns regarding the whitelist policy,
 please create an issue or send an email to the [SIG Release] mailing list.
 
-#### Whitelisting Policy
-
-A third-party component under a non-Apache 2.0 license is deemed
-automatically approved by the Governing Board for inclusion in a CNCF codebase
-as an exception to the CNCF Intellectual Property Policy,
-if all of the following apply:
-
-1. It is fully licensable under the approved licenses set forth below under
-[Approved Licenses] (including combinations with Apache-2.0); AND
-
-2. It is stored unmodified in a designated third-party folder; AND
-
-3. It has indications of substantial use outside CNCF by satisfying one of the following:
-
-    1. the component is part of the applicable programming language’s standard library; or
-
-    2. the component was created on Github at least 12 months ago and has at least 10 stars or 10 forks.
-
-#### Approved Licenses for Whitelist
-
-To be approved as “whitelisted,” a third-party component must be fully
-licenseable under one or more of the following licenses, and must meet the other
-whitelist criteria set forth in the [Whitelisting Policy] above.
-
-License IDs refer to the SPDX License List at https://spdx.org/licenses, except where
-a URL is specified below for licenses that are not on the SPDX License List.
-
-- BSD-2-Clause
-- BSD-2-Clause-FreeBSD
-- BSD-3-Clause
-- MIT
-- ISC
-- Python-2.0
-- PostgreSQL
-- X11
-- Zlib
-- Google patent license for Golang (https://golang.org/PATENTS)
-
-[Approved Licenses]: #approved-licenses-for-whitelist
-[Whitelisting Policy]: #whitelisting-policy
-[CNCF Charter]: https://github.com/cncf/foundation/blob/master/charter.md
+[Whitelist Policy]: https://github.com/cncf/foundation/blob/master/whitelist-policy.md
 [SIG Release]: https://groups.google.com/forum/#!forum/kubernetes-sig-release


### PR DESCRIPTION
CNCF would appreciate if SIG Release would switch to citing the CNCF Whitelist Policy by reference rather than including a copy of it here. We will notify the SIG Release team if any changes to the policy are approved by the CNCF Governing Board in the future.

Cc @swinslow 