### PR TITLE
remind Tim where to send email for patch release team

### DIFF
--- a/release-managers.md
+++ b/release-managers.md
@@ -30,9 +30,9 @@ The responsibilities of each role are described below.
 
 The Patch Release Team is responsible for coordinating patch releases (`x.y.z`, where `z` >= 0) of Kubernetes. This team at times works in close conjunction with the [Product Security Committee](https://git.k8s.io/community/committee-product-security/README.md) and therefore should abide by the guidelines set forth in the [Security Release Process](https://git.k8s.io/security/security-release-process.md). 
 
-Access: [@kubernetes/release-managers](https://github.com/orgs/kubernetes/teams/release-managers)
+GitHub Access Controls: [@kubernetes/release-managers](https://github.com/orgs/kubernetes/teams/release-managers)
 
-Contact: [@kubernetes/patch-release-team](https://github.com/orgs/kubernetes/teams/patch-release-team)
+GitHub Mentions: [@kubernetes/patch-release-team](https://github.com/orgs/kubernetes/teams/patch-release-team)
 
 - Aleksandra Malinowska ([@aleksandra-malinowska](https://github.com/aleksandra-malinowska))
 - Doug MacEachern ([@dougm](https://github.com/dougm))

--- a/releases/patch-releases.md
+++ b/releases/patch-releases.md
@@ -22,7 +22,8 @@ Please give us a business day to respond - we may be in a different timezone!
 In between releases the team is looking at incoming cherry-pick
 requests on a weekly basis.  The team will get in touch with
 submitters via GitHub PR, SIG channels in Slack, and direct messages
-in Slack and email if there are questions on the PR.
+in Slack and [email](mailto:release-managers-private@kubernetes.io)
+if there are questions on the PR.
 
 ## Cherry-Picks
 


### PR DESCRIPTION
For some reason I _always_ Cc: the wrong email address.  Maybe these
tiny edits will point my future self at the correct email address of
our team.

Signed-off-by: Tim Pepper <tpepper@vmware.com>