### PR TITLE
Update Release Managers and add note on GCP IAM Google Groups

### DIFF
--- a/release-managers.md
+++ b/release-managers.md
@@ -60,6 +60,13 @@ Release Manager Associates are apprentices to the Branch Managers, formerly refe
 - Giri Kuncoro ([@girikuncoro](https://github.com/girikuncoro))
 - Peter Swica ([@pswica](https://github.com/pswica))
 - Ace Eldeib ([@alexeldeib](https://github.com/alexeldeib))
+- Kendrick Coleman ([@kacole2](https://github.com/kacole2))
+- Sascha Grunert ([saschagrunert](https://github.com/saschagrunert))
+- Seth McCombs ([@sethmccombs](https://github.com/sethmccombs))
+- Marko Mudrinić ([@xmudrii](https://github.com/xmudrii))
+- Taylor Dolezal ([@onlydole](https://github.com/onlydole))
+- Paul Bouwer ([@paulbouwer](https://github.com/paulbouwer))
+- Jim Angel ([@jimangel](https://github.com/jimangel))
 
 ## Build Admins
 
@@ -69,7 +76,8 @@ GitHub team: [@kubernetes/build-admins](https://github.com/orgs/kubernetes/teams
 
 - Aleksandra Malinowska ([@aleksandra-malinowska](https://github.com/aleksandra-malinowska))
 - Linus Arver ([@listx](https://github.com/listx))
-- Premdeep Sharma ([@ps882 (premdeep)](https://github.com/ps882))
+- Premdeep Sharma ([@ps882](https://github.com/ps882))
+- Simon Yang ([@simony-gke](https://github.com/simony-gke))
 - Sumitran Raghunathan ([@sumitranr](https://github.com/sumitranr))
 
 ## SIG Release Chairs

--- a/release-managers.md
+++ b/release-managers.md
@@ -7,18 +7,11 @@ The responsibilities of each role are described below.
 - [Contact](#contact)
 - [Handbooks](#handbooks)
 - [Patch Release Team](#patch-release-team)
-  - [GitHub teams](#github-teams)
-  - [Members](#members)
 - [Branch Managers](#branch-managers)
-  - [Members](#members-1)
 - [Associates](#associates)
-  - [Members](#members-2)
 - [Build Admins](#build-admins)
-  - [GitHub team](#github-team)
-  - [Members](#members-3)
 - [SIG Release Chairs](#sig-release-chairs)
-  - [GitHub team](#github-team-1)
-  - [Members](#members-4)
+- [GCP IAM Groups](#gcp-iam-groups)
 
 ## Contact
 
@@ -27,23 +20,20 @@ The responsibilities of each role are described below.
 | [release-managers@kubernetes.io](mailto:release-managers@kubernetes.io) | [#release-management](https://kubernetes.slack.com/messages/CJH2GBF7Y) (channel) / @release-managers (user group) | Public | Public discussion for Release Managers | All Release Managers (Patch Release Team, Branch Managers, Associates, Build Admins, SIG Chairs) |
 | [release-managers-private@kubernetes.io](mailto:release-managers-private@kubernetes.io)| [#release-private](https://kubernetes.slack.com/messages/GKEA5EL67) | Private | Private discussion for privileged Release Managers | Patch Release Team, Build Admins, SIG Chairs |
 
-
 ## Handbooks
 
 - [Patch Release Team](/release-engineering/role-handbooks/patch-release-team.md)
 - [Branch Managers](/release-engineering/role-handbooks/branch-manager.md)
 - [Build Admins](/release-engineering/packaging.md)
 
-
 ## Patch Release Team
 
 The Patch Release Team is responsible for coordinating patch releases (`x.y.z`, where `z` >= 0) of Kubernetes. This team at times works in close conjunction with the [Product Security Committee](https://git.k8s.io/community/committee-product-security/README.md) and therefore should abide by the guidelines set forth in the [Security Release Process](https://git.k8s.io/security/security-release-process.md). 
 
-### GitHub teams
-- Access: [@kubernetes/release-managers](https://github.com/orgs/kubernetes/teams/release-managers)
-- Contact: [@kubernetes/patch-release-team](https://github.com/orgs/kubernetes/teams/patch-release-team)
+Access: [@kubernetes/release-managers](https://github.com/orgs/kubernetes/teams/release-managers)
 
-### Members
+Contact: [@kubernetes/patch-release-team](https://github.com/orgs/kubernetes/teams/patch-release-team)
+
 - Aleksandra Malinowska ([@aleksandra-malinowska](https://github.com/aleksandra-malinowska))
 - Doug MacEachern ([@dougm](https://github.com/dougm))
 - Hannes Hörl ([@hoegaarden](https://github.com/hoegaarden))
@@ -51,22 +41,18 @@ The Patch Release Team is responsible for coordinating patch releases (`x.y.z`, 
 - Tim Pepper ([@tpepper](https://github.com/tpepper))
 - Yang Li ([@idealhack](https://github.com/idealhack))
 
-
 ## Branch Managers
 
 Branch Managers are responsible for minor releases (`x.y.z`, where `z` = 0) of Kubernetes, working in close conjunction with the [Release Team](/release-team/README.md) through each release cycle.
 
-### Members
 - Carlos Panato ([@cpanato](https://github.com/cpanato))
 - Cheryl Fong ([@bubblemelon](https://github.com/bubblemelon))
 - Stephen Augustus ([@justaugustus](https://github.com/justaugustus))
-
 
 ## Associates
 
 Release Manager Associates are apprentices to the Branch Managers, formerly referred to as Branch Manager shadows.
 
-### Members
 - Nikhil Manchanda ([@slicknik](https://github.com/slicknik))
 - Dhawal Yogesh Bhanushali ([@imkin](https://github.com/imkin))
 - Nikhita Raghunath ([@nikhita](https://github.com/nikhita))
@@ -75,20 +61,16 @@ Release Manager Associates are apprentices to the Branch Managers, formerly refe
 - Peter Swica ([@pswica](https://github.com/pswica))
 - Ace Eldeib ([@alexeldeib](https://github.com/alexeldeib))
 
-
 ## Build Admins
 
 Build Admins are (currently) Google employees with the requisite access to Google build systems/tooling to publish deb/rpm packages on behalf of the Kubernetes project.
 
-### GitHub team
-- [@kubernetes/build-admins](https://github.com/orgs/kubernetes/teams/build-admins)
+GitHub team: [@kubernetes/build-admins](https://github.com/orgs/kubernetes/teams/build-admins)
 
-### Members
 - Aleksandra Malinowska ([@aleksandra-malinowska](https://github.com/aleksandra-malinowska))
 - Linus Arver ([@listx](https://github.com/listx))
 - Premdeep Sharma ([@ps882 (premdeep)](https://github.com/ps882))
 - Sumitran Raghunathan ([@sumitranr](https://github.com/sumitranr))
-
 
 ## SIG Release Chairs
 
@@ -96,14 +78,23 @@ SIG Release Chairs are responsible for the governance of SIG Release. They are m
 
 As such, they are highly privileged community members and privy to some private communications, which can at times relate to Kubernetes security disclosures.
 
-### GitHub team
-- [@kubernetes/sig-release-admins](https://github.com/orgs/kubernetes/teams/sig-release-admins)
+GitHub team: [@kubernetes/sig-release-admins](https://github.com/orgs/kubernetes/teams/sig-release-admins)
 
-### Members
 - Caleb Miles ([@calebamiles](https://github.com/calebamiles))
 - Stephen Augustus ([@justaugustus](https://github.com/justaugustus))
 - Tim Pepper ([@tpepper](https://github.com/tpepper))
 
+## GCP IAM Groups
+
+The following kubernetes.io Google Groups exist to grant Release Managers access to k8s-infra GCP resources.
+
+Mail to the groups below will be ignored. Please instead use the [contact groups listed at the top of this document](#contact).
+
+- `k8s-infra-release-admins`
+- `k8s-infra-release-editors`
+- `k8s-infra-release-viewers`
+
+[Membership](https://git.k8s.io/k8s.io/groups/groups.yaml) and [permissions](https://git.k8s.io/k8s.io/infra/gcp/ensure-release-projects.sh) for each group is defined in [kubernetes/k8s.io](https://git.k8s.io/k8s.io).
 
 ---
 


### PR DESCRIPTION
- Add new Release Manager Associates
  - Kendrick Coleman - @kacole2 
  - Sascha Grunert - @saschagrunert 
  - Seth McCombs - @sethmccombs 
  - Marko Mudrinić - @xmudrii 
  - Taylor Dolezal - @onlydole 
  - Paul Bouwer - @paulbouwer 
  - Jim Angel - @jimangel 
- Add Simon Yang (@simony-gke) to Build Admins
- Add note on GCP IAM Google Groups

/area release-eng
/assign @tpepper @calebamiles 
cc: @kubernetes/release-engineering 