### PR TITLE
Update Release Managers (take two)

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -15,7 +15,7 @@ aliases:
     - feiskyer # Patch Release Team
     - hoegaarden # Patch Release Team
     - idealhack # Patch Release Team
-    - justaugustus # subproject owner
+    - justaugustus # subproject owner / Patch Release Team
     - tpepper # subproject owner / Patch Release Team
   release-team:
     - aishsundar # 1.13 RT Lead
@@ -27,8 +27,8 @@ aliases:
     - spiffxp # 1.14 RT Lead
     - tpepper # subproject owner / 1.12 RT Lead
   branch-managers:
-    - bubblemelon
-    - justaugustus
+    - cpanato
+    - saschagrunert
   build-admins:
     - aleksandra-malinowska
     - listx

--- a/release-managers.md
+++ b/release-managers.md
@@ -38,6 +38,7 @@ GitHub Mentions: [@kubernetes/patch-release-team](https://github.com/orgs/kubern
 - Doug MacEachern ([@dougm](https://github.com/dougm))
 - Hannes Hörl ([@hoegaarden](https://github.com/hoegaarden))
 - Pengfei Ni ([@feiskyer](https://github.com/feiskyer))
+- Stephen Augustus ([@justaugustus](https://github.com/justaugustus))
 - Tim Pepper ([@tpepper](https://github.com/tpepper))
 - Yang Li ([@idealhack](https://github.com/idealhack))
 
@@ -46,22 +47,14 @@ GitHub Mentions: [@kubernetes/patch-release-team](https://github.com/orgs/kubern
 Branch Managers are responsible for minor releases (`x.y.z`, where `z` = 0) of Kubernetes, working in close conjunction with the [Release Team](/release-team/README.md) through each release cycle.
 
 - Carlos Panato ([@cpanato](https://github.com/cpanato))
-- Cheryl Fong ([@bubblemelon](https://github.com/bubblemelon))
-- Stephen Augustus ([@justaugustus](https://github.com/justaugustus))
+- Sascha Grunert ([saschagrunert](https://github.com/saschagrunert))
 
 ## Associates
 
 Release Manager Associates are apprentices to the Branch Managers, formerly referred to as Branch Manager shadows.
 
-- Nikhil Manchanda ([@slicknik](https://github.com/slicknik))
-- Dhawal Yogesh Bhanushali ([@imkin](https://github.com/imkin))
-- Nikhita Raghunath ([@nikhita](https://github.com/nikhita))
-- Javier B Perez ([@javier-b-perez](https://github.com/javier-b-perez))
-- Giri Kuncoro ([@girikuncoro](https://github.com/girikuncoro))
-- Peter Swica ([@pswica](https://github.com/pswica))
 - Ace Eldeib ([@alexeldeib](https://github.com/alexeldeib))
 - Kendrick Coleman ([@kacole2](https://github.com/kacole2))
-- Sascha Grunert ([saschagrunert](https://github.com/saschagrunert))
 - Seth McCombs ([@sethmccombs](https://github.com/sethmccombs))
 - Marko Mudrinić ([@xmudrii](https://github.com/xmudrii))
 - Taylor Dolezal ([@onlydole](https://github.com/onlydole))


### PR DESCRIPTION
Proposing the following updates to the Release Managers groups:

### Patch Release Team
- Add Stephen Augustus

### Branch Managers
- Promote Sascha Grunert (@saschagrunert)
- Remove Cheryl Fong (@Bubblemelon)

### Release Manager Associates

Remove inactive associates:
- Nikhil Manchanda (@SlickNik)
- Dhawal Yogesh Bhanushali (@imkin)
- Nikhita Raghunath (@nikhita)
- Javier B Perez (@javier-b-perez)
- Giri Kuncoro (@girikuncoro)
- Peter Swica (@pswica)

(This reverts commit 8e9c01b6166031d968c22e08d181927f15fadc8b, reversing
changes made to e7d102f69085ed882c309945892ef70b1a6b4e77.)

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

Supersedes #866 and #867.

I'll leave this to lazy consensus and set a date to merge for Tuesday, December 3rd.
/hold

/assign @tpepper @calebamiles 
@kubernetes/sig-release-admins @kubernetes/release-engineering @kubernetes/release-managers 
/milestone v1.18
/priority important-longterm
/kind feature cleanup