### PR TITLE
Update the test-infra handbook

### DIFF
--- a/release-team/role-handbooks/test-infra/README.md
+++ b/release-team/role-handbooks/test-infra/README.md
@@ -1,15 +1,10 @@
 # Test Infra Lead Handbook
 
-Note: Currently, the test-infra lead has to be someone from Google GKE Engprod Team, in order to gain access to the prow cluster. This
-will change once we migrate our testing infrastructure under CNCF account. (xref kubernetes/test-infra#5085)
-
-There are three major area that test-infra lead need to take care during the release cycle, which are:
+There are two major areas that test-infra lead need to take care of during the release cycle, which are:
 
 1. [Create CI/Presubmit jobs for the new release, and populate the Testgrid dashboard](#create-cipresubmit-jobs-for-the-new-release)
 
 1. [Configure merge automation for code freeze, and thaw](#configure-merge-automation-for-code-freeze-and-thaw)
-
-1. [Watch for test infra status, make sure test infra is stable, react to test infra related issues and notify Release Lead and CI Signal Lead of issue status changes](#ensure-the-stability-of-test-infra)
 
 You can work with @kubernetes/test-infra-maintainers or [test infra oncall](https://go.k8s.io/oncall) if you are blocked by anything.
 Also feel free to ping the `#sig-testing` and `#testing-ops` Kubernetes Slack channels to reach out for help.
@@ -18,26 +13,26 @@ Also feel free to ping the `#sig-testing` and `#testing-ops` Kubernetes Slack ch
 
 This step should happen in week 6-7, when we create the new release branch.
 
-Most of the release blocking jobs are named with -beta|-stableX, which are mapped to our [release channels](https://github.com/kubernetes/test-infra#release-branch-jobs--image-validation-jobs).
+1. Update [`images/kubekins-e2e/variants.yaml`](https://github.com/kubernetes/test-infra/blob/master/images/kubekins-e2e/variants.yaml)
+   by deleting the oldest entry and copying the `master` block to create an entry
+   using the latest version number. Create a PR with this and wait for it to land,
+   then wait for the `test-infra-push-kubekins-e2e` presubmit to finish (you can
+   [check on prow](https://prow.k8s.io/?job=post-test-infra-push-kubekins-e2e)).
+   Pull latest master before continuing.
 
-Note that this section reflects the status of the world today, we are actively looking for simplify the process.
+1. Run `bazel run //experiment:prepare_release_branch`
 
-1. Bump build job branches for the [k8s build jobs](https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml)
+1. grep for `manual-release-bump-required` under [test-infra](https://github.com/kubernetes/test-infra)
+   and duplicate appropriately.
 
-1. Create kubekins images for the new release, add a new release target in the [kubekins Makefile](https://github.com/kubernetes/test-infra/blob/master/images/kubekins-e2e/Makefile)
-
-1. Update release version in the [image bump script](https://github.com/kubernetes/test-infra/blob/master/experiment/bump_e2e_image.sh) and push new kubekins images by running the script. (Note that the runner need to have access to [k8s-testimages](https://pantheon.corp.google.com/home/dashboard?project=k8s-testimages) gcp project)
-
-1. Similarly, make a new Dockerfile for [kubekins-test](https://github.com/kubernetes/test-infra/tree/master/images/kubekins-test) image, this is the image we used for our integration and verify jobs. Also bump the image tags in the [kubernetes_verify scenario](https://github.com/kubernetes/test-infra/blob/master/scenarios/kubernetes_verify.py)
-
-1. grep for `manual-release-bump-required` under [test-infra](https://github.com/kubernetes/test-infra), those are the jobs that need to be manually bumped per release cycle, remap them to the up-to-date branches. Similar to 2, Fork a new version of kubernetes/kubernetes presubmit job, and remove references to the older branches.
-
-1. Okay, now let's update the Testgrid config. It's a manual work now, basically you want to find dashboard tabs for release-1.x, and bump that, and the jobs inside, to release-1.(x+1)
+1. Verify that testgrid is in a reasonable state. As of today, this means
+   deleting the oldest `sig-release-<version>-{master,informing,all}`
+   dashboards and making new `sig-release-<version>-{master,informing,all}`
+   ones. You can run `bazel test //testgrid/cmd/configurator/...` to make sure
+   you are in a good state.
 
 1. Finally, update the [release target section](https://github.com/kubernetes/test-infra#release-branch-jobs--image-validation-jobs)
-
-Not all the steps need to happen together, some new jobs, like bazel-build/integration/verify will require images to be pushed before they can work properly. 
-
+   of the README.
 
 ## Configure merge automation for code freeze, and thaw
 
@@ -81,6 +76,9 @@ We only add additional merge requirements for PRs to these two branches for code
 
 Milestone requirements are configured by adding `milestone: foo` to a query config.
 
+It is also helpful to remind #sig-testing when code freeze starts so they know
+not to do anything too dangerous to the test infrastructure.
+
 
 ```yaml
   - repos:
@@ -123,29 +121,6 @@ Code thaw removes the release cycle merge restrictions and replaces the two quer
       # as above...
 ```
 
-## Ensure the stability of test infra
-
-During the release cycle, especially inside the code freeze, the test infra lead need to actively watch for
-
-1. If the presubmit/CI is failing due to test infra issues (do some initial triage with CI Signal Lead)
-
-1. If Tide is merging PRs into the master and release branches
-
-We record test-infra commit SHAs in each Testgrid tab, and if CI starts to fail between two test-infra commits, test infra lead can diff the SHAs to triage if the failure is caused by a test-infra change.
-
-The [velodrome monitoring dashboard](http://velodrome.k8s.io/dashboard/db/monitoring?orgId=1) will be your good friends.
-
-### Monitoring Tide
-
-It is important to monitor Tide after config changes are made for code freeze and thaw to ensure that the changes are having the intended effect.
-
-Until the CNCF infra migration is complete, a member of Google's gke-engprod team will need to monitor Tide logs.
-However, most of Tide's behavior can be monitored without access to the cluster. The [Tide dashboard](https://prow.k8s.io/tide) and [Velodrome monitoring dashboard](http://velodrome.k8s.io/dashboard/db/monitoring?orgId=1) provide insight into what Tide is currently doing, how much load it is handling, and how it is performing.
-
-### Test-Infra 'Code Freeze'
-
-The stability of our test infra is critical to getting reliable testing signals throughout the release cycle, but the signal is most important at the end of the release cycle during code freeze. While the `kubernetes/test-infra` repo does not enforce additional merge restrictions related to the release cycle, we do try to limit the changes that are merged. Specifically, during freeze, changes to test-infra should be limited to important fixes and work that doesn't impact critical infrastructure. Large changes should be delayed if possible.
-In particular, bumping the kubekins-e2e images should be avoided unless a critical fix in necessary.
 
 ## Useful Links
 


### PR DESCRIPTION
Update the test-infra handbook to reflect the following changes:

* Handling creation of new images and jobs is now largely automated, and will continue to become moreso
* The role no longer substantially involved maintenance of prow itself (this falls to the oncall role)
* The role no longer requires you to be a Googler

Mostly, this is just removing things that don't matter any more.

/cc @amwat @cjwagner @spiffxp @imkin 