### PR TITLE
Update the Blocking Jobs document and the CI Signal Handbook based on…

### DIFF
--- a/release-blocking-jobs.md
+++ b/release-blocking-jobs.md
@@ -1,53 +1,69 @@
-# Release Blocking Jobs
+# Release Blocking Test Jobs
 
-Here is a list of jobs that should block release if not healthy.
+[SIG-Release TestGrid](https://testgrid.k8s.io/sig-release-master-blocking)
 
-If you want to add a release-branch job, please add them to the appropriate
-sig-release-x.y-all dashboard first. Then show the test is not flaky, and the
-release team can decide if the test should be added to release-blocking
-dashboard as well.
+SIG-release maintains two sets of jobs that decide whether the release is
+healthy: Blocking and Informing.  Each of these sets is instantiated for each
+active release (beta or later), plus Master, so at any given time there will
+be 8-10 dashboards in pairs.
 
-## Release-Blocking Criteria
+Below, the set of "sig-release-master-blocking" and "sig-release-X.Y-blocking"
+dashboards will be referred to collectively as "Blocking", and the set of all
+"-informing" dashboards as Informing.  Where only specific dashboards are
+required, they will be referred to by name or pattern.
 
-NB: Note that while we describe the "ideal" goals below, not all jobs currently
-in the release-blocking dashboards currently meet these criteria, and we intend
-to correct with follow on PR's.  Please see the umbrella issue for followup
-work: [kubernetes/sig-release#347](https://github.com/kubernetes/sig-release/issues/347)
+There are also some other release dashboards, such as sig-release-misc,
+sig-release-orphaned, and sig-release-x.y-all, none of which are used to
+determine readiness to release.  They are there either to support other
+teams (such as the Release Engineering) or as "parking" for jobs that need to
+be fixed.
 
-The ideal release-blocking job meets the following criteria:
+If you want to add a release-blocking job, please add them to the appropriate
+Informing dashboard first. The release team can later decide if the test should
+be moved to the Blocking dashboard.
 
-- It provisions clusters via open-source software instead of a hosted service
-<!-- TODO(spiffxp):
-  - should any allowances be made for conformance?
--->
-- It finishes a run in 120 minutes or less
-<!-- TODO(spiffxp):
-  - this should be a percentile, not a max
--->
-- It runs at least every 3 hours
-- Is capable of passing 3 times in a row against the same commit
-- Is owned by a SIG that is responsive to addressing failures
-  - Represented by a configured testgrid alert email (enforced via presubmit)
-- It passes 75% of all of its runs in the past week (regardless of underlying
-  commit(s)) and fails for no more than 10 runs in a row
-  - In the case of failures, there must be an issue in kubernetes/kubernetes
-    detailing that there is at least one person from the owning SIG working to
-    resolve the issue. Said issue must be acknowledged within a short period
-    (i.e., a week) and resolved within a short period being acknowledged by the
-    owning SIG (i.e., a week as well).
-- Has a documented reason for its inclusion in the release-blocking suite
+Additional documentation may be found in the [CI Signal Role Handbook](./release-team/role-handbooks/ci-signal/README.md).
+
+## Release-Blocking Dashboard
+
+Jobs on the Blocking dashboard for a particular release should block that
+release if they do not have at least three successive "green" runs at go/nogo
+decision time.  In some cases, the CI Signal team may authorize release with a
+job still failing for thoroughly investigated reasons, but the general
+expectation is "jobs red, do not release."
+
+As such, criteria for what jobs are on Blocking are rather stringent, in order
+to prevent aborting a release unnecessarily.  Note that not all current jobs
+meet the below criteria completely due to technical debt.  Blocking jobs must:
+
+- Have a documented reason for its inclusion in the release-blocking suite
 <!-- TODO(spiffxp):
   - represented in description? link to an issue where discussion was had?
 -->
+- Provision clusters via open-source software instead of a hosted service
+<!-- TODO(spiffxp):
+  - should any allowances be made for conformance?
+-->
+- Have 75% of runs, or more, finishing in 120 minutes or less
+- Run at least every 3 hours
+- Be able to pass 3 times in a row against the same commit
+- Be Owned by a SIG, WG, or other team that is responsive to addressing failures, and whose alert email is configured in the job.
+- Have passed 75% of all of its runs in the week before adding it to Blocking, and have failed for no more than 10 runs in a row
 
-The reasoning for the above is that as we get to the end of a release cycle,
+*In the case of failures, there must be an issue in kubernetes/kubernetes
+detailing that there is at least one person from the owning SIG working to
+resolve the issue. Said issue must be acknowledged within a short period
+(i.e., a week) and resolved within a short period being acknowledged by the
+owning SIG (i.e., a week as well).*
+
+The reasoning for the above time limits is that as we get to the end of a release cycle,
 we are usually waiting on a handful of bug fixes and want to be certain that
 the underlying bug is truly fixed. This means we prefer to see multiple test
 results for the same commit. If we wait for three successful runs that are
 scheduled every three hours, we wait for nine hours.  This effectively gives
 us the chance to make two changes/decisions in a 24 hour period.
 
-The thresholds given are aspirational. We recognize that not every job may be
+The thresholds given have some flexibility. We recognize that not every job may be
 able to strictly adhere to all of these criteria all of the time.  We also
 recognize that metrics can be gamed. Thus we consider human review to be the
 ultimate authority in the process to promote a demote a job as
@@ -55,29 +71,31 @@ release-blocking, and metrics to be the triggering criteria for such review.
 There is no shame in being demoted, and once the problems have been fixed, a
 job can be promoted back.
 
+<!--
 We intend to drive the criteria to stricter thresholds over time, e.g.,
 - finishing a run in 60min or less
 - running at least every 2 hours
 - passing at least 90% of all runs
+-->
 
-## Release-Informing Criteria
+## Release-Informing Dashboard
 
 Jobs that are considered useful or necessary to inform whether a commit on
 master is ready for release, but that clearly do not meet release-blocking
-criteria, may be placed on the sig-release-master-informing dashboard. These
+criteria, may be placed on the Informing dashboard. These
 are often jobs that are some combination of slow, flaky, infrequent, or
-difficult to maintain.
+difficult to maintain.  There are often good reasons for these jobs to not meet
+Blocking criteria, such as requiring 12 hours for each run, or having
+intrinsic race conditions.
 
 These jobs may still block the release, but because they require a lot of
 manual, human interpretation, we choose to move them to a separate dashboard.
 
-<!-- TOOD(spiffxp): implement release-master-informing, populate with e.g.:
-- gce-master-scale-performance
-- gce-cos-master-serial
-- gke-cos-master-serial
-- packages-pushed-master
-- conformance jobs that run less frequently than every 3 hours
--->
+CI Signal Team members will regularly check the Informing Dashboard for new
+failures.  Unexplained failures that are not flakes should be considered reason
+to block the release until the failures are investigated and evaluated.  Unlike
+Blocking, however, jobs in Informing do not need to be green before authorizing
+a release, they can be failing for known and "acceptable" reasons.
 
 ## Promoting or Demoting Jobs
 
@@ -105,55 +123,3 @@ improve.
   - rationale for why this job is meaningful or necessary (or is no longer
     meaningful or necessary)
   - etc.
-
-## Release-Blocking Dashboards
-
-<!-- TODO(krzyzacy): use master-blocking dashboard, once we sort out jobs
-                     like scalability -->
-
-We use [1.12 release-blocking dashboard](http://k8s-testgrid.appspot.com/sig-release-1.12-blocking)
-as a source of truth. The tab names are autogenerated based on the job names,
-and have the branch/version in their name. For example, for release x.y:
-
-* Make & Unit & Integration
-  - build-x.y
-  - verify-x.y
-  - integration-x.y
-  - bazel-build-x.y
-  - bazel-test-x.y
-* GCE
-  - gce-cos-default-x.y
-  - gce-cos-serial-x.y
-  - gce-cos-slow-x.y
-  - gce-cos-ingress-x.y
-  - gce-cos-reboot-x.y
-  - gce-cos-alphafeatures-x.y
-  - gce-cos-conformance-x.y
-  - gce-gpu-device-plugin-x.y
-  - gci-gce-scalability-x.y
-* GKE
-  - gke-cos-default-x.y
-  - gke-cos-serial-x.y
-  - gke-cos-slow-x.y
-  - gke-cos-ingress-x.y
-  - gke-cos-reboot-x.y
-  - gke-gpu-device-plugin-x.y
-  - gke-gpu-device-plugin-p100-x.y
-* AWS
-  - kops-aws-x.y
-* Node
-  - node-kubelet-x.y
-* [Kubeadm](https://github.com/kubernetes/kubeadm/blob/master/docs/managing-e2e-tests.md)
-  - kubeadm-gce
-  - kubeadm-gce-x.$(y-1)-on-x.y
-
-## Testgrid Release Blocking Dashboards
-
-- [master blocking](https://k8s-testgrid.appspot.com/sig-release-master-blocking)
-- [1.12 blocking](https://k8s-testgrid.appspot.com/sig-release-1.12-blocking)
-- [1.11 blocking](https://k8s-testgrid.appspot.com/sig-release-1.11-blocking)
-- [1.10 blocking](https://k8s-testgrid.appspot.com/sig-release-1.10-blocking)
-
-<!--
-The link map need to be updated every release
--->

--- a/release-team/role-handbooks/ci-signal/README.md
+++ b/release-team/role-handbooks/ci-signal/README.md
@@ -98,24 +98,35 @@ Increased attention on maintaining signal early in the release cycle goes a long
 ### Burndown to Code Freeze
 
 This is when things really begin to ramp up in the release cycle with active bug triaging and followup on possible release blocking issues to assess release health. Day to day tasks of CI Signal lead include
-- Auditing test status of master-blocking, master-upgrade and release-1.x.y-blocking dashboards on **daily basis**
-- Keeping issues' status upto-date on GitHub
+- Auditing test status of master-blocking, master-informing, release-1.x.y-blocking and release-1.x.y-informing dashboards on **daily basis**
+- Keeping issues' status up-to-date on GitHub
 - Working closely with SIGs, test owners, bug triage lead and Release team in triaging, punting and closing issues
 - Updating issue tracker frequently so anyone on the release team can get to speed and help followup on open issues
 - Continuing to send [weekly CI signal report](#reporting-status)
 
 ### During Code Freeze
 
-- Continue best practices from Burndown stage. Monitor master-blocking, master-upgrade and release-1.x.y-blocking dashboards on **daily basis**
+- Continue best practices from Burndown stage. Monitor master-blocking, master-informing, release-1.x.y-blocking, and release-1.x.y-informing dashboards on **daily basis**
 - Quickly escalate any new failures to release team and SIGs
 - Continuing to send [weekly CI signal report](#reporting-status)
 
 ### Exit Code Freeze
 
 - Once 1.x.y-rc.1 release branch is cut and master re-opens for next release PRs
-  - continue **monitoring master-upgrade and 1.x.y-blocking dashboards on daily basis**
+  - continue **1.x.y-blocking, and 1.x.y-informing dashboards on daily basis**
+  - check the **scalability jobs on master-informing** daily.
   - you need not monitor master-blocking on a daily basis. It is, however, worth keeping an eye on master-blocking especially before risky cherry-picks make their way into the release branch
 - If tests have stabilized (they should have by now), you may stop sending the weekly CI report
+
+## Blocking vs. Informing Dashboards
+
+Summary: failing Blocking jobs always block release.  Failing Informing jobs sometimes block release.
+
+Jobs on the master-blocking and 1.x.y-blocking dashboards are expected to be green *all the time*.  As such, you should take immediate action when one of them turns red, and may recommend postponing the release if any one of these jobs is not passing.
+
+Jobs on the master-informing and 1.x.y-informing dashboards require more interpretation.  Some run infrequently or for a long time, and can take days to show effects from merged changes.  Others are inconsistent and require you to wait for several failed runs to file an issue and consult the owning SIG.  As a result, these tests block release either when they have unexplained failures, or failures that have been investigated and relate to blocking issues.  If they're just flaking, or failing for explained and tolerated reasons, they do not block.
+
+For more detailed information about what's on these dashboards, see [Release Blocking Jobs](../../../release-blocking-jobs.md) documentation.
 
 ## Special high risk test categories to monitor
 
@@ -132,6 +143,8 @@ The following scalability jobs/tests could regress quite easily (due to seemingl
 - [master-informing gce-scale-correctness](https://testgrid.k8s.io/sig-release-master-informing#gce-master-scale-correctness)
 - [master-informing gce-scale-performance](https://testgrid.k8s.io/sig-release-master-informing#gce-master-scale-performance)
 - `release 1.xx-blocking gce-cos-1.xx-scalability-100`
+
+Importantly, the expensive scalability jobs that run on master-informing do not run or appear on release-1.x.y-informing because we don't currently run them against the release branch as well as master.  As such, you need to look at these in master-informing even after you've otherwise stopped tracking master, and may need to interpret the delta between master and your release branch.
 
 The CI Signal lead should
 - Continuously monitor these tests early in the release cycle, ensure issues are filed and escalated to the Release team and right owners in SIG-Scalability (@bobwise, @shyamjvs, @wojtek-t)


### PR DESCRIPTION
… the implemetation of the Release Blocking criteria (#347) and discussions with SIG-Scalability.  Emphasizes that Informing jobs still need daily monitoring.

This should complete #347.

/kind documentation
/area release-team
/assign @spiffxp 

attn:
@lachie83 @wojtek-t @alejandrox1 