### PR TITLE
Quarterly OWNERS update

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -3,10 +3,9 @@
 approvers:
   - sig-release-leads
 reviewers:
+  - licensing
+  - release-engineering
   - release-team
   - release-team-lead-role
-  - idvoretskyi
-  - jdumars
-  - spiffxp
 labels:
   - sig/release

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -4,73 +4,66 @@ aliases:
     - justaugustus
     - tpepper
   licensing:
-    - dims
-    - justaugustus
-    - nikhita
-    - swinslow
+    - dims # subproject owner
+    - justaugustus # subproject owner
+    - nikhita # subproject owner
+    - swinslow # subproject owner
   release-engineering:
-    - aleksandra-malinowska
-    - calebamiles
-    - ixdy
-    - mikedanese
-    - tpepper
+    - aleksandra-malinowska # Patch Release Team
+    - calebamiles # subproject owner
+    - dougm # Patch Release Team
+    - feiskyer # Patch Release Team
+    - hoegaarden # Patch Release Team
+    - idealhack # Patch Release Team
+    - justaugustus # subproject owner
+    - tpepper # subproject owner / Patch Release Team
   release-team:
-    - aishsundar
-    - claurence
-    - jberkus
-    - justaugustus
-    - spiffxp
-    - tpepper
-  patch-release-team:
-    - aleksandra-malinowska
-    - feiskyer
-    - hoegaarden
-    - tpepper
+    - aishsundar # 1.13 RT Lead
+    - claurence # 1.15 RT Lead
+    - guineveresaenger # 1.17 RT Lead
+    - jberkus # 1.11 RT Lead
+    - justaugustus # subproject owner
+    - lachie83 # 1.16 RT Lead
+    - spiffxp # 1.14 RT Lead
+    - tpepper # subproject owner / 1.12 RT Lead
   branch-managers:
     - bubblemelon
-    - idealhack
+    - justaugustus
   build-admins:
     - aleksandra-malinowska
     - listx
+    - ps882
     - sumitranr
   release-team-lead-role:
-    - aishsundar # 1.13
     - spiffxp # 1.14
     - claurence # 1.15
     - lachie83 # 1.16
+    - guineveresaenger # 1.17
   ci-signal-role:
-    - jberkus # 1.13
     - mariantalla # 1.14
     - alejandrox1 # 1.16 / 1.15
+    - alenkacz # 1.17
   enhancements-role:
     - kacole2 # 1.16 / 1.15 / 1.13
     - claurence # 1.14
-  test-infra-role:
-    - cjwagner # 1.13 / 1.12
-    - amwat # 1.14
-    - imkin # 1.15
+    - mrbobbytables # 1.17
   bug-triage-role:
     - nikopen # 1.14 / 1.13
     - soggiest # 1.15
     - xmudrii # 1.16
+    - josiahbjorgaard # 1.17
   docs-role:
-    - tfogo # 1.13
     - jimangel # 1.14
     - MAKOSCAFEE # 1.15
     - simplytunde # 1.16
+    - daminisatya # 1.17
   release-notes-role:
-    - marpaia # 1.13
     - dstrebel # 1.14
     - onyiny-ang # 1.15
     - saschagrunert # 1.16
+    - cartyc # 1.17
   communications-role:
-    - kbarnard10 # 1.13 / 1.12 / 1.11
     - nwoods3 # 1.14
     - castrojo # 1.15
     - onlydole # 1.16
-  committee-product-security:
-    - philips
-    - cjcullen
-    - tallclair
-    - liggitt
-    - joelsmith
+    - rawkode # 1.17

--- a/release-engineering/OWNERS
+++ b/release-engineering/OWNERS
@@ -2,7 +2,6 @@
 
 approvers:
   - release-engineering
-  - patch-release-team
 reviewers:
   - branch-managers
   - build-admins

--- a/release-team/role-handbooks/branch-manager/OWNERS
+++ b/release-team/role-handbooks/branch-manager/OWNERS
@@ -1,6 +1,6 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-  - branch-managers
+  - release-engineering
 reviewers:
-  - branch-managers
+  - release-engineering

--- a/release-team/role-handbooks/patch-release-manager/OWNERS
+++ b/release-team/role-handbooks/patch-release-manager/OWNERS
@@ -1,6 +1,6 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-  - patch-release-team
+  - release-engineering
 reviewers:
-  - patch-release-team
+  - release-engineering

--- a/release-team/role-handbooks/test-infra/OWNERS
+++ b/release-team/role-handbooks/test-infra/OWNERS
@@ -1,6 +1,6 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-  - test-infra-role
+  - release-engineering
 reviewers:
-  - test-infra-role
+  - release-engineering

--- a/releases/OWNERS
+++ b/releases/OWNERS
@@ -5,4 +5,3 @@ approvers:
   - release-team-lead-role
 labels:
   - area/release-team
-


### PR DESCRIPTION
- Prune 1.13 Release Team members
- Add 1.17 Release Team role leads
- Update Release Engineering OWNERS
  - Include all Release Engineering subproject OWNERS
  - Add new Patch Release Team members (@dougm + @idealhack) (ref: https://github.com/kubernetes/sig-release/issues/737)
  - Remove inactive (@ixdy, @mikedanese)
- Add @ps882 to Build Admins
- Set Release Engineering to own deprecated RT role handbook folders
- Remove test-infra-role alias

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/assign @tpepper @calebamiles 
/cc @kubernetes/release-engineering @kubernetes/release-team @kubernetes/licensing 