### PR TITLE
Identify myself as a Release Manager Associate

### DIFF
--- a/release-managers.md
+++ b/release-managers.md
@@ -52,6 +52,7 @@ Branch Managers are responsible for minor releases (`x.y.z`, where `z` = 0) of K
 Release Manager Associates are apprentices to the Branch Managers, formerly referred to as Branch Manager shadows.
 
 - Stephen Augustus ([@justaugustus](https://github.com/justaugustus))
+- Nikhil Manchanda ([@slicknik](https://github.com/slicknik))
 
 
 ## Build Admins


### PR DESCRIPTION
Based on being Branch Manager Shadow for past releases, add
myself (SlickNik) as a Release Manager Associate - in accordance with
the updated roles for the 1.16 release.