### PR TITLE
Fix URL in Release Manager onboarding issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-manager.md
+++ b/.github/ISSUE_TEMPLATE/release-manager.md
@@ -38,7 +38,7 @@ e.g., permanent, temporary
     - [#sig-release](https://kubernetes.slack.com/messages/C2C40FMNF)
     - [#release-management](https://kubernetes.slack.com/messages/CJH2GBF7Y)
   - [ ] Is a [Kubernetes GitHub org member](https://github.com/kubernetes/community/blob/master/community-membership.md#member)
-- [ ] Update [Release Managers](https://github.com/kubernetes/sig-release/blob/master/release-managers.md) page to include the new Release Manager
+- [ ] Update [Release Managers](https://git.k8s.io/sig-release/release-managers.md) page to include the new Release Manager
 
 <!-- 
 Uncomment the appropriate checklist for the Release Manager role the new candidate will hold.

--- a/.github/ISSUE_TEMPLATE/release-manager.md
+++ b/.github/ISSUE_TEMPLATE/release-manager.md
@@ -38,7 +38,7 @@ e.g., permanent, temporary
     - [#sig-release](https://kubernetes.slack.com/messages/C2C40FMNF)
     - [#release-management](https://kubernetes.slack.com/messages/CJH2GBF7Y)
   - [ ] Is a [Kubernetes GitHub org member](https://github.com/kubernetes/community/blob/master/community-membership.md#member)
-- [ ] Update [Release Managers](/release-managers.md) page to include the new Release Manager
+- [ ] Update [Release Managers](https://github.com/kubernetes/sig-release/blob/master/release-managers.md) page to include the new Release Manager
 
 <!-- 
 Uncomment the appropriate checklist for the Release Manager role the new candidate will hold.


### PR DESCRIPTION
Trying to open the Release Managers page by following the link from issues created using the Release Manager onboarding template returns `Not Found` error. This PR tries to fix this by using the full URL.

For example, see issues #893 and #892.

/assign @justaugustus 