### PR TITLE
add machine requirement to run branchff

### DIFF
--- a/release-engineering/role-handbooks/branch-manager.md
+++ b/release-engineering/role-handbooks/branch-manager.md
@@ -552,6 +552,10 @@ Prior to running `./branchff`, you will need:
 - permission to run under `root` privileges
 - membership in the [Release Managers GitHub Group](https://github.com/orgs/kubernetes/teams/release-managers)
 
+Machine requirements:
+- at least 8 Gb of memory (better 16 GB)
+- at least 4 CPUs (will take some time - better 6 CPUs)
+
 Command invocation:
 ```bash
 ./branchff release-x.y


### PR DESCRIPTION
When running `branchff` in my local vagrant machine it took a long time to run and failed due out of memory.

checking the config it was only 1Gb and 1 vcpu to that VM.
- spin a node in DO with 4vcpu/8gb and it ran ok and did another test with 6vpcu/16Gb which this last one was much better.

adding a note in the Branchff for the machine requirement to not loose time as me :)

/area release-team
/sig release
/cc @kubernetes/release-team
/cc @justaugustus