### PR TITLE
fix link text to sig-release-master-informing

### DIFF
--- a/release-blocking-jobs.md
+++ b/release-blocking-jobs.md
@@ -1,7 +1,7 @@
 # Release Blocking Jobs and Criteria
 
 * [SIG-Release-Master-Blocking](https://testgrid.k8s.io/sig-release-master-blocking)
-* [SIG-Release-Master-Blocking](https://testgrid.k8s.io/sig-release-master-informing)
+* [SIG-Release-Master-Informing](https://testgrid.k8s.io/sig-release-master-informing)
 
 SIG-release maintains two sets of jobs that decide whether the release is
 healthy: Blocking and Informing.  Each of these sets is instantiated for each


### PR DESCRIPTION
Fixes typo for informing jobs on [release-blocking-jobs.md](https://github.com/kubernetes/sig-release/blob/master/release-blocking-jobs.md).


Signed-off-by: hasheddan <georgedanielmangum@gmail.com>