### PR TITLE
Update Release Managers contacts to use kubernetes.io Google Groups

### DIFF
--- a/release-engineering/packaging.md
+++ b/release-engineering/packaging.md
@@ -132,7 +132,7 @@ If there is continued test failure on this dashboard without intervention from t
 [rapture-readme]: https://g3doc.corp.google.com/cloud/kubernetes/g3doc/release/rapture.md?cl=head
 [release-engineering-dashboard]: https://testgrid.k8s.io/sig-release-misc
 [release-management-slack]: https://kubernetes.slack.com/messages/CJH2GBF7Y
-[release-managers-group]: https://groups.google.com/forum/#!forum/kubernetes-release-managers
+[release-managers-group]: https://groups.google.com/a/kubernetes.io/forum/#!forum/release-managers
 [release-team]: https://groups.google.com/forum/#!forum/kubernetes-release-team
 [security-release-process]: /security-release-process-documentation/security-release-process.md
 [test-infra-oncall]: https://go.k8s.io/oncall

--- a/release-engineering/role-handbooks/branch-manager.md
+++ b/release-engineering/role-handbooks/branch-manager.md
@@ -670,4 +670,4 @@ See the branch management process prior to v1.12 when `anago` was still used.
 
 
 [kubernetes-release-team]: https://groups.google.com/forum/#!forum/kubernetes-release-team
-[release-managers-group]: https://groups.google.com/forum/#!forum/kubernetes-release-managers
+[release-managers-group]: https://groups.google.com/a/kubernetes.io/forum/#!forum/release-managers

--- a/release-managers.md
+++ b/release-managers.md
@@ -4,28 +4,28 @@ Release Managers is an umbrella term that encompasses the set of Kubernetes cont
 
 The responsibilities of each role are described below.
 
-- [Contact](#Contact)
-- [Handbooks](#Handbooks)
-- [Patch Release Team](#Patch-Release-Team)
-  - [GitHub teams](#GitHub-teams)
-  - [Members](#Members)
-- [Branch Managers](#Branch-Managers)
-  - [Members](#Members-1)
-- [Associates](#Associates)
-  - [Members](#Members-2)
-- [Build Admins](#Build-Admins)
-  - [GitHub team](#GitHub-team)
-  - [Members](#Members-3)
-- [SIG Release Chairs](#SIG-Release-Chairs)
-  - [GitHub team](#GitHub-team-1)
-  - [Members](#Members-4)
+- [Contact](#contact)
+- [Handbooks](#handbooks)
+- [Patch Release Team](#patch-release-team)
+  - [GitHub teams](#github-teams)
+  - [Members](#members)
+- [Branch Managers](#branch-managers)
+  - [Members](#members-1)
+- [Associates](#associates)
+  - [Members](#members-2)
+- [Build Admins](#build-admins)
+  - [GitHub team](#github-team)
+  - [Members](#members-3)
+- [SIG Release Chairs](#sig-release-chairs)
+  - [GitHub team](#github-team-1)
+  - [Members](#members-4)
 
 ## Contact
 
 | Mailing List | Slack | Visibility | Usage | Membership |
 |---|---|---|---|---|
-| [kubernetes-release-managers@googlegroups.com](mailto:kubernetes-release-managers@googlegroups.com) | [#release-management](https://kubernetes.slack.com/messages/CJH2GBF7Y) (channel) / @release-managers (user group) | Public | Public discussion for Release Managers | All Release Managers (Patch Release Team, Branch Managers, Associates, Build Admins, SIG Chairs) |
-| [kubernetes-release-managers-private@googlegroups.com](mailto:kubernetes-release-managers-private@googlegroups.com)| [#release-private](https://kubernetes.slack.com/messages/GKEA5EL67) | Private | Private discussion for privileged Release Managers | Patch Release Team, Build Admins, SIG Chairs |
+| [release-managers@kubernetes.io](mailto:release-managers@kubernetes.io) | [#release-management](https://kubernetes.slack.com/messages/CJH2GBF7Y) (channel) / @release-managers (user group) | Public | Public discussion for Release Managers | All Release Managers (Patch Release Team, Branch Managers, Associates, Build Admins, SIG Chairs) |
+| [release-managers-private@kubernetes.io](mailto:release-managers-private@kubernetes.io)| [#release-private](https://kubernetes.slack.com/messages/GKEA5EL67) | Private | Private discussion for privileged Release Managers | Patch Release Team, Build Admins, SIG Chairs |
 
 
 ## Handbooks

--- a/release-team/role-handbooks/release-team-lead/README.md
+++ b/release-team/role-handbooks/release-team-lead/README.md
@@ -295,7 +295,7 @@ Release Day
 [onboarding]: /release-team/release-team-onboarding.md
 [Prow]: https://prow.k8s.io/
 [release-blocking]: /release-blocking-jobs.md
-[release-managers-group]: https://groups.google.com/forum/#!forum/kubernetes-release-managers
+[release-managers-group]: https://groups.google.com/a/kubernetes.io/forum/#!forum/release-managers
 [security-release-team]: https://groups.google.com/a/kubernetes.io/forum/#!forum/security-release-team
 [selection]: /release-team/release-team-selection.md
 [Testgrid]: https://testgrid.k8s.io/


### PR DESCRIPTION
Further deduping the Release Engineering lists by moving them to the kubernetes.io GSuite account:
- release-managers@kubernetes.io
- release-managers-private@kubernetes.io

This gets us the ability to nest groups, if needed. We will also use these new groups for permissions on GCP: https://github.com/kubernetes/sig-release/issues/732

Putting a lazy consensus hold (Wednesday, 8/7 at 6pm ET) on this for visibility (the group changes have already been approved in the above referenced issue).

I'll make the mailing list name changes once lazy consensus is achieved.

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/assign @tpepper @calebamiles 
/hold
/milestone v1.16
/priority important-soon