### PR TITLE
Add Kubernetes 1.18 Leads and Emeritus Adviser

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -19,6 +19,7 @@ aliases:
     - tpepper # subproject owner / Patch Release Team
   release-team:
     - aishsundar # 1.13 RT Lead
+    - alejandrox1 # 1.18 RT Lead
     - claurence # 1.15 RT Lead
     - guineveresaenger # 1.17 RT Lead
     - jberkus # 1.11 RT Lead
@@ -35,35 +36,35 @@ aliases:
     - ps882
     - sumitranr
   release-team-lead-role:
-    - spiffxp # 1.14
     - claurence # 1.15
     - lachie83 # 1.16
     - guineveresaenger # 1.17
+    - alejandrox1 # 1.18
   ci-signal-role:
-    - mariantalla # 1.14
     - alejandrox1 # 1.16 / 1.15
     - alenkacz # 1.17
+    - droslean # 1.18
   enhancements-role:
     - kacole2 # 1.16 / 1.15 / 1.13
-    - claurence # 1.14
     - mrbobbytables # 1.17
+    - jeremyrickard # 1.18
   bug-triage-role:
-    - nikopen # 1.14 / 1.13
     - soggiest # 1.15
     - xmudrii # 1.16
     - josiahbjorgaard # 1.17
+    - smourapina # 1.18
   docs-role:
-    - jimangel # 1.14
     - MAKOSCAFEE # 1.15
     - simplytunde # 1.16
     - daminisatya # 1.17
+    - VineethReddy02 # 1.18
   release-notes-role:
-    - dstrebel # 1.14
     - onyiny-ang # 1.15
     - saschagrunert # 1.16
     - cartyc # 1.17
+    - Evillgenius75 # 1.18
   communications-role:
-    - nwoods3 # 1.14
     - castrojo # 1.15
     - onlydole # 1.16
     - rawkode # 1.17
+    - karenhchu # 1.18

--- a/releases/release-1.18/OWNERS
+++ b/releases/release-1.18/OWNERS
@@ -1,0 +1,13 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - alejandrox1       # Release Team Lead
+  - lachie83          # Emeritus Adviser
+
+reviewers:
+  - jeremyrickard     # Enhancements
+  - droslean          # CI Signal
+  - smourapina        # Bug Triage
+  - VineethReddy02    # Docs
+  - Evillgenius75     # Release Notes
+  - karenhchu         # Communications

--- a/releases/release-1.18/release_team.md
+++ b/releases/release-1.18/release_team.md
@@ -1,0 +1,16 @@
+# Kubernetes 1.18 Release Team
+
+| **Role** | **Name** (**GitHub / Slack ID**)  | **Shadow Name(s) (GitHub / Slack ID)** |
+| ------ | ------ | ------ |
+| Lead |  Jorge Alarcon ([@alejandrox1](https://github.com/alejandrox1) / Slack: `@alejandrox1`) |  |
+| Enhancements | Jeremy Rickard ([jeremyrickard](https://github.com/jeremyrickard) / Slack: `@jerickar`) |  |
+| CI Signal | Nikolaos Moraitis / ([@droslean](https://github.com/droslean) / Slack: `@droslean`) |  |
+| Bug Triage | Silvia Pina / ([@smourapina](https://github.com/smourapina) / Slack: `@smourapina`) |  |
+| Docs | Vineeth Pothulapati ([@VineethReddy02](https://github.com/VineethReddy02) / Slack: `@Vineeth`) |  |
+| Release Notes | Eddie Villalba ([@Evillgenius75](https://github.com/Evillgenius75) / Slack: `Evill_genius`) |  |
+| Communications | Karen Chu ([@karenhchu](https://github.com/karenhchu) / Slack: `@kchu`) |  |
+| Emeritus Adviser | Lachlan Evenson ([@lachie83](https://github.com/lachie83)) / Slack: `@lachie83`) | -- |
+
+Review the [Release Managers page](/release-managers.md) for up-to-date contact information on Release Engineering personnel.
+
+The schedule for all patch releases can be found at [Patch Releases page](/releases/patch-releases.md). It will be updated to include 1.18, once the 1.18 release cycle concludes.


### PR DESCRIPTION
- Add 1.18 Leads and Emeritus Adviser
- Update `OWNERS` for Kubernetes 1.18

ref: #871 

/assign @alejandrox1 @lachie83 
/cc @guineveresaenger @claurence 
/milestone v1.18
/kind feature cleanup
/priority important-soon