### PR TITLE
Update Release Managers

### DIFF
--- a/release-managers.md
+++ b/release-managers.md
@@ -53,12 +53,6 @@ Branch Managers are responsible for minor releases (`x.y.z`, where `z` = 0) of K
 
 Release Manager Associates are apprentices to the Branch Managers, formerly referred to as Branch Manager shadows.
 
-- Nikhil Manchanda ([@slicknik](https://github.com/slicknik))
-- Dhawal Yogesh Bhanushali ([@imkin](https://github.com/imkin))
-- Nikhita Raghunath ([@nikhita](https://github.com/nikhita))
-- Javier B Perez ([@javier-b-perez](https://github.com/javier-b-perez))
-- Giri Kuncoro ([@girikuncoro](https://github.com/girikuncoro))
-- Peter Swica ([@pswica](https://github.com/pswica))
 - Ace Eldeib ([@alexeldeib](https://github.com/alexeldeib))
 - Kendrick Coleman ([@kacole2](https://github.com/kacole2))
 - Seth McCombs ([@sethmccombs](https://github.com/sethmccombs))

--- a/release-managers.md
+++ b/release-managers.md
@@ -47,7 +47,7 @@ GitHub Mentions: [@kubernetes/patch-release-team](https://github.com/orgs/kubern
 Branch Managers are responsible for minor releases (`x.y.z`, where `z` = 0) of Kubernetes, working in close conjunction with the [Release Team](/release-team/README.md) through each release cycle.
 
 - Carlos Panato ([@cpanato](https://github.com/cpanato))
-- Cheryl Fong ([@bubblemelon](https://github.com/bubblemelon))
+- Sascha Grunert ([saschagrunert](https://github.com/saschagrunert))
 
 ## Associates
 
@@ -61,7 +61,6 @@ Release Manager Associates are apprentices to the Branch Managers, formerly refe
 - Peter Swica ([@pswica](https://github.com/pswica))
 - Ace Eldeib ([@alexeldeib](https://github.com/alexeldeib))
 - Kendrick Coleman ([@kacole2](https://github.com/kacole2))
-- Sascha Grunert ([saschagrunert](https://github.com/saschagrunert))
 - Seth McCombs ([@sethmccombs](https://github.com/sethmccombs))
 - Marko Mudrinić ([@xmudrii](https://github.com/xmudrii))
 - Taylor Dolezal ([@onlydole](https://github.com/onlydole))

--- a/release-managers.md
+++ b/release-managers.md
@@ -38,6 +38,7 @@ GitHub Mentions: [@kubernetes/patch-release-team](https://github.com/orgs/kubern
 - Doug MacEachern ([@dougm](https://github.com/dougm))
 - Hannes Hörl ([@hoegaarden](https://github.com/hoegaarden))
 - Pengfei Ni ([@feiskyer](https://github.com/feiskyer))
+- Stephen Augustus ([@justaugustus](https://github.com/justaugustus))
 - Tim Pepper ([@tpepper](https://github.com/tpepper))
 - Yang Li ([@idealhack](https://github.com/idealhack))
 
@@ -47,7 +48,6 @@ Branch Managers are responsible for minor releases (`x.y.z`, where `z` = 0) of K
 
 - Carlos Panato ([@cpanato](https://github.com/cpanato))
 - Cheryl Fong ([@bubblemelon](https://github.com/bubblemelon))
-- Stephen Augustus ([@justaugustus](https://github.com/justaugustus))
 
 ## Associates
 


### PR DESCRIPTION
Proposing the following updates to the Release Managers groups:

### Patch Release Team
- Add Stephen Augustus

### Branch Managers
- Promote Sascha Grunert (@saschagrunert)
- Remove Cheryl Fong (@Bubblemelon)

### Release Manager Associates

Remove inactive associates:
- Nikhil Manchanda (@SlickNik)
- Dhawal Yogesh Bhanushali (@imkin)
- Nikhita Raghunath (@nikhita)
- Javier B Perez (@javier-b-perez)
- Giri Kuncoro (@girikuncoro)
- Peter Swica (@pswica)

I'll leave this to lazy consensus and set a date to merge for Tuesday, December 3rd.
/hold

/assign @tpepper @calebamiles 
@kubernetes/sig-release-admins @kubernetes/release-engineering @kubernetes/release-managers 
/milestone v1.18
/priority important-longterm
/kind feature cleanup