### PR TITLE
Role handbook updates - remove org membership as a shadow requirement

### DIFF
--- a/release-team/role-handbooks/branch-manager/README.md
+++ b/release-team/role-handbooks/branch-manager/README.md
@@ -46,7 +46,14 @@ For example, as branch manager of v1.15, the release cut dates as specified in t
 * General knowledge of Google Cloud (Cloud Build and Cloud Storage).
 * Open to seeking help and can communicating clearly.
 
-# Prerequisite
+# Prerequisites for Branch Manager and Shadows
+
+## General Requirements
+
+**Before continuing on to the Branch Manager specific requirements listed below, please review and work through the tasks in the [Release Team Onboarding Guide](/release-team/release-team-onboarding.md).**
+
+## Branch Manager Specific 
+
 * Contact [Kubernetes Build Admins][kubernetes-build-admins], identifying yourself as the incoming release branch manager for the current release team and requesting to be added to the special privilege group for the GCP project used to build the releases
    * TODO: should the release lead also request some type of read access here for themselves?
    * TODO: should the branch manager shadows also get at least read access at the beginning?  If a shadow is going to exercise the process on behalf of the lead, they will need full read/write access ahead of time.

--- a/release-team/role-handbooks/bug-triage/README.md
+++ b/release-team/role-handbooks/bug-triage/README.md
@@ -1,24 +1,29 @@
 Bug Triage Handbook
 ==============================
 
--   [Summary](#summary)
-    -   [How To Do Your Job](#how-to-do-your-job)
-    -   [How To Escalate](#how-to-escalate)
--   [Early Release](#early-release)
-    -   [Sample Searches](#sample-searches-early)
-    -   [Reports](#reports-early)
--   [Brace Yourselves, Code Freeze Is Coming](#brace-yourselves-code-freeze-is-coming)
-    -   [Filtering / What belongs in the milestone](#filtering--What-belongs-in-the-milestone)
-    -   [Priority label definitions](#priority-label-definitions)
-    -   [Sample Searches](#sample-searches-before-freeze)
-    -   [Reports](#reports-before-freeze)
-    -   [Issue Categorization](#issue-categorization)
--   [Code Freeze](#code-freeze)
-    -   [Sample Searches](#sample-searches-freeze)
-    -   [Reports](#reports-freeze)
--   [Code Thaw](#code-thaw)
-    -   [Sample Searches](#sample-searches-thaw)
-    -   [Reports](#reports-thaw)
+- [Bug Triage Handbook](#Bug-Triage-Handbook)
+  - [Summary](#Summary)
+  - [Requirements](#Requirements)
+    - [Time Requirements](#Time-Requirements)
+    - [Additional Requirements for Shadows](#Additional-Requirements-for-Shadows)
+    - [Additional Requirements for Leads](#Additional-Requirements-for-Leads)
+  - [How To Do Your Job](#How-To-Do-Your-Job)
+    - [How to Escalate](#How-to-Escalate)
+  - [Early Release](#Early-Release)
+    - [Sample Searches [Early]](#Sample-Searches-Early)
+    - [Reports [Early]](#Reports-Early)
+  - [Brace Yourselves, Code Freeze Is Coming](#Brace-Yourselves-Code-Freeze-Is-Coming)
+    - [Filtering / What belongs in the milestone](#Filtering--What-belongs-in-the-milestone)
+    - [Priority label definitions](#Priority-label-definitions)
+    - [Sample Searches [Before Freeze]](#Sample-Searches-Before-Freeze)
+    - [Reports [Before Freeze]](#Reports-Before-Freeze)
+    - [Issue Categorization](#Issue-Categorization)
+  - [Code Freeze](#Code-Freeze)
+    - [Sample Searches [Freeze]](#Sample-Searches-Freeze)
+    - [Reports [Freeze]](#Reports-Freeze)
+  - [Code Thaw](#Code-Thaw)
+    - [Sample Searches [Thaw]](#Sample-Searches-Thaw)
+    - [Reports [Thaw]](#Reports-Thaw)
 
 ## Summary
 Primarily, your job is to make sure that bugs which affect the release are dealt with in a timely fashion.  
@@ -44,6 +49,8 @@ There are four relevant periods where your workload changes:
 4. Code Thaw: Last two weeks of the cycle. *Duration: ~2 weeks*
 
 ## Requirements
+
+**Before continuing on to the Bug Triage specific requirements listed below, please review and work through the tasks in the [Release Team Onboarding Guide](/release-team/release-team-onboarding.md).**
 
 ### Time Requirements
 

--- a/release-team/role-handbooks/ci-signal/README.md
+++ b/release-team/role-handbooks/ci-signal/README.md
@@ -25,6 +25,8 @@ The core responsibility of the CI Signal lead is to foster a culture of continuo
 
 ## Requirements
 
+**Before continuing on to the CI Signal specific requirements listed below, please review and work through the tasks in the [Release Team Onboarding Guide](/release-team/release-team-onboarding.md).**
+
 ### Time Requirements
 
 CI Signal is one of the more time-intensive roles on the release team, and as such is not recommended for candidates who do not have employer support for their work on the Release Team.  General time requirements for Leads and Shadows are:

--- a/release-team/role-handbooks/communications/README.md
+++ b/release-team/role-handbooks/communications/README.md
@@ -6,7 +6,11 @@ The Communications Coordinator role is responsible for facilitating, empowering,
 
 Additionally, there are specific deliverables that must come from the release process in the form of a release blog, event speaking opportunities, webinars, coordination of 5 Day blog series with the CNCF, and approved messaging for media. In the event that the release schedule slips, the communications coordinator will ensure press timing is synchronized and kept advised of the revised timing.
 
-## Skills and Experience Required:
+## Requirements
+
+**Before continuing on to the Communications specific requirements listed below, please review and work through the tasks in the [Release Team Onboarding Guide](/release-team/release-team-onboarding.md).**
+
+### Skills and Experience Required:
 
 - Strong written and verbal communications skills
 - Experience with the Kubernetes release process enough to understand how communications milestones fit into the overall release
@@ -14,7 +18,7 @@ Additionally, there are specific deliverables that must come from the release pr
 - A working knowledge of Kubernetes concepts
 - Project management experience is helpful
 
-## Expected Time Investment
+### Expected Time Investment
 
 The Kubernetes release cycle usually spans 12 weeks. The typical workload for the communications team is _very_ light the first few weeks. In the later weeks of the release cycle, the workload can get very heavy.
 

--- a/release-team/role-handbooks/docs/README.md
+++ b/release-team/role-handbooks/docs/README.md
@@ -30,7 +30,11 @@ Responsibilities include:
 
 ## Prerequisites for Docs Lead and Shadows
 
-### General Time Requirements
+### General Requirements
+
+**Before continuing on to the Docs specific requirements listed below, please review and work through the tasks in the [Release Team Onboarding Guide](/release-team/release-team-onboarding.md).**
+
+### Time Requirements
 
 A release is usually 12 weeks long. In general, there's a lot of work in the first few weeks of the release cycle to get the process started, and a lot of work in the last few weeks of the release cycle as documentation deadlines approach. 
 
@@ -55,7 +59,7 @@ In addition to the time requirements above, a Docs Lead must:
 Docs Lead Shadows are people who are preparing to be a Docs Lead in the future. In addition to the time requirements above, shadows must: 
 
 - Have signed the [contributor CLA](https://github.com/kubernetes/community/blob/master/CLA.md) for Kubernetes.
-- Be a Kubernetes org member. The process to become one is in the [Kubernetes community membership ladder](https://github.com/kubernetes/community/blob/master/community-membership.md#member)
+- Be invested in becoming an org member within the release cycle. This can often be achieved during the release cycle with sponsorship from a role lead. See the [Release Team onboarding guide](/release-team/release-team-onboarding.md) for more details.
 - General knowledge of our SIG-Docs [areas of responsibility](https://github.com/kubernetes/community/tree/master/sig-docs#subprojects).
 - Experience with the general process involved with [contributing](https://kubernetes.io/docs/contribute/start/) to Kubernetes website.
 

--- a/release-team/role-handbooks/enhancements/README.md
+++ b/release-team/role-handbooks/enhancements/README.md
@@ -26,13 +26,18 @@ An Enhancements Lead holds the following responsibilities:
 - Identify candidates to assume the Enhancements Lead role (according to the [Release Team selection process][rt-selection]) in the following release cycle
   - Chose Enhancement shadows whom you believe would be a good fit for succession and help mentor them throughout the release cycle  
 
-## General Requirements
+## Prerequisits for Enhancements Lead and Shadows
 
-In addition to the [requirements detailed for all Release Team members][rt-requirements], becoming an Enhancements Lead has additional gates:
-  - MUST have served on the Release Team in a previous capacity, ideally as an Enhancements Shadow
-  - MUST be a member of the [Release Team Google Group][rt-group]
-  - MUST be a member of the [SIG Release Google Group][sig-release-group]
-  - MUST be a member of the [SIG PM Google Group][sig-pm-group]
+### General Requirements
+
+**Before continuing on to the Enhancements specific requirements listed below, please review and work through the tasks in the [Release Team Onboarding Guide](/release-team/release-team-onboarding.md).**
+
+### Enhancements Specific Requirements
+
+- MUST have served on the Release Team in a previous capacity, ideally as an Enhancements Shadow
+- MUST be a member of the [Release Team Google Group][rt-group]
+- MUST be a member of the [SIG Release Google Group][sig-release-group]
+- MUST be a member of the [SIG PM Google Group][sig-pm-group]
 
 Helpful characteristics of an Enhancements Lead include:
 - experience with the Kubernetes community, code layout, ecosystem projects, organizational norms, governance, SIG structure, architecture, and release process
@@ -143,7 +148,7 @@ https://groups.google.com/forum/#!topic/kubernetes-dev/5qU8irU7_tE
 [k/enhancements]: https://github.com/kubernetes/enhancements
 [rt-group]: https://groups.google.com/forum/#!forum/kubernetes-release-team
 [rt-selection]: /README.md#release-team-selection
-[rt-requirements]: /README.md#release-team-requirements
+[rt-requirements]: /release-team/release-team-onboarding.md
 [sig-docs-group]: https://groups.google.com/forum/#!forum/kubernetes-sig-docs
 [sig-leads-group]: https://groups.google.com/forum/#!forum/kubernetes-sig-leads
 [sig-pm]: https://github.com/kubernetes/community/blob/master/sig-pm/README.md

--- a/release-team/role-handbooks/patch-release-manager/README.md
+++ b/release-team/role-handbooks/patch-release-manager/README.md
@@ -51,6 +51,13 @@ Manager should endeavor to keep this document up to date, improve
 its content, and improve the overall process of patch management
 for the project.
 
+## Prerequisites for Patch Release Lead and Shadows
+
+### General Requirements
+
+**Before continuing on to the Patch Release specific requirements listed below, please review and work through the tasks in the [Release Team Onboarding Guide](/release-team/release-team-onboarding.md).**
+
+
 ## Getting started
 
 You're here because you've volunteered and have been selected to

--- a/release-team/role-handbooks/release-notes/README.md
+++ b/release-team/role-handbooks/release-notes/README.md
@@ -4,7 +4,11 @@
 
 The Release Notes role is responsible for collecting and fine-tuning release-notes from the many contributions to Kubernetes between release cycles. This role is likely to find that work during the first several weeks of the release cycle is very laid back with the bulk of the tasks being completed at the end, once the release is firmed up.
 
-## Requirements
+## Prerequisites for Release Notes Lead and Shadows
+
+### General Requirements
+
+**Before continuing on to the Release Notes specific requirements listed below, please review and work through the tasks in the [Release Team Onboarding Guide](/release-team/release-team-onboarding.md).**
 
 ### Skills and Experience Requirments:
 

--- a/release-team/role-handbooks/release-team-lead/README.md
+++ b/release-team/role-handbooks/release-team-lead/README.md
@@ -4,6 +4,11 @@
 
 The release team leader role is responsible for coordinating release activities, assembling the release team, taking ultimate accountability for all release tasks to be completed on time, and ensuring that a retrospective happens. The lead is also responsible for ensuring a successor is selected and trained for future release cycles.
 
+## Prerequisites Release Lead and Shadows
+
+**Before continuing on to the Release Lead specific requirements listed below, please review and work through the tasks in the [Release Team Onboarding Guide](/release-team/release-team-onboarding.md).**
+
+
 ## Authority and Responsibility:
 
 The Release Team Lead should be an arbiter of decisions, and not the primary decision-maker. A lead should constantly search for the best-qualified people or SIGs to guide the decision, not "go it alone", unless it is a very specific concern within the release process itself. When decisions are made they must be weighted in favor of community concerns over those of individuals or specific companies. Leads must also relinquish any favoritism for the company they work for. If there is a conflict of interest, the lead must recuse themselves from that decision. Above all, the release lead is a servant leader to the team and the community.

--- a/release-team/role-handbooks/test-infra/README.md
+++ b/release-team/role-handbooks/test-infra/README.md
@@ -1,5 +1,13 @@
 # Test Infra Lead Handbook
 
+## Prerequisites for Test Infra Lead and Shadows
+
+### General Requirements
+
+**Before continuing on to the Test Infra specific requirements listed below, please review and work through the tasks in the [Release Team Onboarding Guide](/release-team/release-team-onboarding.md).**
+
+## Test Infra Responsibilities
+
 There are two major areas that test-infra lead need to take care of during the release cycle, which are:
 
 1. [Create CI/Presubmit jobs for the new release, and populate the Testgrid dashboard](#create-cipresubmit-jobs-for-the-new-release)


### PR DESCRIPTION
Detailed in #665. Shadows don't _have_ to be an org member but _should_ be in the process and/or committed to becoming a Kubernetes org member 

Two goals here -
- scrub any references in all handbooks that someone must be an org member, before being accepted as a role shadow
- link out each of the handbooks to the onboarding guide
