### PR TITLE
releng: Add Stephen Augustus as Branch Manager

### DIFF
--- a/release-managers.md
+++ b/release-managers.md
@@ -56,6 +56,7 @@ Branch Managers are responsible for minor releases (`x.y.z`, where `z` = 0) of K
 
 ### Members
 - Cheryl Fong ([@bubblemelon](https://github.com/bubblemelon))
+- Stephen Augustus ([@justaugustus](https://github.com/justaugustus))
 - Yang Li ([@idealhack](https://github.com/idealhack))
 
 
@@ -64,7 +65,6 @@ Branch Managers are responsible for minor releases (`x.y.z`, where `z` = 0) of K
 Release Manager Associates are apprentices to the Branch Managers, formerly referred to as Branch Manager shadows.
 
 ### Members
-- Stephen Augustus ([@justaugustus](https://github.com/justaugustus))
 - Nikhil Manchanda ([@slicknik](https://github.com/slicknik))
 - Vivek Taparia ([@vivektaparia](https://github.com/vivektaparia))
 - Christian Jantz ([@chrisz100](https://github.com/chrisz100))


### PR DESCRIPTION
I was discussing this a little with @tpepper, and we like to do this for a few reasons:
- As a SIG Chair, I own most of the systems required most of the systems that Branch Managers need access to do execute the job
- I have been cutting releases (https://github.com/kubernetes/sig-release/issues/726, https://github.com/kubernetes/sig-release/issues/756) and assisting with Release Engineering activities this cycle
- This provides some clarity, as I already access to certain things, where we deny another Release Manager Associate the same access. Having me in the Release Manager Associates group blurs the line and probably makes it confusing for the other Associates. 

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/assign @tpepper @calebamiles 
cc: @kubernetes/release-engineering 
/milestone v1.16
/priority important-soon