### PR TITLE
branchmgmt: Address previous handbook review comments

### DIFF
--- a/release-engineering/role-handbooks/branch-manager.md
+++ b/release-engineering/role-handbooks/branch-manager.md
@@ -6,7 +6,6 @@
   - [Minimum Skills and Requirements](#minimum-skills-and-requirements)
   - [Associates Expectations](#associates-expectations)
 - [Prerequisites](#prerequisites)
-  - [Release Team Onboarding](#release-team-onboarding)
   - [Branch Management Onboarding](#branch-management-onboarding)
   - [Safety Check](#safety-check)
 - [Releases Management](#releases-management)
@@ -120,15 +119,10 @@ This is not a rigid list of obligations from Associates under branch management,
 
 This is a collection of requirements and conditions to fulfill when taking on the role as branch manager.
 
-### Release Team Onboarding
-
-**Please review and work through the tasks in the [Release Team Onboarding Guide](https://github.com/kubernetes/sig-release/blob/master/release-team/release-team-onboarding.md) first, before proceeding with the section specific to branch management below.**
-
 ### Branch Management Onboarding
 
-A list of To Do(s) to get started as Branch Manager:
+**Before we can grant Release Manager access to new Branch Managers, a [Release Manager onboarding issue](https://github.com/kubernetes/sig-release/issues/new?labels=sig%2Frelease%2C+area%2Frelease-eng&template=release-manager.md&title=Release+Manager+access+for+%3CGH-handle%3E) _MUST_ be opened in this repo. Please take a moment to do that before executing the tasks contained in the this handbook.**
 
-- Open a [Release Manager onboarding issue](https://github.com/kubernetes/sig-release/issues/new?labels=sig%2Frelease%2C+area%2Frelease-eng&template=release-manager.md&title=Release+Manager+access+for+%3CGH-handle%3E) in this repo
 - Machine setup:
   - Linux OS
     - MacOS/Windows are not supported by [release tools] today. However, running inside a Linux container on MacOS via Docker works well.

--- a/release-engineering/role-handbooks/branch-manager.md
+++ b/release-engineering/role-handbooks/branch-manager.md
@@ -39,9 +39,9 @@
     - [Generate release branch jobs](#generate-release-branch-jobs)
     - [Update Kubernetes versions document](#update-kubernetes-versions-document)
   - [Configure Merge Automation](#configure-merge-automation)
-  - [Tide](#tide)
-  - [Code Freeze](#code-freeze)
-  - [Code Thaw](#code-thaw)
+    - [Tide](#tide)
+    - [Code Freeze](#code-freeze)
+    - [Code Thaw](#code-thaw)
   - [Branch Fast Forward](#branch-fast-forward)
   - [Reverts](#reverts)
   - [Cherry Picks](#cherry-picks)
@@ -562,7 +562,7 @@ Code freeze initiates additional merge requirements, while Code thaw marks the s
 
 As Branch Manager, coordinate with the Release Lead on checking whichever config changes are required to enable and disable merge restrictions.
 
-### Tide
+#### Tide
 
 Tide automate merges. Its configuration lives in `[config.yaml](https://github.com/kubernetes/test-infra/blob/master/prow/config.yaml)`. Tide identifies PRs that are mergeable using GitHub queries that correspond to the entries in the queries field. Here is an example of what the query config for `kubernetes/kubernetes` looks like without additional constraints related to the release cycle:
 
@@ -588,7 +588,7 @@ Tide automate merges. Its configuration lives in `[config.yaml](https://github.c
 
 During code freeze, two queries are used instead of just one for the `kubernetes/kubernetes` repo. One query handles the `master` and current release branches while the other query handles all other branches. The partition is achieved with the `includedBranches` and `excludedBranches` fields.
 
-### Code Freeze
+#### Code Freeze
 
 Code freeze is when merge requirements for the `master` and current release branch diverge from the requirements for the other branches so this is when the `kubernetes/kubernetes` Tide query splits into two queries.
 
@@ -628,7 +628,7 @@ It is also helpful to remind [#sig-testing](https://kubernetes.slack.com/message
       .
 ```
 
-### Code Thaw
+#### Code Thaw
 
 Code Thaw removes the release cycle merge restrictions and replaces the two queries with one single query. We remain in this state until the next Code Freeze.
 

--- a/release-engineering/role-handbooks/branch-manager.md
+++ b/release-engineering/role-handbooks/branch-manager.md
@@ -513,7 +513,7 @@ Here's an [example PR](https://github.com/kubernetes/test-infra/pull/15015).
    bazel run //experiment:prepare_release_branch
    ```
 
-2. Update release dashboards in the [Testgrid config](https://git.k8s.io/test-infra/config/testgrids/config.yaml) ([example commit](https://github.com/kubernetes/test-infra/pull/15023/commits/cad8a3ce8ef3537568b12619634dff702b16cda7))
+2. Update release dashboards in the [Testgrid config](https://git.k8s.io/test-infra/config/testgrids/kubernetes/sig-release/config.yaml) ([example commit](https://github.com/kubernetes/test-infra/pull/15023/commits/cad8a3ce8ef3537568b12619634dff702b16cda7))
    - Remove the oldest release `sig-release-<version>-{blocking,informing}` dashboards
    - Add dashboards for the current release e.g., `sig-release-1.17-{blocking,informing}`
 

--- a/release-engineering/role-handbooks/branch-manager.md
+++ b/release-engineering/role-handbooks/branch-manager.md
@@ -7,6 +7,11 @@
   - [Associates Expectations](#associates-expectations)
 - [Prerequisites](#prerequisites)
   - [Branch Management Onboarding](#branch-management-onboarding)
+  - [Machine setup](#machine-setup)
+    - [Operating System](#operating-system)
+    - [Release tooling](#release-tooling)
+    - [Google Cloud SDK](#google-cloud-sdk)
+    - [Sending mail](#sending-mail)
   - [Safety Check](#safety-check)
 - [Releases Management](#releases-management)
   - [Alpha Releases](#alpha-releases)
@@ -123,16 +128,57 @@ This is a collection of requirements and conditions to fulfill when taking on th
 
 **Before we can grant Release Manager access to new Branch Managers, a [Release Manager onboarding issue](https://github.com/kubernetes/sig-release/issues/new?labels=sig%2Frelease%2C+area%2Frelease-eng&template=release-manager.md&title=Release+Manager+access+for+%3CGH-handle%3E) _MUST_ be opened in this repo. Please take a moment to do that before executing the tasks contained in the this handbook.**
 
-- Machine setup:
-  - Linux OS
-    - MacOS/Windows are not supported by [release tools] today. However, running inside a Linux container on MacOS via Docker works well.
-    - See "Cutting v1.15.0-alpha.2" under [References](#References) for an example Dockerfile.
-  - Setup SSH keys for GitHub (either static .ssh/config or ssh agent works)
-  - Install the [Google Cloud SDK](https://cloud.google.com/sdk/docs/quickstart-debian-ubuntu)
-  - Run `gcloud init` using the identity (i.e. email address) that you had authorized for the GCP project
-  - `git clone git@github.com:kubernetes/release.git`
-  - ability to run `sendmail` from local Unix command line
-    - You may send the email notification manually to [kubernetes-announce][k-announce-list] by taking the contents from the Google Cloud Bucket: [`Buckets/kubernetes-release/archive/anago-vX.Y.0-{alpha,beta,rc}.z`](https://console.cloud.google.com/storage/browser/kubernetes-release/archive/?project=kubernetes-release-test)
+### Machine setup
+
+#### Operating System
+
+We make a modicum of effort to ensure our [release tools] are supported on multiple platforms, please note that only the following systems are known to be supported:
+
+- Debian-like (Debian, Ubuntu)
+- Fedora-like (Fedora, RHEL, CentOS)
+- MacOS
+
+Windows is not supported by [release tools].
+
+While our tooling may not support every platform, you may find success running within a container image.
+
+See "Cutting v1.15.0-alpha.2" under [References](#References) for an example Dockerfile.
+
+**If you notice that [release tools] are not working as expected, please be sure to file an issue in [kubernetes/release][release tools].**
+
+#### Release tooling
+
+To leverage/contribute to our [release tools], Release Managers will need to fork and clone the [kubernetes/release][release tools] repo.
+
+Release Managers primarily use SSH to authenticate to GitHub.
+
+GitHub has documentation to assist in:
+
+- [Connecting to GitHub with SSH](https://help.github.com/en/github/authenticating-to-github/connecting-to-github-with-ssh)
+- [Forking a repo](https://help.github.com/en/github/getting-started-with-github/fork-a-repo)
+
+Additionally, `kubernetes/community` has a great [overview of the GitHub workflow](https://git.k8s.io/community/contributors/guide/github-workflow.md) we use across several Kubernetes org repositories.
+
+Please take a moment to review that documentation before continuing.
+
+#### Google Cloud SDK
+
+[Kubernetes release artifacts](/release-engineering/artifacts.md) are stored on Google Cloud Platform (GCP).
+
+Release Managers will need to use the Google Cloud SDK to interact with release artifacts.
+
+Google Cloud has [documentation on installing and configuring the Google Cloud SDK CLI tools](https://cloud.google.com/sdk/docs/quickstarts).
+
+#### Sending mail
+
+At the end of a release, Release Managers will need to announce the new release to the community.
+
+This can be done in one of two ways:
+
+- The `./release-notify` tool -- `sendmail` will need to be configured correctly on your environment for this to work
+- Manually -- Send the email notification manually to [kubernetes-announce][k-announce-list] by taking the contents from the Google Cloud Bucket: `gs://kubernetes-release/archive/anago-vX.Y.0-{alpha,beta,rc}.z`:
+  - [Example subject](https://gcsweb.k8s.io/gcs/kubernetes-release/archive/anago-v1.17.0-rc.2/announcement-subject.txt)
+  - [Example body](https://gcsweb.k8s.io/gcs/kubernetes-release/archive/anago-v1.17.0-rc.2/announcement.html)
 
 [k-announce-list]: https://groups.google.com/forum/#!forum/kubernetes-announce
 [k-announce-request]: https://groups.google.com/forum/#!contactowner/kubernetes-announce


### PR DESCRIPTION
These are some of the remaining tasks to tie off https://github.com/kubernetes/sig-release/issues/696:
- Explicitly reference Release Manager onboarding in handbook
- Update machine setup section (ref: https://github.com/kubernetes/sig-release/pull/852#pullrequestreview-325132504 - @xmudrii)
- Fix SIG Release Testgrid config link (ref: https://github.com/kubernetes/sig-release/pull/757#discussion_r313852658 - @nikhita)
- Fix headings for merge automation sections (ref: https://github.com/kubernetes/sig-release/pull/757#discussion_r314110054 - @spiffxp)

/assign @cpanato @saschagrunert 
cc: @kubernetes/release-engineering 
/milestone v1.17
/kind documentation cleanup
/priority important-soon