### PR TITLE
releng: Update Release Manager GitHub template with more requirements

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-manager.md
+++ b/.github/ISSUE_TEMPLATE/release-manager.md
@@ -13,11 +13,31 @@ e.g., (at)example_user
 
 e.g., Patch Release Team, Branch Manager, Release Manager Associate
 
+### Tenure
+
+<!--
+Provide reasoning behind the tenure selection here.
+For temporary access, we should specify a revocation time AND keep the issue open until the temporary Release Manager has been offboarded.
+
+Examples:
+- temporary: Alice is a Release Manager Associate being granted temporary elevated access to execute the Branch Management role. Access should be revoked after the x.y.z-alpha.m release is cut.
+- temporary: Carmen is a Release Team Lead being granted Release Manager Associate access to observe Release Management during the x.y release cycle. Access should be revoked once the x.y cycle is complete.
+-->
+e.g., permanent, temporary
+
 ### Release Manager Onboarding
 
 **All pull requests within these checklists should be marked with an _explicit_ hold and only released once approved by a Release Engineering subproject owner.**
 
 - [ ] Addition of a new Release Manager has been discussed with and approved by Release Engineering subproject owners
+- [ ] Ensure new Release Manager:
+  - [ ] Has joined the following mailing lists:
+    - [kubernetes-sig-release](https://groups.google.com/forum/#!forum/kubernetes-sig-release)
+    - [kubernetes-dev](https://groups.google.com/forum/#!forum/kubernetes-dev)
+  - [ ] Has joined the following Slack channels:
+    - [#sig-release](https://kubernetes.slack.com/messages/C2C40FMNF)
+    - [#release-management](https://kubernetes.slack.com/messages/CJH2GBF7Y)
+  - [ ] Is a [Kubernetes GitHub org member](https://github.com/kubernetes/community/blob/master/community-membership.md#member)
 - [ ] Update [Release Managers](/release-managers.md) page to include the new Release Manager
 
 <!-- 
@@ -34,6 +54,9 @@ As you work through the checklist, use the following PRs as guides:
 
 <!-- ### Patch Release Team
 
+- [ ] Release Manager has agreed (on this issue) to abide by the guidelines set forth in the
+  [Security Release Process](https://git.k8s.io/security/security-release-process.md),
+  specifically the embargo on CVE communications
 - [ ] Update GitHub teams [(`kubernetes/org`)](https://git.k8s.io/org/config/kubernetes/sig-release/teams.yaml)
   - `milestone-maintainers`
   - `patch-release-team`
@@ -41,10 +64,12 @@ As you work through the checklist, use the following PRs as guides:
   - `release-managers`
   - `sig-release`
 - [ ] Update `OWNERS`
-  - `kubernetes/sig-release`
-    - Entry in the `release-engineering` section in `OWNERS_ALIASES`
-  - `kubernetes/release`
-    - Entry in the `release-engineering` section in `OWNERS_ALIASES`
+  - `kubernetes/sig-release` `OWNERS_ALIASES`
+    - Add entry in the `release-engineering` section
+    - Remove entry in the `branch-managers` section
+  - `kubernetes/release` `OWNERS_ALIASES`
+    - Add entry in the `release-engineering` section
+    - Remove entry in the `branch-managers` section
   - `kubernetes/test-infra`
     - Add as reviewer for SIG Release `OWNERS`
 - [ ] Update Google Groups/GCP IAM membership [(`kubernetes/k8s.io`)](https://git.k8s.io/k8s.io/groups/groups.yaml)
@@ -52,27 +77,35 @@ As you work through the checklist, use the following PRs as guides:
   - `k8s-infra-release-viewers@`
   - `release-managers@`
   - `release-managers-private@`
+- [ ] Manually grant permission to post on [kubernetes-announce](https://groups.google.com/forum/#!forum/kubernetes-announce)
+- [ ] Manually remove from the [Release Team Google Group](https://groups.google.com/forum/#!forum/kubernetes-release-team)
 - [ ] Update Slack `release-managers` User Group [(`kubernetes/community`)](https://git.k8s.io/community/communication/slack-config/sig-release/usergroups.yaml)
+- [ ] Manually add to the [#release-private](https://kubernetes.slack.com/archives/GKEA5EL67) Slack channel
 -->
 
 <!-- ### Branch Manager
 
+- [ ] Release Manager has agreed (on this issue) to abide by the guidelines set forth in the
+  [Security Release Process](https://git.k8s.io/security/security-release-process.md),
+  specifically the embargo on CVE communications
 - [ ] Update GitHub teams [(`kubernetes/org`)](https://git.k8s.io/org/config/kubernetes/sig-release/teams.yaml)
   - `milestone-maintainers`
   - `release-managers`
   - `release-engineering`
   - `sig-release`
 - [ ] Update `OWNERS`
-  - `kubernetes/sig-release`
-    - Entry in the `branch-managers` section in `OWNERS_ALIASES`
-  - `kubernetes/release`
-    - Entry in the `branch-managers` section in `OWNERS_ALIASES`
+  - `kubernetes/sig-release` `OWNERS_ALIASES`
+    - Add entry in the `branch-managers` section
+  - `kubernetes/release` `OWNERS_ALIASES`
+    - Add entry in the `branch-managers` section
   - `kubernetes/test-infra`
     - Add as reviewer for SIG Release `OWNERS`
 - [ ] Update Google Groups/GCP IAM membership [(`kubernetes/k8s.io`)](https://git.k8s.io/k8s.io/groups/groups.yaml)
   - `k8s-infra-release-editors@`
   - `k8s-infra-release-viewers@`
   - `release-managers@`
+- [ ] Manually grant permission to post on [kubernetes-announce](https://groups.google.com/forum/#!forum/kubernetes-announce)
+- [ ] Manually add to the [Release Team Google Group](https://groups.google.com/forum/#!forum/kubernetes-release-team)
 - [ ] Update Slack `release-managers` User Group [(`kubernetes/community`)](https://git.k8s.io/community/communication/slack-config/sig-release/usergroups.yaml)
 -->
 
@@ -85,3 +118,5 @@ As you work through the checklist, use the following PRs as guides:
   - `k8s-infra-release-viewers@`
   - `release-managers@`
 -->
+
+cc: @kubernetes/release-engineering

--- a/release-engineering/role-handbooks/branch-manager.md
+++ b/release-engineering/role-handbooks/branch-manager.md
@@ -128,10 +128,7 @@ This is a collection of requirements and conditions to fulfill when taking on th
 
 A list of To Do(s) to get started as Branch Manager:
 
-- Contact the [Release Managers Google Group][release-managers-group] to identify yourself as the incoming release branch manager for the current release team and request to be added to the special privilege group for the `kubernetes-release-test` GCP project that's used to build the releases
-  - Similar access later in the cycle should be granted to the associates depending on how they progress and what actions they prove able to step up to exercise during the cycle.
-- Request permission to post on [kubernetes-announce][k-announce-list] via owner contact form [here][k-announce-request]
-  - If you haven't received access after 24 hrs, contact the [Release Team][kubernetes-release-team].
+- Open a [Release Manager onboarding issue](https://github.com/kubernetes/sig-release/issues/new?labels=sig%2Frelease%2C+area%2Frelease-eng&template=release-manager.md&title=Release+Manager+access+for+%3CGH-handle%3E) in this repo
 - Machine setup:
   - Linux OS
     - MacOS/Windows are not supported by [release tools] today. However, running inside a Linux container on MacOS via Docker works well.
@@ -142,10 +139,6 @@ A list of To Do(s) to get started as Branch Manager:
   - `git clone git@github.com:kubernetes/release.git`
   - ability to run `sendmail` from local Unix command line
     - You may send the email notification manually to [kubernetes-announce][k-announce-list] by taking the contents from the Google Cloud Bucket: [`Buckets/kubernetes-release/archive/anago-vX.Y.0-{alpha,beta,rc}.z`](https://console.cloud.google.com/storage/browser/kubernetes-release/archive/?project=kubernetes-release-test)
-- Join these mailing lists to stay current:
-  - [kubernetes-sig-release](https://groups.google.com/forum/#!forum/kubernetes-sig-release)
-  - [kubernetes-release-team](https://groups.google.com/forum/#!forum/kubernetes-release-team)
-  - [kubernetes-dev](https://groups.google.com/forum/#!forum/kubernetes-dev)
 
 [k-announce-list]: https://groups.google.com/forum/#!forum/kubernetes-announce
 [k-announce-request]: https://groups.google.com/forum/#!contactowner/kubernetes-announce


### PR DESCRIPTION
Follow-up to #880
- Dedupe requirements listed in the Branch Manager handbook
  Here we're holding off on updates to the Patch Release Team handbook
  as it's more out-of-date and warrants its' own pull request
- Add a section to declare the tenure for a Release Manager (permanent
  vs temporary)
- Mention pruning membership to certain groups when being promoted from
  Branch Manager to Patch Release Team
- Ensure release-engineering GitHub team gets notified on new
  onboarding requests
- Add tasks to update membership for kubernetes-release-team@ and
  kubernetes-announce@
- Add task for Patch Release Team members and Branch Managers to adhere
  to the Security Release Process and the CVE embargo contained therein
- Add tasks to ensure Release Managers have joined or been added to the
  correct Slack channels

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/assign @cpanato @saschagrunert 
cc: @kubernetes/release-engineering 
/milestone v1.17
/kind cleanup
/priority important-soon