### PR TITLE
Consolidate communication channels for Release Managers

### DIFF
--- a/release-engineering/packaging.md
+++ b/release-engineering/packaging.md
@@ -24,7 +24,7 @@ This guide outlines the process of building debs/rpms for Kubernetes minor and p
 
 ## Communication
 
-The [Patch Release Team][patch-release-team] (patch releases) or [Branch Manager][branch-manager-handbook] (minor releases) will reach out to the [Kubernetes Build Admins][kubernetes-build-admins] via [email][kubernetes-build-admins] or `#release-managers` on [Kubernetes Slack](https://slack.k8s.io) (for more synchronous communication) requesting help to build the debs and rpms.
+The [Patch Release Team][patch-release-team] (patch releases) or [Branch Manager][branch-manager-handbook] (minor releases) will reach out to the [Kubernetes Build Admins][kubernetes-build-admins] via the [Release Managers Google Group][release-managers-group] or [`#release-management`][release-management-slack] (for more synchronous communication) requesting help to build the debs and rpms.
 
 Patch Release Team members or Branch Managers requesting debs/rpms should be sure to provide explicit details on the package name(s), version(s), and revision(s) they need built.
 
@@ -117,20 +117,22 @@ The following jobs are currently configured to do some aspect of package validat
 
 **These tend to break when we are in the middle of a push.**
 
-If any of these tests are broken, the [Patch Release Team][patch-release-team] should receive an alert regarding the failure.
+If any of these tests are broken, the [Release Managers Google Group][release-managers-group] should receive an alert regarding the failure.
 
-If there is continued test failure on this dashboard without intervention from the Patch Release Team, escalate to the current [Release Team][release-team] and [test-infra on-call][test-infra-oncall].
+If there is continued test failure on this dashboard without intervention from the Release Managers, escalate to the current [Release Team][release-team] and [test-infra on-call][test-infra-oncall].
 
 
 [branch-manager-handbook]: /release-engineering/role-handbooks/branch-manager.md
 [branch-manager-build-and-release]: /release-engineering/role-handbooks/branch-manager.md#build-and-release
 [kubeadm-install]: https://kubernetes.io/docs/setup/independent/install-kubeadm/#installing-kubeadm-kubelet-and-kubectl
 [kubernetes/release]: https://git.k8s.io/release
-[kubernetes-build-admins]: https://groups.google.com/forum/#!forum/kubernetes-build-admins
-[patch-release-team]: /releases/patch-releases.md
+[kubernetes-build-admins]: /release-managers.md#build-admins
+[patch-release-team]: /release-managers.md#patch-release-team
 [rapture]: https://cs.corp.google.com/piper///depot/google3/experimental/users/mehdy/kubernetes/k8s-rapture.sh
 [rapture-readme]: https://g3doc.corp.google.com/cloud/kubernetes/g3doc/release/rapture.md?cl=head
 [release-engineering-dashboard]: https://testgrid.k8s.io/sig-release-misc
+[release-management-slack]: https://kubernetes.slack.com/messages/CJH2GBF7Y
+[release-managers-group]: https://groups.google.com/forum/#!forum/kubernetes-release-managers
 [release-team]: https://groups.google.com/forum/#!forum/kubernetes-release-team
 [security-release-process]: /security-release-process-documentation/security-release-process.md
 [test-infra-oncall]: https://go.k8s.io/oncall

--- a/release-engineering/role-handbooks/branch-manager.md
+++ b/release-engineering/role-handbooks/branch-manager.md
@@ -1,4 +1,4 @@
-# Branch Manager Handbook
+# Branch Manager Handbook <!-- omit in toc -->
 
 - [Overview](#Overview)
   - [Minimum Skills and Requirements](#Minimum-Skills-and-Requirements)
@@ -22,9 +22,9 @@
   - [Code Freeze](#Code-Freeze)
   - [Code Thaw](#Code-Thaw)
 - [Branch Content Management](#Branch-Content-Management)
-   - [Branch Fast Forward](#Branch-Fast-Forward)
-   - [Reverts](#Reverts)
-   - [Cherry Picks](#Cherry-Picks)
+  - [Branch Fast Forward](#Branch-Fast-Forward)
+  - [Reverts](#Reverts)
+  - [Cherry Picks](#Cherry-Picks)
 - [Staging Repositories](#Staging-Repositories)
 - [Debugging](#Debugging)
 - [References](#References)
@@ -85,7 +85,7 @@ This is a collection of requirements and conditions to fulfil when taking on the
 
 A list of To Do(s) to get started as Branch Manager:
 
-- [ ] Contact [Kubernetes Build Admins][kubernetes-build-admins], to identify yourself as the incoming release branch manager for the current release team and request to be added to the special privilege group for the `kubernetes-release-test` GCP project that's used to build the releases
+- [ ] Contact the [Release Managers Google Group][release-managers-group] to identify yourself as the incoming release branch manager for the current release team and request to be added to the special privilege group for the `kubernetes-release-test` GCP project that's used to build the releases
    * Similar access later in the cycle should be granted to shadows depending on how they progress and what actions they prove able to step up to exercise during the cycle.
 - [ ] Request permission to post on [kubernetes-announce][k-announce-list] via owner contact form [here][k-announce-request]
    * If you haven't received access after 24 hrs, contact the [Release Team][kubernetes-release-team].
@@ -280,7 +280,7 @@ To better prepare and see what to expect, this is a sequence of events that took
 
 ### Debian and RPM Packaging
 
-[Packaging the Official Release](https://github.com/kubernetes/sig-release/blob/master/release-engineering/packaging.md) is by conducted by employees at Google. Once `./gcbmgr release --offical ...` has completed, **before sending out the email notification**, contact the [Kubernetes Build Admins][kubernetes-build-admins] to notify them that an official release for `vX.Y` is complete and the release is ready to be packaged.
+[Packaging the Official Release](https://github.com/kubernetes/sig-release/blob/master/release-engineering/packaging.md) is by conducted by employees at Google. Once `./gcbmgr release --offical ...` has completed, **before sending out the email notification**, contact the [Release Managers Google Group][release-managers-group] to notify them that an official release for `vX.Y` is complete and the release is ready to be packaged.
 
 The entire packaging process including the build and validation of the builds could take around 3-4 hours. It is preferable to have the DEB and RPM files ready prior to sending out the release notification email since, people worldwide will attempt to download the official release. Since packaging uses the release tag, it is important to [validate the release process](#release-validation).
 
@@ -581,9 +581,6 @@ The bot runs every four hours, so it might take sometime for a new tag to appear
 
 The client-go major release (.e.g `v1.13.0`) is released manually a day after the main Kubernetes release.
 
-[kubernetes-build-admins]: mailto:kubernetes-build-admins@googlegroups.com
-[kubernetes-release-team]: https://groups.google.com/forum/#!forum/kubernetes-release-team
-
 # Debugging
 
 Logs from `branchff`, `gcbmgr`, etc are stored in the `/tmp` directory and can provide more details as to why command executions are failing.
@@ -670,3 +667,7 @@ See the branch management process prior to v1.12 when `anago` was still used.
 * [Branch Management Playbook](https://docs.google.com/document/d/1Qoqz5IZYBp6A-Q_R9CGhMAc358ykOiE49GXZU9r5usQ/edit#heading=h.s71iha1627td)
 
 > Note: To view this document, you will need to join the [kubernetes-dev](https://groups.google.com/forum/#!forum/kubernetes-dev) Google group.
+
+
+[kubernetes-release-team]: https://groups.google.com/forum/#!forum/kubernetes-release-team
+[release-managers-group]: https://groups.google.com/forum/#!forum/kubernetes-release-managers

--- a/release-managers.md
+++ b/release-managers.md
@@ -7,19 +7,25 @@ The responsibilities of each role are described below.
 - [Contact](#Contact)
 - [Handbooks](#Handbooks)
 - [Patch Release Team](#Patch-Release-Team)
+  - [GitHub teams](#GitHub-teams)
+  - [Members](#Members)
 - [Branch Managers](#Branch-Managers)
+  - [Members](#Members-1)
 - [Associates](#Associates)
+  - [Members](#Members-2)
 - [Build Admins](#Build-Admins)
+  - [GitHub team](#GitHub-team)
+  - [Members](#Members-3)
 - [SIG Release Chairs](#SIG-Release-Chairs)
+  - [GitHub team](#GitHub-team-1)
+  - [Members](#Members-4)
 
 ## Contact
 
-| Role | Mailing List | Mailing List Visibility/Usage | GitHub | Slack |
+| Mailing List | Slack | Visibility | Usage | Membership |
 |---|---|---|---|---|
-| All | [kubernetes-release-managers@googlegroups.com](mailto:kubernetes-release-managers@googlegroups.com) | Private, communications to all roles | [@kubernetes/release-managers](https://github.com/orgs/kubernetes/teams/release-managers) | [#release-management](https://kubernetes.slack.com/messages/CJH2GBF7Y) (channel) / @release-managers (user group)
-| Patch Release Managers | [kubernetes-patch-release-team@googlegroups.com](mailto:kubernetes-patch-release-team@googlegroups.com) | Private, communications regarding patch releases | [@kubernetes/patch-release-team](https://github.com/orgs/kubernetes/teams/patch-release-team) | [#release-private](https://kubernetes.slack.com/messages/GKEA5EL67) (**_private_** channel) |
-| Branch Managers | N/A | N/A | N/A | N/A |
-| Build Admins | [kubernetes-build-admins@googlegroups.com](mailto:kubernetes-patch-release-team@googlegroups.com) | Private, communications regarding packaging debs/rpms | [@kubernetes/build-admins](https://github.com/orgs/kubernetes/teams/build-admins) | N/A |
+| [kubernetes-release-managers@googlegroups.com](mailto:kubernetes-release-managers@googlegroups.com) | [#release-management](https://kubernetes.slack.com/messages/CJH2GBF7Y) (channel) / @release-managers (user group) | Public | Public discussion for Release Managers | All Release Managers (Patch Release Team, Branch Managers, Associates, Build Admins, SIG Chairs) |
+| [kubernetes-release-managers-private@googlegroups.com](mailto:kubernetes-release-managers-private@googlegroups.com)| [#release-private](https://kubernetes.slack.com/messages/GKEA5EL67) | Private | Private discussion for privileged Release Managers | Patch Release Team, Build Admins, SIG Chairs |
 
 
 ## Handbooks
@@ -33,6 +39,11 @@ The responsibilities of each role are described below.
 
 The Patch Release Team is responsible for coordinating patch releases (`x.y.z`, where `z` >= 0) of Kubernetes. This team at times works in close conjunction with the [Product Security Committee](https://git.k8s.io/community/committee-product-security/README.md) and therefore should abide by the guidelines set forth in the [Security Release Process](https://git.k8s.io/security/security-release-process.md). 
 
+### GitHub teams
+- Access: [@kubernetes/release-managers](https://github.com/orgs/kubernetes/teams/release-managers)
+- Contact: [@kubernetes/patch-release-team](https://github.com/orgs/kubernetes/teams/patch-release-team)
+
+### Members
 - Aleksandra Malinowska ([@aleksandra-malinowska](https://github.com/aleksandra-malinowska))
 - Hannes Hörl ([@hoegaarden](https://github.com/hoegaarden))
 - Pengfei Ni ([@feiskyer](https://github.com/feiskyer))
@@ -43,6 +54,7 @@ The Patch Release Team is responsible for coordinating patch releases (`x.y.z`, 
 
 Branch Managers are responsible for minor releases (`x.y.z`, where `z` = 0) of Kubernetes, working in close conjunction with the [Release Team](/release-team/README.md) through each release cycle.
 
+### Members
 - Cheryl Fong ([@bubblemelon](https://github.com/bubblemelon))
 - Yang Li ([@idealhack](https://github.com/idealhack))
 
@@ -51,6 +63,7 @@ Branch Managers are responsible for minor releases (`x.y.z`, where `z` = 0) of K
 
 Release Manager Associates are apprentices to the Branch Managers, formerly referred to as Branch Manager shadows.
 
+### Members
 - Stephen Augustus ([@justaugustus](https://github.com/justaugustus))
 - Nikhil Manchanda ([@slicknik](https://github.com/slicknik))
 - Vivek Taparia ([@vivektaparia](https://github.com/vivektaparia))
@@ -70,6 +83,10 @@ Release Manager Associates are apprentices to the Branch Managers, formerly refe
 
 Build Admins are (currently) Google employees with the requisite access to Google build systems/tooling to publish deb/rpm packages on behalf of the Kubernetes project.
 
+### GitHub team
+- [@kubernetes/build-admins](https://github.com/orgs/kubernetes/teams/build-admins)
+
+### Members
 - Aleksandra Malinowska ([@aleksandra-malinowska](https://github.com/aleksandra-malinowska))
 - Linus Arver ([@listx](https://github.com/listx))
 - Sumitran Raghunathan ([@sumitranr](https://github.com/sumitranr))
@@ -81,6 +98,10 @@ SIG Release Chairs are responsible for the governance of SIG Release. They are m
 
 As such, they are highly privileged community members and privy to some private communications, which can at times relate to Kubernetes security disclosures.
 
+### GitHub team
+- [@kubernetes/sig-release-admins](https://github.com/orgs/kubernetes/teams/sig-release-admins)
+
+### Members
 - Caleb Miles ([@calebamiles](https://github.com/calebamiles))
 - Stephen Augustus ([@justaugustus](https://github.com/justaugustus))
 - Tim Pepper ([@tpepper](https://github.com/tpepper))

--- a/release-team/role-handbooks/release-team-lead/README.md
+++ b/release-team/role-handbooks/release-team-lead/README.md
@@ -123,7 +123,7 @@ Release Team selection should happen in accordance with the [Release Team Select
 ### Week 3
 
 - Create the release notes draft file in the release directory per the standard above
-- Prepare for x.y.0-alpha.0 "release", specifically that there is a branch manager on the team, and that master-blocking tests are all green. The alpha.0 artifacts were created already as a part of the prior release. But this synthetic notation is a point to review process with the branch manager. Request access to GCB through [Kubernetes Build Admins][kubernetes-build-admins] for branch manager lead and optionally also read-only access (if system supports this) for the release lead and release lead shadow.
+- Prepare for x.y.0-alpha.0 "release", specifically that there is a branch manager on the team, and that master-blocking tests are all green. The alpha.0 artifacts were created already as a part of the prior release. But this synthetic notation is a point to review process with the branch manager. Request access to GCB through the [Release Managers Google Group][release-managers-group] for branch manager lead and optionally also read-only access (if system supports this) for the release lead and release lead shadow.
 - Begin coordination with SIG-Cluster-Lifecycle for their kubeadm release (they may create an issue in the milestone to track release blocking issues)
 - Identify any other dependent ecosystem projects that need release coordination
 - Announce/email that the following week is "enhancements freeze" and what that means
@@ -244,17 +244,18 @@ Release Day
 
 - Release retrospective participation (you may also choose to facilitate it, but it’s not recommended)
 - Follow-up interviews with the media, the media roundtable.
-- Contact [Kubernetes Build Admins][kubernetes-build-admins] to remove release lead, release lead shadow, and branch manager authorization in GCB, as appropriate for release team turn over.
+- Contact the [Release Managers Google Group][release-managers-group] to remove release lead, release lead shadow, and branch manager authorization in GCB, as appropriate for release team turn over.
 - Ensure self, shadows, and branch managers are removed as members of [security-release-team], leaving patch release manager.
 
 ### Week 14
 
 - Help fill the any open positions for the next release milestone
 
-[kubernetes-build-admins]: https://groups.google.com/forum/#!forum/kubernetes-build-admins
+
 [kubernetes-release-calendar]: https://bit.ly/k8s-release-cal
 [kubernetes-release-team]: https://groups.google.com/forum/#!forum/kubernetes-release-team
 [kubernetes-sig-release]: https://groups.google.com/forum/#!forum/kubernetes-sig-release
 [kubernetes-sig-leads]: https://groups.google.com/forum/#!forum/kubernetes-sig-leads
 [kubernetes-dev]: https://groups.google.com/forum/#!forum/kubernetes-dev
+[release-managers-group]: https://groups.google.com/forum/#!forum/kubernetes-release-managers
 [security-release-team]: https://groups.google.com/a/kubernetes.io/forum/#!forum/security-release-team

--- a/releases/patch-releases.md
+++ b/releases/patch-releases.md
@@ -44,60 +44,63 @@ for the next patch release.
 
 Coming soon...
 
-| **Patch Release** | **Cherry-picks deadline** | **Target date** | **Owner** |
-| --- | --- | --- | --- |
-| 1.15.1 | TBD early July | TBD early July | [kubernetes-patch-release-team] |
+| Patch Release | Cherry-picks deadline | Target date |
+| --- | --- | --- |
+| 1.15.1 | TBD early July | TBD early July |
+
 
 ### 1.14
 
 Next patch release is **1.14.4**.
 
-| **Patch Release** | **Cherry-picks deadline** | **Target date** | **Owner** |
-| --- | --- | --- | --- |
-| 1.14.5 | TBD  | TBD | [kubernetes-patch-release-team] |
-| 1.14.4 | 2019-07-02 | 2019-07-08 | [kubernetes-patch-release-team] |
-| 1.14.3 | 2019-06-03 | 2019-06-06 | [kubernetes-patch-release-team] |
-| 1.14.2 | 2019-05-10 | 2019-05-14 | [kubernetes-patch-release-team] |
-| 1.14.1 | 2019-04-05 | 2019-04-08 | [kubernetes-patch-release-team] |
+| Patch Release | Cherry-picks deadline | Target date |
+| --- | --- | --- |
+| 1.14.5 | TBD  | TBD |
+| 1.14.4 | 2019-07-02 | 2019-07-08 |
+| 1.14.3 | 2019-06-03 | 2019-06-06 |
+| 1.14.2 | 2019-05-10 | 2019-05-14 |
+| 1.14.1 | 2019-04-05 | 2019-04-08 |
+
 
 ### 1.13
 
 Next patch release is **1.13.8**.
 
-| **Patch Release** | **Cherry-picks deadline** | **Target date** | **Owner** |
-| --- | --- | --- | --- |
-| 1.13.9 | TBD | TBD | [kubernetes-patch-release-team] |
-| 1.13.8 | 2019-07-02 | 2019-07-08 | [kubernetes-patch-release-team] |
-| 1.13.7 | 2019-06-03 | 2019-06-06 | [kubernetes-patch-release-team] |
-| 1.13.6 | 2019-05-06 | 2019-05-08 | [kubernetes-patch-release-team] |
-| 1.13.5 | 2019-03-21 | 2019-03-25 | @aleksandra-malinkowska, @tpepper |
-| 1.13.4 | 2019-02-26 | 2019-02-28 | @aleksandra-malinkowska |
-| 1.13.3 | 2019-01-24 | 2019-02-01 | @tpepper |
-| 1.13.2 | 2019-01-08 | 2019-01-10 | @tpepper |
-| 1.13.1 | 2018-12-11 | 2018-12-13 | @aleksandra-malinowska |
+| Patch Release | Cherry-picks deadline | Target date |
+| --- | --- | --- |
+| 1.13.9 | TBD | TBD |
+| 1.13.8 | 2019-07-02 | 2019-07-08 |
+| 1.13.7 | 2019-06-03 | 2019-06-06 |
+| 1.13.6 | 2019-05-06 | 2019-05-08 |
+| 1.13.5 | 2019-03-21 | 2019-03-25 |
+| 1.13.4 | 2019-02-26 | 2019-02-28 |
+| 1.13.3 | 2019-01-24 | 2019-02-01 |
+| 1.13.2 | 2019-01-08 | 2019-01-10 |
+| 1.13.1 | 2018-12-11 | 2018-12-13 |
+
 
 ### 1.12
 
 Next patch release is **1.12.9**.
 
-| **Patch Release** | **Cherry-picks deadline** | **Target date** | **Owner** |
-| --- | --- | --- | --- |
-| 1.12.10 | 2019-06-28 | 2019-07-01 | @feiskyer |
-| 1.12.9 | 2019-05-24 | 2019-05-27 | @feiskyer |
-| 1.12.8 | 2019-04-19 | 2019-04-24 | @feiskyer |
-| 1.12.7 | 2019-03-21 | 2019-03-25 | @feiskyer |
-| 1.12.6 | 2019-02-23 | 2019-02-26 | @feiskyer |
-| 1.12.5 | 2019-01-15 | 2019-01-17 | @feiskyer |
-| 1.12.4 | 2018-12-13 | 2018-12-18 | @feiskyer |
-| 1.12.3 | 2018-11-08 | 2018-11-26 | @feiskyer |
-| 1.12.2 | 2018-10-23 | 2018-10-26 | @feiskyer |
-| 1.12.1 | 2018-10-05 | 2018-10-05 | @feiskyer |
+| Patch Release | Cherry-picks deadline | Target date |
+| --- | --- | --- |
+| 1.12.10 | 2019-06-28 | 2019-07-01 |
+| 1.12.9 | 2019-05-24 | 2019-05-27 |
+| 1.12.8 | 2019-04-19 | 2019-04-24 |
+| 1.12.7 | 2019-03-21 | 2019-03-25 |
+| 1.12.6 | 2019-02-23 | 2019-02-26 |
+| 1.12.5 | 2019-01-15 | 2019-01-17 |
+| 1.12.4 | 2018-12-13 | 2018-12-18 |
+| 1.12.3 | 2018-11-08 | 2018-11-26 |
+| 1.12.2 | 2018-10-23 | 2018-10-26 |
+| 1.12.1 | 2018-10-05 | 2018-10-05 |
+
 
 ### 1.11 and older
 
 These releases are no longer supported.
 
+[cherry-pick process]: https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md
 [release-managers]: /release-managers.md
 [release process description]: https://git.k8s.io/community/contributors/devel/sig-release/release.md
-[kubernetes-patch-release-team]: mailto:kubernetes-patch-release-team@googlegroups.com
-[cherry-pick process]: https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md


### PR DESCRIPTION
After some thought, I feel it makes sense to consolidate some of the channels for contacting Release Managers. 

So I propose the following:
- [ ] Rename kubernetes-build-admins@googlegroups.com to kubernetes-release-managers@googlegroups.com (public comms)
- [ ] Rename kubernetes-patch-release-team@googlegroups.com to kubernetes-release-managers-private@googlegroups.com (private comms)

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

I'll keep this on hold until another SIG Release Chair approves:
/hold
/assign @calebamiles @tpepper 
/cc @kubernetes/patch-release-team @kubernetes/release-managers @kubernetes/build-admins 

ref: https://github.com/kubernetes/sig-release/pull/701#issuecomment-506909538