### PR TITLE
Fixed Karen's slack handle

### DIFF
--- a/releases/release-1.18/release_team.md
+++ b/releases/release-1.18/release_team.md
@@ -8,7 +8,7 @@
 | Bug Triage | Silvia Pina / ([@smourapina](https://github.com/smourapina) / Slack: `@smourapina`) |  |
 | Docs | Vineeth Pothulapati ([@VineethReddy02](https://github.com/VineethReddy02) / Slack: `@Vineeth`) |  |
 | Release Notes | Eddie Villalba ([@Evillgenius75](https://github.com/Evillgenius75) / Slack: `Evill_genius`) |  |
-| Communications | Karen Chu ([@karenhchu](https://github.com/karenhchu) / Slack: `@kchu`) |  |
+| Communications | Karen Chu ([@karenhchu](https://github.com/karenhchu) / Slack: `@karenhchu`) |  |
 | Emeritus Adviser | Lachlan Evenson ([@lachie83](https://github.com/lachie83)) / Slack: `@lachie83`) | -- |
 
 Review the [Release Managers page](/release-managers.md) for up-to-date contact information on Release Engineering personnel.


### PR DESCRIPTION
There doesn't seem to be a `kchu` in slack but there is a `karenhchu`.

Signed-off-by: alejandrox1 <alarcj137@gmail.com>