### PR TITLE
Rework the Bug Triage handbook

### DIFF
--- a/release-team/role-handbooks/bug-triage/README.md
+++ b/release-team/role-handbooks/bug-triage/README.md
@@ -1,49 +1,27 @@
-Bug Triage Handbook
-==============================
+# Bug Triage Role Handbook
 
-- [Bug Triage Handbook](#Bug-Triage-Handbook)
-  - [Summary](#Summary)
-  - [Requirements](#Requirements)
-    - [Time Requirements](#Time-Requirements)
-    - [Additional Requirements for Shadows](#Additional-Requirements-for-Shadows)
-    - [Additional Requirements for Leads](#Additional-Requirements-for-Leads)
-  - [How To Do Your Job](#How-To-Do-Your-Job)
-    - [How to Escalate](#How-to-Escalate)
-  - [Early Release](#Early-Release)
-    - [Sample Searches [Early]](#Sample-Searches-Early)
-    - [Reports [Early]](#Reports-Early)
-  - [Brace Yourselves, Code Freeze Is Coming](#Brace-Yourselves-Code-Freeze-Is-Coming)
-    - [Filtering / What belongs in the milestone](#Filtering--What-belongs-in-the-milestone)
-    - [Priority label definitions](#Priority-label-definitions)
-    - [Sample Searches [Before Freeze]](#Sample-Searches-Before-Freeze)
-    - [Reports [Before Freeze]](#Reports-Before-Freeze)
-    - [Issue Categorization](#Issue-Categorization)
-  - [Code Freeze](#Code-Freeze)
-    - [Sample Searches [Freeze]](#Sample-Searches-Freeze)
-    - [Reports [Freeze]](#Reports-Freeze)
-  - [Code Thaw](#Code-Thaw)
-    - [Sample Searches [Thaw]](#Sample-Searches-Thaw)
-    - [Reports [Thaw]](#Reports-Thaw)
+## Overview
 
-## Summary
-The role of the bug triage team is to make sure that Pull Requests (PRs) and Github Issues which affect the release are dealt with in a timely fashion.
+The bug triage team is responsible to make sure that Issues and Pull Requests (PRs) which are targeted for the ongoing release cycle are dealt with in a timely fashion.
 
-Primary tasks include:
-- Listing the status of open issues / PRs
-- Communicating with relevant assignees / owners / sig-leads of issues/PRs to get status
+The role has been interchangeably called "Bug Triage" and "Issue Triage", but the general term "issue" can be conflated with the specific GitHub usage of `is:issue` artifact type. It is important to consider both `is:issue` and `is:pr` GitHub artifacts when triaging bugs.
+
+## Responsibilities
+
+The bug triage role has the following responsibilities:
+
+- Listing open issues and PRs targeted for the ongoing release cycle
+- Communicating with relevant assignees, owners, and SIG leads of issues/PRs to get the status
 - Updating issues/PRs, clarifying situations, enabling next level decision making
-- Presenting summary reports at release meetings
+- Presenting summary reports at release team and burndown meetings
+- Maintaining the automation around tracking issues/PRs against the current milestone
 
 There are four relevant periods where the workload changes:
 
-1. Early Release: from day 1 up to about a week before Code Freeze. *Duration: ~ 7-8 weeks*
-2. Code Freeze is Coming: ~2 weeks before Code Freeze. *Duration: ~2 weeks*
-3. Code Freeze: Code Freeze & Burndown, beta releases, until Code Thaw. *Duration: ~2 weeks*
-4. Code Thaw: Last two weeks of the cycle. *Duration: ~2 weeks*
-
-Secondarily, you will be helping improve automation around tracking issues against the current milestone during the Early Release phase.
-
-The role has been interchangeably called "Bug Triage" and "Issue Triage", but the general term "issue" can be conflated with the specific GitHub usage of `is:issue` artifact type.  It is important to consider both `is:issue` and `is:pr` GitHub artifacts when triaging bugs.
+1. Early Release: from week 0 up to mid-release cycle (week 6). *Duration: ~6-7 weeks*
+2. Mid release: from week 6 up to the code freeze (around week 9). *Duration: ~3-4 weeks*
+3. Code Freeze: from around week 9 up to the code thaw (week 11). *Duration: ~2 weeks*
+4. Code Thaw: the last week of the cycle. *Duration: 1 week*
 
 ## Requirements
 
@@ -55,233 +33,208 @@ Bug Triage has a lower time requirement than most roles at the beginning of the 
 
 General time requirements for Leads and Shadows are:
 
-- Availability to attend the majority of Release Team (weekly) and Burndown meetings (daily during Code Freeze). At least one member in the Bug Triage role should be present for all burndown meeting.
-- Ability to follow-up on issues and PRs during Code Freeze at arbitrary times to ensure rapid turnaround.
-- The time commitment becomes greater through the release cycle, peaking during Code Freeze.  In the last two weeks of the release, leading up to and during Code Freeze, Shadows should expect to spend at least 5 hours and leads at least 10 hours.
+- Availability to attend the majority of Release Team (weekly) and Burndown meetings
+- Ability to follow-up on issues and PRs since around week 6 (mid-release)
+- Since week 6 to the end of the release cycle the time commitment becomes greater. Shadows should expect to spend at least 3-5 hours and leads around 5-10 hours a week.
 
 ### Additional Requirements for Shadows
 
 - Have signed the contributor CLA for Kubernetes.
-- [Become a Kubernetes org member](https://git.k8s.io/community/community-membership.md#member). This should be done with the sponsorship of the Bug Triage Lead or Release Lead in the first week of the cycle.
+- [Become a Kubernetes org member](https://git.k8s.io/community/community-membership.md#member). This should be done with the sponsorship of the Bug Triage Lead and the Release Lead in the first weeks of the cycle.
   - The process to become one of these is in [our community membership ladder](https://github.com/kubernetes/community/blob/master/community-membership.md#requirements-for-outside-collaborators)
 - General familiarity with GitHub labels and how to find issues/PRs for the current milestone.
-- Commitment to follow-up with contributors about issues/PRs on Slack, email, Discuss, and SIG meetings, as appropriate.
+- Commitment to follow-up with contributors about issues/PRs on Slack, mailing lists, and SIG meetings, as appropriate.
 - General knowledge of the [Kubernetes Community governance model](https://git.k8s.io/community/governance.md#community-groups), specifically, a SIGs' areas of responsibility.
 
 Additionally, the following qualifications make a candidate more suitable for the Bug Triage team, but are not requirements:
 - Experience with quality assurance and bug tracking systems.
-- Experience with GitHub automation.
+- Experience with the GitHub automation.
 
 ### Additional Requirements for Leads
 
 In addition to the above requirements for Shadows, most of which become prerequisites, Bug Triage Leads must:
 
-- Have the ability to add a milestone to issues, so must be a member of the [milestone maintainers](/release-team/README.md#milestone-maintainers)
-- Have a working knowledge of GitHub labeling. Bug Triage leads must be able to identify relevant issues and PRs for a given milestone.
-- Have an understanding of what defines a ["Release Blocking"](/release-blocking-jobs.md) issue or PR, or know who to contact to determine that information.
+- Have the ability to add a milestone to issues/PRs, so must be a member of the [milestone maintainers team](/release-team/README.md#milestone-maintainers)
+- Have a working knowledge of GitHub labeling and labels used by the project. Bug Triage leads must be able to identify relevant issues and PRs for a given milestone.
+- Have an understanding of what defines a Release Blocking issue or PR, or know who to contact to determine that information.
 
-## How To Do Your Job
+## Getting Started
 
-As Bug Triage lead, _it is not your job_ to label, sort or gatekeep issues and PRs.
+As the Bug Triage lead, _it is not your job_ to make decisions in what milestone issue/PR should end up, how should it be prioritized, or to gatekeep issues and PRs. Instead, you should get the assignees, owners, SIG leads or key contributors to do it, as it is their job to do so. Check [How To Escalate](#how-to-escalate) on how you can do it.
 
-Instead, you should get the assignees, owners, SIG-leads or key contributors to do it, as it is their job to do so.
-Check [How To Escalate](#how-to-escalate) on how you can do it.
+In practice, you should fix anything simple that saves folks time when the intent is obvious or a milestone decision has been made. For example, you might add/modify `kind` and `priority` labels for a PR to match a correlating issue, or make sure an urgently awaited PR is in the milestone so it will pass CI.
 
-In general, you shouldn't decide whether something is in or out of a milestone; either the SIG or the Release Team Lead needs to do that.
-In practice, you should fix anything simple that saves folks time when the intent is obvious or a milestone decision has been made.
-For example, you might add/modify `kind` and `priority` labels for a PR to match a correlating issue, or make sure an urgently awaited PR is in the milestone so it will pass CI.  See [the documentation for issue kind labels](https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label).
+The Bug Triage role relates to both the Enhancements and CI Signal roles. Understanding the in-bound enhancements is important during the Early Release phase as they set the themes for incoming issues and bugs. Having an awareness on current test status is also critical, even though there is a specific lead for that area. The [documentation for CI Signal lead role](../ci-signal) includes a listing of special high risk test categories to monitor with useful information for the Bug Triage to also understand. The Bug Triage Lead should regularly interact with the peer leads for Enhancements and CI Signal.
 
-Bug Triage relates to both the Enhancements Lead and CI Signal Lead roles.  Understanding the in-bound enhancements is important during the Early Release phase as they set the themes for incoming issues and bugs.  Having an awareness on current test status is also critical, even though there is a specific lead for that area.  The [documentation for CI Signal lead role](../ci-signal) includes a listing of special high risk test categories to monitor with useful information for the Bug Triage Lead to also understand.  The Bug Triage Lead should regularly interact with the peer leads for Enhancements and CI Signal.
+Before starting, the Bug Triage members should refer to the following guides to get familiar with used labels:
+- [the documentation for issue `kind` labels](https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label)
+- [the documentation for defining priority and `priority` labels](https://github.com/kubernetes/community/blob/master/contributors/guide/issue-triage.md#define-priority).
 
 ### How to Escalate
-Whenever you find a bug that needs to be "fixed" or kicked out of the release, try the following escalation path:
 
-1. Leave a comment on the GitHub issue or PR: "This issue hasn't been updated in 3 months.  Are you still expecting to complete it for 1.17?".  It's helpful here to @ mention individuals or SIG ```-bugs``` or ```-pr-reviews``` aliases, e.g. "@kubernetes/sig-node-bugs" or "@kubernetes/sig-network-pr-reviews".
-2. Send a message to relevant SIG slack channels or mailing list about the problem: It's helpful to directly @ mention the relevant SIG Leads / Owners, and to condense multiple issues into a list, e.g. "Hey, these three issues haven't seen any attention, are they still valid for 1.17?"
-3. Message individual owners and reviewers directly via Slack and/or email (GitHub notification emails must have been filtered or missed if you're past step #1).  Individual's email addresses may be harder to find than GitHub ID, but are usually in the git commit history.  Sometimes Slack handles are hard to find.  There is no master list mapping human names to GitHub ID, email or Slack ID.  If you can't find contact info, asking in the appropriate SIG's Slack channel will usually get you pointed in the right direction.
+Whenever you find an issue or PR that needs to be finished or kicked out of the release, try the following escalation path:
+
+1. Leave a comment on the GitHub issue or PR: "This issue hasn't been updated in 3 months. Are you still expecting to complete it for 1.17?". It's helpful to @ mention individuals or SIG ```-bugs``` or ```-pr-reviews``` aliases, e.g. "@kubernetes/sig-node-bugs" or "@kubernetes/sig-network-pr-reviews".
+2. Send a message to relevant SIG Slack channel or mailing list about the problem: It's helpful to directly @ mention the relevant SIG Leads / Owners, and to condense multiple issues into a list, e.g. "Hey, these three issues haven't seen any attention, are they still valid for 1.17?"
+3. Message individual owners and reviewers directly via Slack.
 4. Escalate to the Release Team Lead with suggestions on what to do with non-responsive issues.
 
+## Timeline
 
-## Early Release
+### Early Release
 
-*There is no critical work for you in this stage.*
+This stage lasts about 6 weeks (from week 0 until week 6/mid-release cycle).
 
-As this stage lasts nearly 2 months up until Code Freeze, you can use this time to familiarize yourself with the _major enhancements and fixes_ planned by each SIG for this release, so that you can have context in advance of when you will need to identify incoming bugs as being associated with a work focus in the current release. This can greatly help in focused communication with the relevant SIG leads, as in later stages there can be an elevated urgency to fix related critical bugs and deliver new features in time.
+You should use this time to familiarize yourself with the _major enhancements and fixes_ planned by each SIG for this release, so that you can have context in advance of when you will need to identify incoming bugs as being associated with a work focus in the current release. This can greatly help in focused communication with the relevant SIG leads, as in later stages there can be an elevated urgency to fix related critical bugs and deliver new features in time.
 
 It is also a good time to interact with the Enhancements Lead and CI Signal Lead to understand any early concerns they might have, as the release team's risk management comes as much from this proactive collaboration more as from the Bug Triage lead reacting to incoming issues and PRs.
+
+The major and potentially release-blocking PRs/issues in this stage should be identified and a strategy to distribute them among the team should be devised. It is also important to identify _priority/critical-urgent_ and _priority/important-soon_ PRs/issues early on which could become release blocking later in the cycle.
 
 This is the best stage to get involved with any automation work that can ease the workload of later stages. Some tasks include:
 - updating/extending scripts to populate spreadsheets with relevant issues/PRs, delegate them to Bug Triage team members, and track them.
 - automation of notifications on relevant issues/PRs of the release cycle timeline.
 - automation of tracking/categorizing issues/PRs by responses to notifications of release cycle timeline.
 
-The major PRs/issues in this stage should be identified and a strategy to distribute the workload amongst the team should be devised. A [tracking spreadsheet](https://docs.google.com/spreadsheets/d/14DzSChatdcwKLBxshMkE9ul4jaocBJGPdR1VnrMCqPs) is in use for this purpose and should be populated using the current status of PRs/issues. It is also important to identify _priority/critical-urgent_ and _priority/important-soon_ PRs/issues early on which could become release blocking later in the cycle.
+#### Setting up the Bug Triage Spreadsheet
 
-### Sample Searches [Early]
+The Bug Triage team is using a [tracking spreadsheet](https://docs.google.com/spreadsheets/d/14DzSChatdcwKLBxshMkE9ul4jaocBJGPdR1VnrMCqPs) to track the current status of all issues and PRs targeting the release, their priorities, and to distribute the work among the Bug Triage team.
+
+At the beginning of the cycle, the Bug Triage Lead should communicate with the Release Team Lead to get the spreadsheet set up for the ongoing release cycle.
+
+Once the spreadsheet is created, the lead needs to update queries in the spreadsheet script to fetch issues and PRs for the correct milestone. To edit the script, choose Tools -> Script editor, and then replace the milestone in queries with the correct one.
+
+With this done, the lead needs to put the link to the spreadsheet in the relevant places, usually in the release team meeting notes and in the [release overview document](https://github.com/kubernetes/sig-release/tree/master/releases).
+
+#### Updating the Bug Triage Spreadsheet
+
+The Bug Triage Spreadsheet is updated manually. The commands for updating the spreadsheet can be found in the `Kubernetes Github Commands` menu.
+
+**Note:** Due to bug in the `Refresh Issues & PRs` command, it is recommended to delete the issues/PRs from the spreadsheet and then run the command. Otherwise, it may happen that some issues are omitted or shown even if closed.
+
+At this stage of the release cycle, it is usually enough to update the spreadsheet once a week, before the release team meeting. At later stages, this is usually done 2-3 times a week and then daily.
+
+#### Sample Searches
+
+You can use the following queries to get yourself familiarized with issues/PRs targeting the release:
+
 * Issues which could require early intervention
-  - [Issues in the v1.17 milestone which haven't been updated in a while](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue+milestone%3Av1.17+updated%3A%3C2019-09-01+repo%3Akubernetes%2Fkubernetes+is%3Aopen+): `is:issue milestone:v1.17 updated:<2019-09-01 repo:kubernetes/kubernetes is:open`
+  - [Issues in the v1.17 milestone with the `priority/critical-urgent` label](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+milestone%3Av1.17+label%3Apriority%2Fcritical-urgent): `is:open is:issue milestone:v1.17 label:priority/critical-urgent`
 
-  - [Issues in the milestone with no SIG label](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+milestone%3Av1.17+label%3Aneeds-sig): `is:issue milestone:v1.17 label:needs-sig is:open`
+  - [PRs in the v1.17 milestone with the `priority/critical-urgent` label](https://github.com/kubernetes/kubernetes/pulls?utf8=%E2%9C%93&q=is%3Aopen+is%3Apr+milestone%3Av1.17+label%3Apriority%2Fcritical-urgent): `is:open is:pr milestone:v1.17 label:priority/critical-urgent`
 
-* Enhancements (for familiarization purposes):
+  - [Issues in the v1.17 milestone which haven't been updated since 2019-09-01](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+milestone%3Av1.17+updated%3A%3C2019-09-01): `is:open is:issue milestone:v1.17 updated:<2019-09-01`
+
+  - [PRs in the v1.17 milestone which haven't been updated since 2019-09-01](https://github.com/kubernetes/kubernetes/pulls?utf8=%E2%9C%93&q=is%3Aopen+is%3Apr+milestone%3Av1.17+updated%3A%3C2019-09-01): `is:open is:pr milestone:v1.17 updated:<2019-09-01`
+
+* Enhancements:
 
   - [k/enhancements repo milestone enhancements](https://github.com/kubernetes/enhancements/issues?q=is%3Aopen+is%3Aissue+milestone%3Av1.17) `is:issue is:open milestone:v1.17 repo:kubernetes/enhancements`
 
   - [k/k main repo milestone enhancements](https://github.com/kubernetes/kubernetes/issues?q=is%3Aopen+is%3Aissue+milestone%3Av1.17+label%3Akind%2Ffeature)`is:issue is:open milestone:v1.17 label:kind/feature repo:kubernetes/kubernetes`
 
-  - [k org-wide milestone enhancements](https://github.com/search?q=org%3Akubernetes+is%3Aissue+is%3Aopen+milestone%3Av1.17+label%3Akind%2Ffeature)`is:issue is:open milestone:v1.17 label:kind/feature org:kubernetes`
+#### Reports
 
-### Reports [Early]
+It is expected that at least one member in the Bug Triage role should be present for all release team meetings to provide the report. At this stage, the report should contain the number of `priority/critical-urgent` issues/PRs and what's their status.
 
-No reports are required during this period.
+The status is usually going to be green or yellow depending on the number of `priority/critical-urgent` issues/PRs and are those going to be fixed in a timely manner. The number of issues/PRs is mostly irrelevant because it's changing rapidly.
 
+### Mid-Release Cycle
 
-## Brace Yourselves, Code Freeze Is Coming
+This stage lasts from around week 6 until the code freeze starts (usually week 9). At this point, the Bug Triage team should start [escalating issues/PRs](#how-to-escalate) and communicating deadlines with contributors and SIG leads.
 
-One of the main purposes of Code Freeze is to get issues and PRs filtered through the use of labels, with `milestone` and the `priority` label playing an important role in that.
+There are three main tasks that should be done:
 
-The following items help with achieving the above:
+- Ensure that issues and PRs targeting the release have a correct *milestone* and *priority* labels
+  - Linked issues and PRs should have the same `priority` and `kind` labels and the milestone
+- Ensure that `priority/critical-urgent` issues and PRs are not blocked
+  - If you find such `priority/critical-urgent` issue/PR you should ping the owner and owner SIGs, as well as, alert the release team leads.
+- Ping all issues and PRs to remind contributors and SIG leads that we are about one month away from the code freeze and what does it mean.
+  - You may want to ping issues at least two times to ensure deadlines are communicated correctly, usually once this stage starts and a couple of days before the code freeze starts.
 
-* issues targeting your release should have a *milestone*, kind, and sig.
-* PRs linked to these issues should have the same labels and milestone.
+At the beginning, you should prioritize pinging issues/PRs that haven't been updated for a longer time. You can use the following queries: [`is:issue is:open milestone:v1.17 sort:updated-asc`](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+milestone%3Av1.17+sort%3Aupdated-asc) and [`is:pr is:open milestone:v1.17 sort:updated-asc`](https://github.com/kubernetes/kubernetes/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Aopen+milestone%3Av1.17+sort%3Aupdated-asc).
 
-If the needed additions on the issues/PRs do not match the above, you can add the relevant labels.
+For pinging, the following template can be used:
 
-If you are not sure (mainly priority), you can comment and ask the owner or SIG leads about the status of the issue/PR (also see [How To Escalate](#how-to-escalate) on pinging options).
+```
+Hello! This <issue|PR> has not been updated for a long time, so I'd like to check what's the status. The code freeze is starting <insert date> (about <number of weeks> from now) and while there is still plenty of time, we want to ensure that each PR has a chance to be merged on time.
 
-Other regular patterns are:
+As the PR is tagged for 1.17, is it still planned for this release?
+```
 
-*Stuck PRs*: Sometimes PRs get stuck in the approval process, as every PR requires both a `/lgtm` and an `/approve` by an Owner. When you detect such cases, you should remind relevant SIG Leads / Owners to review/approve these.
+#### Reports
 
-*CI Signal*: Checking newly-reported test failures becomes more important; you should assume that any new failure is related to the upcoming release. Bring the issue to the attention of the CI Signal lead, and assist in getting follow-up from the appropriate SIG.  Generally the CI Signal lead will track these failures, but newly opened issues may not initially have sufficient labelling to catch their attention.
+Beside the number of the `priority/critical-urgent` issues, you can start reporting the number of `priority/important-soon` issues and how good the response rate is for pinged issues.
 
-[The release document from the developer's guide](https://git.k8s.io/community/contributors/devel/release.md) is also a good resource on describing how developers target issues and pull requests to a milestone.
+Similar to the early release phase, the status (green/yellow/red) depends on the number of release blocking issues/PRs. You might want to declare yellow or red if there are big number of release blocking/`priority/critical-urgent` issues and/or if they're being blocked for any reason.
 
-### Filtering / What belongs in the milestone
+### Code Freeze
 
-Around this point, the release is about 1 month away, and there is less and less time for PRs to make it in time.
+One of the main purposes of Code Freeze is to ensure that the code base is stable and that most of tests are passing (CI Signal is green). At this point, only release-blocking issues and PRs (usually bug fixes/`kind/bug`) are considered to be merged.
 
-Filtering is one of the main functions of the Bug Triage role. It involves informing owners and SIG leads about the timelines and asking  whether an issue/PR at hand is relevant to the release, whether it should be prioritized or moved to another release via the use of `milestone`. This process involves a mix of multiple parameters such as:
+Your responsibility here is to actively watch for any new issues/PRs targeting the milestone, monitor the status of existing issues/PRs, and filter the milestone by removing issues/PRs that are not needed for this release cycle.
 
-- *Criticality*: How critical is the Issue to be fixed for the currently imminent release?
-- *Relevance*: What does it fix/introduce? e.g. - issues marked as kind/cleanup are usually less important.
-- *Time Estimation*: Is the PR expected to be ready for merging soon? Is there any time left?
-- *CI Stability*: How big is the change? Could it cause instability to CI? If so, it either needs to be closely tracked /or/ moved.
-- *Consensus*
-- *Critical Thinking*
+#### Day Of The Code Freeze
 
-As stated on a previous section, decisions and actions should be made either by the Release Lead or SIG Leads - Bug Triage's role is mainly to keep track, ping people and report the overall status to the Release Lead.
+On the day of the Code Freeze, your responsibility is to try to help contributors to get the approval on their PRs and needed label. Check [How To Escalate](#how-to-escalate) part of the document for guide how to do this.
 
-If you see an issue or PR that is not making progress, hasn't got an update for a while and there is no anecdotal knowledge that someone is working on it, you should comment and ask about the status. If there is no response for quite some time, it's very likely that it will be marked for the subsequent release. The task of filtering becomes more frequent as time progresses.
+When the code freeze starts, the highest priority has the PRs which had `approved` and `lgtm` labels before the code freeze started and are in the milestones. Depending on the merge queue length, it might be proposed to hold PRs that have `approved` and `lgtm`, but are not in the milestone.
 
-This section is also described in [the release document](https://github.com/kubernetes/community/blob/master/contributors/devel/release.md#removal-of-items-from-the-milestone) from the contributor's perspective.
+You can monitor PRs using the following queries:
+- [PRs supposed to be in the merge pool (`is:pr is:open milestone:v1.17 label:approved label:lgtm -label:do-not-merge/hold`)](https://github.com/kubernetes/kubernetes/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Aopen+milestone%3Av1.17+label%3Aapproved+label%3Algtm+-label%3Ado-not-merge%2Fhold)
+- [PRs that have `approved` and `lgtm`, but are on-hold (`is:pr is:open milestone:v1.17 label:approved label:lgtm label:do-not-merge/hold`)](https://github.com/kubernetes/kubernetes/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Aopen+milestone%3Av1.17+label%3Aapproved+label%3Algtm+label%3Ado-not-merge%2Fhold+)
+- [PRs that doesn't have `approved` but have `lgtm` (`is:pr is:open milestone:v1.17 -label:approved label:lgtm`)](https://github.com/kubernetes/kubernetes/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Aopen+milestone%3Av1.17+-label%3Aapproved+label%3Algtm)
+- [PRs that doesn't have `lgtm` but have `approved` (`is:pr is:open milestone:v1.17 label:approved -label:lgtm`)](https://github.com/kubernetes/kubernetes/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Aopen+milestone%3Av1.17+label%3Aapproved+-label%3Algtm+)
 
-### Priority label definitions
+#### Once the Code Freeze starts until one week later
 
-You can [refer to this guide](https://github.com/kubernetes/community/blob/master/contributors/guide/issue-triage.md#define-priority).
+Usually, the removal of issues/PRs doesn't start right once the code freeze starts. Depending on the CI Signal, the merge queue length, and the release team lead's decision, it might be decided to allow some more time for PRs to get merged. At this stage, `kind/bug` PRs are prioritized, but other PRs can be allowed too if there is no risk of destabilizing the release/CI Signal (such PRs require an exception).
 
+You can still use the queries from the previous section at this stage to monitor PRs, but you should also monitor issues using similar queries.
 
-### Sample Searches [Before Freeze]
-* Open v1.14 Issues
-   * `is:open is:issue milestone:v1.14 -label:"kind/feature" -label:"kind/failing-test"` [milestone open issues, excluding kind/feature and kind/failing-test](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+milestone%3Av1.14+-label%3A%22kind%2Ffeature%22+-label%3A%22kind%2Ffailing-test%22+)
-   * `is:open is:issue milestone:v1.14` [milestone open issues, no exclusions](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+milestone%3Av1.14)
-* Open v1.14 PRs
-   * `is:open is:pr milestone:v1.14 -label:"kind/feature" -label:"kind/failing-test"` [milestone open PRs, excluding kind/feature and kind/failing-test](https://github.com/kubernetes/kubernetes/pulls?utf8=%E2%9C%93&q=is%3Aopen+is%3Apr+milestone%3Av1.14+-label%3A%22kind%2Ffeature%22+-label%3A%22kind%2Ffailing-test%22+)
-  * `is:open is:pr milestone:v1.14"` [milestone open PRs, no exclusions](https://github.com/kubernetes/kubernetes/pulls?utf8=%E2%9C%93&q=is%3Aopen+is%3Apr+milestone%3Av1.14)
+#### Week 1 of Code Freeze until Code Thaw starts
 
+At this stage, the Bug Triage team should start removing issues/PRs from the milestone. Before doing so, the Bug Triage Lead should confirm the intention with the Release Team Lead.
 
-### Reports [Before Freeze]
+If the issue/PR got confirmation that it's planned for the next milestone or there was recent activity, it should be moved to the next milestone using the `/milestone v1.xx` command.
 
-At this point, release meetings start occurring ~3 times per week and a report is expected in each of them.
+If there is no response on the issue/PR and no recent activity, the issue/PR should be removed from the milestone to reduce the burden on the next Bug Triage team. This is done by using the `/milestone clear` command.
 
-You should soon start maintaining an overall list of items/areas/issues which seem to be delaying, at risk of not making it in time, or in need of attention by the Release Lead or other roles, and present it in the meetings.
+If the issue/PR has the `priority/critical-urgent` label, it should be coordinated with the owning SIG and the Release Team Lead should it be allowed to stay or should the priority be decreased and issue/PR moved to the next milestone.
 
-The Release Lead will include a template for this information in the Monday/Wednesday/Friday release team meeting notes.
+#### Reports
 
-Code Freeze hasn't really started yet at this point, and it depends on the overall status and volume of open issues/PRs on how many to report. It's good to have some numbers of total issues/PRs available to see general trends over time, like increased or lowered volumes.
+At this point, the report is contained of the following items:
+- Total number of non-test/flake related issues, number of `priority/critical-urgent` and `priority/important-soon` issues
+  - If there are `priority/critical-urgent` issues, those should be listed
+- Total number of PRs and number of `priority/critical-urgent` and `priority/important-soon` PRs
+  - If there are `priority/critical-urgent` PRs, those should be listed
+- Total number of issues, including flake/test related ones
 
-### Issue Categorization
+If there are issues/PRs that are going to block the release (i.e. `priority/critical-urgent` issues) and those are not close to being merged (e.g. in the merge pool or in-review process) that status is usually red. Otherwise, the status is yellow (if such issues/PRs are close to being merged) or green (if we don't have such issues/PRs).
 
-Issues can be categorized with the following 'status codes', Green/Yellow/Red.
+### Code Thaw
 
-* green: issues/PRs where the resolution is known and will be resolved soon
-* yellow: issues/PRs which are in progress but are not as easy and need to be watched
-* red: issues/PRs that are heavily release-impacting, and/or with a likelihood of not making it in time.
-
-In each meeting, it is good to give an overall status of Bug Triage: Green, Yellow or Red, generally based on the amount of issues from each category. Examples are:
-
-- status can be Red if there are multiple release-impacting issues that are in danger of not being fixed in the release.
-- status can be Yellow if there are multiple issues open but they are being worked on, which is the usual state of the world.
-- status can be Green if there are no Red issues and workpaces seem normal.
-
-It is useful to keep Red issues on a separate section and report them during the meetings.
-
-
-## Code Freeze
-
-Once Code Freeze kicks in, only PRs targeting the upcoming release (/milestone v1.xx) are able to get merged. This is done to stabilize the release as much as possible, and reduce the overall tracking footprint to focus on the upcoming release.
-
-This is enforced via test-infra automation, as a means of "new release coming in a few weeks - we're only merging relevant PRs in".
-
-As explained in sections [Code Freeze Preparation](#code-freeze-preparation) and [Filtering](#filtering), it becomes incrementally more difficult to merge new stuff as time progresses. As such, in the days around the start of Code Freeze, owners of issues and PRs should be poked again, reminding them that Code Freeze starts/started at DD/MM.
-
-The criteria for moving issues are described in [Filtering](#filtering).
-
-For issues/PRs that look tricky, you can always coordinate with the Release Lead and SIG/PR owners to reach a decision.
-
-Any new enhancements that aren't making rapid progress need to either jump to the next release, or reduce their scope.
-You may need to send daily reminders/queries about stuck PRs.
-
-New test failures will also show up during Code Freeze and you need to make sure that these are labeled properly, get attention of the CI Signal lead, and get attention from the appropriate SIGs.
-
-
-### Sample Searches [Freeze]
-
-* Prow is an alternative tool for PR visualisation that can run full GH queries:
-    * [PRs with LGTM but not 'approved' in Prow](https://prow.k8s.io/pr?query=is%3Apr%20state%3Aopen%20label%3Algtm%20-label%3Aapproved%20milestone%3Av1.14)
-
-* Open v1.14 Issues
-  * `is:open is:issue milestone:v1.14 -label:"kind/feature" -label:"kind/failing-test"` [milestone open issues, excluding kind/feature and kind/failing-test](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+milestone%3Av1.14+-label%3A%22kind%2Ffeature%22+-label%3A%22kind%2Ffailing-test%22+)
-  * `is:open is:issue milestone:v1.14` [milestone open issues, no exclusions](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+milestone%3Av1.14+)
-  * `is:open is:issue created:>2018-06-14` [open issues, no exclusions, created since you last looked](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aopen++created%3A%3E2018-06-14)
-  * `is:open is:issue modified:>2018-06-14` [open issues, no exclusions, modified since you last looked](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aopen++modified%3A%3E2018-06-14)
-* Open v1.14 PRs
-  * `is:open is:pr milestone:v1.14 -label:"kind/feature" -label:"kind/failing-test"` [milestone open PRs, excluding kind/feature and kind/failing-test](https://github.com/kubernetes/kubernetes/pulls?utf8=%E2%9C%93&q=is%3Aopen+is%3Apr+milestone%3Av1.14+-label%3A%22kind%2Ffeature%22+-label%3A%22kind%2Ffailing-test%22+)
-  * `is:open is:pr milestone:v1.14"` [milestone open PRs, no exclusions](https://github.com/kubernetes/kubernetes/pulls?utf8=%E2%9C%93&q=is%3Aopen+is%3Apr+milestone%3Av1.14+)
-  * `is:open is:pr created:>2018-06-14` [open PRs, no exclusions, created since you last looked](https://github.com/kubernetes/kubernetes/pulls?utf8=%E2%9C%93&q=is%3Aopen++created%3A%3E2018-06-14)
-  * `is:open is:pr modified:>2018-06-14` [open PRs, no exclusions, modified since you last looked](https://github.com/kubernetes/kubernetes/pulls?utf8=%E2%9C%93&q=is%3Aopen++modified%3A%3E2018-06-14)
-* Reports against the beta(s):
-  * `is:issue "1.14.0-beta"' [issues mentioning beta version](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=%221.14.0-beta%22)
-  * `is:pr "1.14.0-beta"' [PRs mentioning beta version](https://github.com/kubernetes/kubernetes/pulls?utf8=%E2%9C%93&q=%221.14.0-beta%22)
-
-### Reports [Freeze]
-
-A few days after Code Freeze kicks in, daily 'burndown' meetings start, which means that either you or a shadow has to give updates every day. See [Issue Categorization](#issue-categorization).
-
-There will also be several enhancements which will have requested exceptions from the normal release timeline/requirements.  You'll want to track the exceptions specifically and report on them.  It is useful to be tracking in a spreadsheet the open issues/PRs which have caught your attention, because GitHub queries are only point in time.  It's easy for an issue you want to follow to stop showing up in a query and thus fall off your radar if you're only going by the queries.
-
-## Code Thaw
-
-Starting a few working days before the first Release Candidate, Code Freeze labeling restrictions are lifted.  At this point, you need to make sure that three things happen:
+Starting a week before the stable release, Code Freeze labeling restrictions are lifted. At this point, you need to make sure that three things happen:
 
 1. major breakage bugs get fixed immediately
-2. any pending PRs get approved and merged
+2. any pending release-blocking PRs get approved and merged
 3. _anything else should get kicked out of the release_
 
 During this period, it's reasonable to expect issue owners and SIG leads to get back to you within hours (check their time zones, though). In cases where SIG Leads are unavailable, you may need to appeal to Kubernetes project leaders to deal with stuck PRs.
 
 Another part of staying on top of code churn, regression, and risk is monitoring commits to master and the release branch especially in the final days of the release, as shown below in Sample Searches for this phase.  On occasion, things will merge that are unexpected by the release team.  This possibility needs to be monitored and when it happens, the commits need to be triaged for destabilizing risk and proper exception justification, tests, docs, etc.
 
-### Sample Searches [Thaw]
+#### Sample Searches
 
 Most important query at this point is a plain `milestone:v1.xx`, which includes all remaining issues/PRs. Ideally, the queue should be empty.
 
 Additionally for tracking recent changes to master and the release branch,
 eg:
 * [master branch commits](https://github.com/kubernetes/kubernetes/commits/master/)
-* [release-1.14 branch commits](https://github.com/kubernetes/kubernetes/commits/release-1.14)
+* [release-1.17 branch commits](https://github.com/kubernetes/kubernetes/commits/release-1.17)
 
-### Reports [Thaw]
+#### Reports
 
 Same as Code Freeze.
 

--- a/release-team/role-handbooks/bug-triage/README.md
+++ b/release-team/role-handbooks/bug-triage/README.md
@@ -1,5 +1,31 @@
 # Bug Triage Role Handbook
 
+- [Bug Triage Role Handbook](#bug-triage-role-handbook)
+  - [Overview](#overview)
+  - [Responsibilities](#responsibilities)
+  - [Requirements](#requirements)
+    - [Time Requirements](#time-requirements)
+    - [Additional Requirements for Shadows](#additional-requirements-for-shadows)
+    - [Additional Requirements for Leads](#additional-requirements-for-leads)
+  - [Getting Started](#getting-started)
+    - [How to Escalate](#how-to-escalate)
+  - [Timeline](#timeline)
+    - [Early Release](#early-release)
+      - [Setting up the Bug Triage Spreadsheet](#setting-up-the-bug-triage-spreadsheet)
+      - [Updating the Bug Triage Spreadsheet](#updating-the-bug-triage-spreadsheet)
+      - [Sample Searches](#sample-searches)
+      - [Reports](#reports)
+    - [Mid-Release Cycle](#mid-release-cycle)
+      - [Reports](#reports-1)
+    - [Code Freeze](#code-freeze)
+      - [Day Of The Code Freeze](#day-of-the-code-freeze)
+      - [Once the Code Freeze starts until one week later](#once-the-code-freeze-starts-until-one-week-later)
+      - [Week 1 of Code Freeze until Code Thaw starts](#week-1-of-code-freeze-until-code-thaw-starts)
+      - [Reports](#reports-2)
+    - [Code Thaw](#code-thaw)
+      - [Sample Searches](#sample-searches-1)
+      - [Reports](#reports-3)
+
 ## Overview
 
 The bug triage team is responsible to make sure that Issues and Pull Requests (PRs) which are targeted for the ongoing release cycle are dealt with in a timely fashion.
@@ -215,7 +241,7 @@ If there are issues/PRs that are going to block the release (i.e. `priority/crit
 
 ### Code Thaw
 
-Starting a week before the stable release, Code Freeze labeling restrictions are lifted. At this point, you need to make sure that three things happen:
+Starting a week before the release target date, Code Freeze labeling restrictions are lifted. At this point, you need to make sure that three things happen:
 
 1. major breakage bugs get fixed immediately
 2. any pending release-blocking PRs get approved and merged

--- a/release-team/role-handbooks/bug-triage/README.md
+++ b/release-team/role-handbooks/bug-triage/README.md
@@ -102,7 +102,7 @@ Whenever you find an issue or PR that needs to be finished or kicked out of the 
 
 1. Leave a comment on the GitHub issue or PR: "This issue hasn't been updated in 3 months. Are you still expecting to complete it for 1.17?". It's helpful to @ mention individuals or SIG ```-bugs``` or ```-pr-reviews``` aliases, e.g. "@kubernetes/sig-node-bugs" or "@kubernetes/sig-network-pr-reviews".
 2. Send a message to relevant SIG Slack channel or mailing list about the problem: It's helpful to directly @ mention the relevant SIG Leads / Owners, and to condense multiple issues into a list, e.g. "Hey, these three issues haven't seen any attention, are they still valid for 1.17?"
-3. Message individual owners and reviewers directly via Slack.
+3. Message individual owners and reviewers directly via Slack. If owners and reviewers are unresponsive, you can reach out to the SIG leads using the `kubernetes-sig-${name}-leads@googlegroups.com` mailing lists.
 4. Escalate to the Release Team Lead with suggestions on what to do with non-responsive issues.
 
 ## Timeline

--- a/release-team/role-handbooks/bug-triage/README.md
+++ b/release-team/role-handbooks/bug-triage/README.md
@@ -35,7 +35,7 @@ General time requirements for Leads and Shadows are:
 
 - Availability to attend the majority of Release Team (weekly) and Burndown meetings
 - Ability to follow-up on issues and PRs since around week 6 (mid-release)
-- Since week 6 to the end of the release cycle the time commitment becomes greater. Shadows should expect to spend at least 3-5 hours and leads around 5-10 hours a week.
+- From week 6 to the end of the release cycle the time commitment becomes greater. Shadows should expect to spend at least 3-5 hours and leads around 5-10 hours a week.
 
 ### Additional Requirements for Shadows
 
@@ -67,7 +67,7 @@ In practice, you should fix anything simple that saves folks time when the inten
 The Bug Triage role relates to both the Enhancements and CI Signal roles. Understanding the in-bound enhancements is important during the Early Release phase as they set the themes for incoming issues and bugs. Having an awareness on current test status is also critical, even though there is a specific lead for that area. The [documentation for CI Signal lead role](../ci-signal) includes a listing of special high risk test categories to monitor with useful information for the Bug Triage to also understand. The Bug Triage Lead should regularly interact with the peer leads for Enhancements and CI Signal.
 
 Before starting, the Bug Triage members should refer to the following guides to get familiar with used labels:
-- [the documentation for issue `kind` labels](https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label)
+- [the documentation for issue `kind` labels](https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label)
 - [the documentation for defining priority and `priority` labels](https://github.com/kubernetes/community/blob/master/contributors/guide/issue-triage.md#define-priority).
 
 ### How to Escalate
@@ -98,7 +98,7 @@ This is the best stage to get involved with any automation work that can ease th
 
 #### Setting up the Bug Triage Spreadsheet
 
-The Bug Triage team is using a [tracking spreadsheet](https://docs.google.com/spreadsheets/d/14DzSChatdcwKLBxshMkE9ul4jaocBJGPdR1VnrMCqPs) to track the current status of all issues and PRs targeting the release, their priorities, and to distribute the work among the Bug Triage team.
+The Bug Triage team is using a tracking spreadsheet to track the current status of all issues and PRs targeting the release, their priorities, and to distribute the work among the Bug Triage team.
 
 At the beginning of the cycle, the Bug Triage Lead should communicate with the Release Team Lead to get the spreadsheet set up for the ongoing release cycle.
 
@@ -108,7 +108,7 @@ With this done, the lead needs to put the link to the spreadsheet in the relevan
 
 #### Updating the Bug Triage Spreadsheet
 
-The Bug Triage Spreadsheet is updated manually. The commands for updating the spreadsheet can be found in the `Kubernetes Github Commands` menu.
+The Bug Triage Spreadsheet is updated manually. The spreadsheet has a dedicated `Kubernetes Github Commands` menu in the spreadsheet header that has commands for managing the data. Open the menu and first run the `Refresh Issues & PRs` command. After it is done, you can run other commands to populate issues/PRs metadata, such as `kind`, `priority` and SIGs. The menu and all commands are implemented as scripts that you can access by choosing Tools -> Script editor.
 
 **Note:** Due to bug in the `Refresh Issues & PRs` command, it is recommended to delete the issues/PRs from the spreadsheet and then run the command. Otherwise, it may happen that some issues are omitted or shown even if closed.
 
@@ -178,7 +178,7 @@ Your responsibility here is to actively watch for any new issues/PRs targeting t
 
 On the day of the Code Freeze, your responsibility is to try to help contributors to get the approval on their PRs and needed label. Check [How To Escalate](#how-to-escalate) part of the document for guide how to do this.
 
-When the code freeze starts, the highest priority has the PRs which had `approved` and `lgtm` labels before the code freeze started and are in the milestones. Depending on the merge queue length, it might be proposed to hold PRs that have `approved` and `lgtm`, but are not in the milestone.
+When the code freeze starts, the highest priority has the PRs which had `approved` and `lgtm` labels before the code freeze started and are in the milestones. Depending on the merge queue length, it might be proposed to hold PRs that have `approved` and `lgtm`, but are not in the milestone (using the following query [`is:pr is:open no:milestone label:approved label:lgtm`](https://github.com/kubernetes/kubernetes/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Aopen+no%3Amilestone+label%3Aapproved+label%3Algtm)).
 
 You can monitor PRs using the following queries:
 - [PRs supposed to be in the merge pool (`is:pr is:open milestone:v1.17 label:approved label:lgtm -label:do-not-merge/hold`)](https://github.com/kubernetes/kubernetes/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Aopen+milestone%3Av1.17+label%3Aapproved+label%3Algtm+-label%3Ado-not-merge%2Fhold)


### PR DESCRIPTION
Signed-off-by: Marko Mudrinić <mudrinic.mare@gmail.com>

This PR is a proposal to rework the Bug Triage Handbook. The current state of the handbook doesn't reflect the process we had for the past 2 release cycles (1.15 and 1.16). The purpose of this rework is to make the handbook up-to-date, easier to read and understand and to have some additional information that might help both leads and shadows.

If you think I've deleted some information that might be useful, please let me know in the review comments and I'd be happy to reconsider to add it back. I'll leave some comments on the PR for points where I wasn't sure what I should do.

I would appreciate feedback on this PR. I'm going to put in on-hold for more in-depth review.
/hold

/assign @josiahbjorgaard @justaugustus @lachie83 @guineveresaenger 
cc @kubernetes/release-team 