### PR TITLE
Adding info for the patch release management team

### DIFF
--- a/releases/release-1.15/release_team.md
+++ b/releases/release-1.15/release_team.md
@@ -9,7 +9,7 @@
 | Docs | Barnabas Makonda ([@MAKOSCAFEE](https://github.com/MAKOSCAFEE) / Slack: `@barnie`) | Tunde Oladipupo ([@simplytunde](https://github.com/simplytunde) / Slack: `@simplytunde`), Damini Satya Kammakomati ([@daminisatya](https://github.com/daminisatya) / Slack: `@Damini satya`), Christian Hernandez ([@christianh814](https://github.com/christianh814) / Slack: `@christianh814`) |
 | Release Notes | Lindsey Tulloch ([@onyiny-ang](https://github.com/onyiny-ang) / Slack: `@onyiny-ang`) | Jeff Sica ([@jeefy](https://github.com/jeefy) / Slack: `@jeefy`), Nick Chase ([@NickChase](https://github.com/NickChase) / Slack: `@nickchase`), Sascha Grunert ([saschagrunert](https://github.com/saschagrunert) / Slack: `@sgrunert`), Alok Patra ([alokpatra](https://github.com/alokpatra) / `@Alok Patra`)|
 | Communications | Jorge Castro ([@castrojo](https://github.com/castrojo)) | Taylor Dolezal ([@onlydole](https://github.com/onlydole)), David McKay ([@rawkode](https://github.com/rawkode))|
-
+| Patch Release Management | [Patch Release Team](https://github.com/orgs/kubernetes/teams/patch-release-team) |
 
 
 **Emeritus Adviser:** Josh Berkus ([@jberkus](https://github.com/jberkus))

--- a/releases/release-1.15/release_team.md
+++ b/releases/release-1.15/release_team.md
@@ -9,7 +9,7 @@
 | Docs | Barnabas Makonda ([@MAKOSCAFEE](https://github.com/MAKOSCAFEE) / Slack: `@barnie`) | Tunde Oladipupo ([@simplytunde](https://github.com/simplytunde) / Slack: `@simplytunde`), Damini Satya Kammakomati ([@daminisatya](https://github.com/daminisatya) / Slack: `@Damini satya`), Christian Hernandez ([@christianh814](https://github.com/christianh814) / Slack: `@christianh814`) |
 | Release Notes | Lindsey Tulloch ([@onyiny-ang](https://github.com/onyiny-ang) / Slack: `@onyiny-ang`) | Jeff Sica ([@jeefy](https://github.com/jeefy) / Slack: `@jeefy`), Nick Chase ([@NickChase](https://github.com/NickChase) / Slack: `@nickchase`), Sascha Grunert ([saschagrunert](https://github.com/saschagrunert) / Slack: `@sgrunert`), Alok Patra ([alokpatra](https://github.com/alokpatra) / `@Alok Patra`)|
 | Communications | Jorge Castro ([@castrojo](https://github.com/castrojo)) | Taylor Dolezal ([@onlydole](https://github.com/onlydole)), David McKay ([@rawkode](https://github.com/rawkode))|
-| Patch Release Management | [Patch Release Team](https://github.com/orgs/kubernetes/teams/patch-release-team) |
+Review the [Patch Releases page](/releases/patch-releases.md) for up-to-date contact information and the schedule for 1.15 patch releases.
 
 
 **Emeritus Adviser:** Josh Berkus ([@jberkus](https://github.com/jberkus))


### PR DESCRIPTION
Per a thread in slack last week adding a breadcrumb to the patch release management team for 1.15.0 so folks know who to reach out to