### PR TITLE
Add note about amd64 container images archives

### DIFF
--- a/release-engineering/artifacts.md
+++ b/release-engineering/artifacts.md
@@ -10,6 +10,9 @@
 | kube-proxy               	|  ✅  	|   ✅   	|  ✅  	|   ✅   	|    ✅    	|   ✅   	|
 | kube-scheduler           	|  ✅  	|   ✅   	|  ✅  	|   ✅   	|    ✅    	|   ✅   	|
 
+Note: starting at 1.16 container images archives for 'amd64' will contain the arch in the name, like 'kube-apiserver-amd64'.
+These can be found inside the binaries tar files, in the manifest.json file under "RepoTags".
+
 ## Storage
 
 ### Binaries


### PR DESCRIPTION
We are removing the legacy no-arch in the container image name for 'amd64'.
All the images should contain the architecture in the name.
The no-arch name is reserved for docker manifests, like 'kube-apiserver'.