### PR TITLE
fix link to branch management handbook under release engineering

### DIFF
--- a/release-team/README.md
+++ b/release-team/README.md
@@ -84,15 +84,9 @@ there are 3 types of Kubernetes releases:
 
 #### Retired Release Team roles
 
-- Patch Release Manager: moved to a role of [Release Managers][release-managers], which operates under the Release Engineering subproject
-- Branch Manager: moved to a role of [Release Managers][release-managers], which operates under the Release Engineering subproject
-
-
-#### Retired Release Team roles
-
-- Test Infra: deprecated at the end of Kubernetes 1.15. Duties are now spread across [Branch Manager](/release-team/role-handbooks/branch-manager/README.md), [Bug Triage](/release-team/role-handbooks/branch-manager/README.md), and [Test Infra On-call (SIG Testing)](https://go.k8s.io/oncall) (#testing-ops and #sig-testing on Slack).
-
-
+- Patch Release Manager: moved to a role of [Release Managers][release-managers], which operates under the Release Engineering subproject.
+- Branch Manager: moved to a role of [Release Managers][release-managers], which operates under the Release Engineering subproject.
+- Test Infra: deprecated at the end of Kubernetes 1.15. Duties are now distributed to the [Branch Manager](/release-engineering/role-handbooks/branch-manager.md) and [Test Infra On-call (SIG Testing)](https://go.k8s.io/oncall) (#testing-ops and #sig-testing on Slack).
 
 ### Release Team Shadow
 Any Release Team member may select one or more mentees to shadow the release process in order to help fulfill future

--- a/release-team/role-handbooks/test-infra/README.md
+++ b/release-team/role-handbooks/test-infra/README.md
@@ -1,7 +1,6 @@
 The Test Infra role was deprecated at the end of the Kubernetes 1.15 release cycle.
 Beginning with the Kubernetes 1.16 release cycle, the duties of the Test Infra role have been spread across the following:
-- Release Managers, specifically the [Branch Manager](/release-team/role-handbooks/branch-manager/README.md)
-- [Bug Triage (Release Team)](/release-team/role-handbooks/branch-manager/README.md)
+- Release Managers, specifically to the [Branch Manager](/release-engineering/role-handbooks/branch-manager.md)
 - [Test Infra On-call (SIG Testing)](https://go.k8s.io/oncall) (#testing-ops and #sig-testing on Slack)
 
 <!--


### PR DESCRIPTION
This PR fixes the links as mentioned here #693 i.e. fix the broken links from the earlier location, `release-team/role-handbooks/..` to the new `release-engineering/role-handbooks/..` location/directory. And well as the path to the bug triage handbook.