### PR TITLE
psc/releng: Update references to the security release process

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-manager.md
+++ b/.github/ISSUE_TEMPLATE/release-manager.md
@@ -52,11 +52,12 @@ As you work through the checklist, use the following PRs as guides:
 - k/community: https://github.com/kubernetes/community/pull/4284
 -->
 
-<!-- ### Patch Release Team
+<!--
+### Patch Release Team
 
-- [ ] Release Manager has agreed (on this issue) to abide by the guidelines set forth in the
-  [Security Release Process](https://git.k8s.io/security/security-release-process.md),
-  specifically the embargo on CVE communications
+- [ ] Release Manager has agreed to abide by the guidelines set forth in the
+  [Security Release Process](https://git.k8s.io/security/security-release-process.md), specifically the embargo on CVE communications.
+  This must be done as an issue comment by the incoming Release Manager.
 - [ ] Update GitHub teams [(`kubernetes/org`)](https://git.k8s.io/org/config/kubernetes/sig-release/teams.yaml)
   - `milestone-maintainers`
   - `patch-release-team`
@@ -83,7 +84,8 @@ As you work through the checklist, use the following PRs as guides:
 - [ ] Manually add to the [#release-private](https://kubernetes.slack.com/archives/GKEA5EL67) Slack channel
 -->
 
-<!-- ### Branch Manager
+<!--
+### Branch Manager
 
 - [ ] Release Manager has agreed (on this issue) to abide by the guidelines set forth in the
   [Security Release Process](https://git.k8s.io/security/security-release-process.md),
@@ -104,12 +106,14 @@ As you work through the checklist, use the following PRs as guides:
   - `k8s-infra-release-editors@`
   - `k8s-infra-release-viewers@`
   - `release-managers@`
+  - `release-managers-private@`
 - [ ] Manually grant permission to post on [kubernetes-announce](https://groups.google.com/forum/#!forum/kubernetes-announce)
 - [ ] Manually add to the [Release Team Google Group](https://groups.google.com/forum/#!forum/kubernetes-release-team)
 - [ ] Update Slack `release-managers` User Group [(`kubernetes/community`)](https://git.k8s.io/community/communication/slack-config/sig-release/usergroups.yaml)
 -->
 
-<!-- ### Release Manager Associate
+<!--
+### Release Manager Associate
 
 - [ ] Update GitHub teams [(`kubernetes/org`)](https://git.k8s.io/org/config/kubernetes/sig-release/teams.yaml)
   - `release-engineering`

--- a/.github/ISSUE_TEMPLATE/release-team-lead.md
+++ b/.github/ISSUE_TEMPLATE/release-team-lead.md
@@ -1,0 +1,79 @@
+---
+name: Release Team Lead onboarding
+about: Grant/update access for new Release Team Leads and/or Lead Shadows
+title: 'Release Team Lead access for <GH-handle>'
+labels: sig/release, area/release-eng, area/release-team
+---
+
+<!--
+This template can be used for onboarding the Release Team Lead and Lead Shadows.
+
+The issue should be kept open for the entirety of the release cycle, so we can track the offboarding tasks as well.
+-->
+
+### GitHub Username(s)
+
+- (at)example_user1
+- (at)example_user2
+- (at)example_user3
+
+### Release Cycle
+
+e.g., Kubernetes 1.18
+
+### Prerequisites
+
+- [ ] Ensure new Release Team Lead:
+  - [ ] Has joined the following mailing lists:
+    - [kubernetes-sig-release](https://groups.google.com/forum/#!forum/kubernetes-sig-release)
+    - [kubernetes-dev](https://groups.google.com/forum/#!forum/kubernetes-dev)
+  - [ ] Has joined the following Slack channels:
+    - [#sig-release](https://kubernetes.slack.com/messages/C2C40FMNF)
+    - [#release-management](https://kubernetes.slack.com/messages/CJH2GBF7Y)
+  - [ ] Is a [Kubernetes GitHub org member](https://github.com/kubernetes/community/blob/master/community-membership.md#member)
+
+### Onboarding
+
+<!--
+As you work through the checklist, use the following PRs as guides:
+- k/sig-release: https://github.com/kubernetes/sig-release/pull/884
+- k/org: https://github.com/kubernetes/org/pull/1205
+- k/k8s.io: https://github.com/kubernetes/k8s.io/pull/452
+-->
+
+- [ ] Release Team Lead has agreed to abide by the guidelines set forth in the
+  [Security Release Process](https://git.k8s.io/security/security-release-process.md), specifically the embargo on CVE communications.
+  This must be done as an issue comment by the incoming Release Team Lead.
+- [ ] Update GitHub teams [(`kubernetes/org`)](https://git.k8s.io/org/config/kubernetes/sig-release/teams.yaml)
+  - `milestone-maintainers`
+  - `release-team`
+  - `release-team-leads`
+  - `sig-release`
+- [ ] Update `kubernetes/sig-release` `OWNERS`
+  - Release Team Lead and Shadows
+    - Add an `approvers` entry in `releases/release-x.y/OWNERS`
+  - **Release Team Lead only**
+    - In `OWNERS_ALIASES`, add an entry in the following sections:
+      - `release-team`
+      - `release-team-lead-role`
+- [ ] Update Google Groups/GCP IAM membership [(`kubernetes/k8s.io`)](https://git.k8s.io/k8s.io/groups/groups.yaml)
+  - `k8s-infra-release-viewers@`
+  - `release-managers@`
+- [ ] Manually grant access on the following Google Groups:
+  - [kubernetes-release-team](https://groups.google.com/forum/#!forum/kubernetes-release-team) (Add as Manager)
+  - [kubernetes-sig-leads](https://groups.google.com/forum/#!forum/kubernetes-sig-leads) (Add as Member)
+
+### Offboarding
+
+- [ ] Remove from GitHub teams [(`kubernetes/org`)](https://git.k8s.io/org/config/kubernetes/sig-release/teams.yaml)
+  - `milestone-maintainers`
+  - `release-team`
+  - `release-team-leads`
+- [ ] Remove from Google Groups/GCP IAM membership [(`kubernetes/k8s.io`)](https://git.k8s.io/k8s.io/groups/groups.yaml)
+  - `k8s-infra-release-viewers@`
+  - `release-managers@`
+- [ ] Manually remove from the following Google Groups:
+  - [kubernetes-release-team](https://groups.google.com/forum/#!forum/kubernetes-release-team) (Add as Manager)
+  - [kubernetes-sig-leads](https://groups.google.com/forum/#!forum/kubernetes-sig-leads) (Add as Member)
+
+cc: @kubernetes/release-engineering @kubernetes/release-team

--- a/release-engineering/role-handbooks/branch-manager.md
+++ b/release-engineering/role-handbooks/branch-manager.md
@@ -25,6 +25,7 @@
   - [Beta Releases](#beta-releases)
   - [Release Candidates](#release-candidates)
   - [Official Releases](#official-releases)
+    - [Security fixes](#security-fixes)
     - [Post-release Activities](#post-release-activities)
       - [Debian and RPM Packaging](#debian-and-rpm-packaging)
       - [Release Validation](#release-validation)
@@ -380,6 +381,20 @@ When staging is done, you may use the command `./gcbmgr release` with the `--bui
 However, there is an embargo policy which requires the nomock release publication happens after 4 pm Pacific (see [Release Team Lead Handbook](https://github.com/kubernetes/sig-release/tree/master/release-team/role-handbooks/release-team-lead#week-12) for details), make sure to coordinates with other roles and follow the timeline.
 
 To better prepare and see what to expect, this is a sequence of events that took place on past [official release days](https://docs.google.com/document/d/1K0B91lgeEiJTbT602VloA5arb6AkaTif-MLryaHmlYc/edit?usp=sharing).
+
+#### Security fixes
+
+The Product Security Committee (PSC) may contact you via the [Security Release Team][security-release-team]
+mailing list if there are security fixes needed on the release branch.
+
+Once the release has been confirmed to contain security fixes, the Branch Manager must inform the current
+Release Team Lead and Lead Shadows. Information pertaining to these fixes is considered need-to-know and should not be disseminated to anyone else on the Release Team.
+
+You must not make any public announcements regarding these fixes unless the PSC tells you to.
+
+See the [Security Release Process](https://git.k8s.io/security/security-release-process.md) doc for more details.
+
+[security-release-team]: https://groups.google.com/a/kubernetes.io/forum/#!forum/security-release-team
 
 #### Post-release Activities
 

--- a/release-engineering/role-handbooks/branch-manager.md
+++ b/release-engineering/role-handbooks/branch-manager.md
@@ -127,7 +127,7 @@ This is a collection of requirements and conditions to fulfill when taking on th
 
 ### Branch Management Onboarding
 
-**Before we can grant Release Manager access to new Branch Managers, a [Release Manager onboarding issue](https://github.com/kubernetes/sig-release/issues/new?labels=sig%2Frelease%2C+area%2Frelease-eng&template=release-manager.md&title=Release+Manager+access+for+%3CGH-handle%3E) _MUST_ be opened in this repo. Please take a moment to do that before executing the tasks contained in the this handbook.**
+**Before we can grant Release Manager access to new Branch Managers, a [Release Manager onboarding issue](https://github.com/kubernetes/sig-release/issues/new?labels=sig%2Frelease%2C+area%2Frelease-eng&template=release-manager.md&title=Release+Manager+access+for+%3CGH-handle%3E) _MUST_ be opened in this repo. Please take a moment to do that before executing the tasks contained in this handbook.**
 
 ### Machine setup
 

--- a/release-engineering/role-handbooks/patch-release-team.md
+++ b/release-engineering/role-handbooks/patch-release-team.md
@@ -15,10 +15,10 @@ for the newest Y on each of those two branches.
 - [Patch branch merge workflow and status tracking](#patch-branch-merge-workflow-and-status-tracking)
   - [Rationale](#rationale)
   - [Spreadsheets](#spreadsheets)
-    - [Time ordered rows](#time-ordered-rows)
+    - [Time Ordered Rows](#time-ordered-rows)
     - [Coloring](#coloring)
-    - [Row details](#row-details)
-  - [Tooling future work](#tooling-future-work)
+    - [Row Details](#row-details)
+  - [Future Work](#future-work)
 - [Branch health](#branch-health)
 - [Release timing](#release-timing)
 - [Release cut](#release-cut)
@@ -566,14 +566,16 @@ next patch release.
 
 ### Security release
 
-The Product Security Committee (PSC) will contact you if a security
-releases are needed on branches.
+The Product Security Committee (PSC) will contact you via the [Security Release Team][security-release-team]
+mailing list if security releases are needed on branches.
 
 In contrast to a normal release, you must not make any public announcements
-or push tags or release artifacts to public repositories until the PST tells you to.
+or push tags or release artifacts to public repositories until the PSC tells you to.
 
 See the [Security Release Process](https://git.k8s.io/security/security-release-process.md)
 doc for more details.
+
+[security-release-team]: https://groups.google.com/a/kubernetes.io/forum/#!forum/security-release-team
 
 ## Release Commands Cheat Sheet
 

--- a/release-managers.md
+++ b/release-managers.md
@@ -18,7 +18,8 @@ The responsibilities of each role are described below.
 | Mailing List | Slack | Visibility | Usage | Membership |
 |---|---|---|---|---|
 | [release-managers@kubernetes.io](mailto:release-managers@kubernetes.io) | [#release-management](https://kubernetes.slack.com/messages/CJH2GBF7Y) (channel) / @release-managers (user group) | Public | Public discussion for Release Managers | All Release Managers (Patch Release Team, Branch Managers, Associates, Build Admins, SIG Chairs) |
-| [release-managers-private@kubernetes.io](mailto:release-managers-private@kubernetes.io)| [#release-private](https://kubernetes.slack.com/messages/GKEA5EL67) | Private | Private discussion for privileged Release Managers | Patch Release Team, Build Admins, SIG Chairs |
+| [release-managers-private@kubernetes.io](mailto:release-managers-private@kubernetes.io) | [#release-private](https://kubernetes.slack.com/messages/GKEA5EL67) | Private | Private discussion for privileged Release Managers | Patch Release Team, Branch Managers, SIG Chairs |
+| [security-release-team@kubernetes.io](mailto:security-release-team@kubernetes.io) | N/A | Private | Security release coordination with the Product Security Committee | [security@kubernetes.io](mailto:security@kubernetes.io), [release-managers-private@kubernetes.io](mailto:release-managers-private@kubernetes.io) |
 
 ## Handbooks
 
@@ -28,7 +29,9 @@ The responsibilities of each role are described below.
 
 ## Patch Release Team
 
-The Patch Release Team is responsible for coordinating patch releases (`x.y.z`, where `z` >= 0) of Kubernetes. This team at times works in close conjunction with the [Product Security Committee](https://git.k8s.io/community/committee-product-security/README.md) and therefore should abide by the guidelines set forth in the [Security Release Process](https://git.k8s.io/security/security-release-process.md). 
+The Patch Release Team is responsible for coordinating patch releases (`x.y.z`, where `z` > 0) of Kubernetes.
+
+This team at times works in close conjunction with the [Product Security Committee][psc] and therefore should abide by the guidelines set forth in the [Security Release Process][security-release-process].
 
 GitHub Access Controls: [@kubernetes/release-managers](https://github.com/orgs/kubernetes/teams/release-managers)
 
@@ -44,7 +47,9 @@ GitHub Mentions: [@kubernetes/patch-release-team](https://github.com/orgs/kubern
 
 ## Branch Managers
 
-Branch Managers are responsible for minor releases (`x.y.z`, where `z` = 0) of Kubernetes, working in close conjunction with the [Release Team](/release-team/README.md) through each release cycle.
+Branch Managers are responsible for minor releases (`x.y.z`, where `z` = 0) of Kubernetes, working with the [Release Team](/release-team/README.md) through each release cycle.
+
+This team at times works in close conjunction with the [Product Security Committee][psc] and therefore should abide by the guidelines set forth in the [Security Release Process][security-release-process].
 
 - Carlos Panato ([@cpanato](https://github.com/cpanato))
 - Sascha Grunert ([@saschagrunert](https://github.com/saschagrunert))
@@ -101,3 +106,6 @@ Mail to the groups below will be ignored. Please instead use the [contact groups
 
 Past Branch Managers, can be found in the [releases directory](/releases) within `release-x.y/release_team.md`.
 Example: [1.15 Release Team](/releases/release-1.15/release_team.md)
+
+[psc]: https://git.k8s.io/community/committee-product-security/README.md
+[security-release-process]: https://git.k8s.io/security/security-release-process.md

--- a/release-team/role-handbooks/release-team-lead/README.md
+++ b/release-team/role-handbooks/release-team-lead/README.md
@@ -291,11 +291,11 @@ Code Freeze will typically fall around Weeks 8 or 9 depending on the length or r
 [merge-labels]: https://git.k8s.io/community/contributors/devel/sig-release/release.md#tldr
 [milestone-maintainers]: /release-team/README.md#milestone-maintainers
 [onboarding]: /release-team/release-team-onboarding.md
+[private-distributors-list]: https://github.com/kubernetes/security/blob/master/private-distributors-list.md
 [Prow]: https://prow.k8s.io/
 [release-blocking]: /release-blocking-jobs.md
 [release-managers-group]: https://groups.google.com/a/kubernetes.io/forum/#!forum/release-managers
 [rtl-onboarding]: https://github.com/kubernetes/sig-release/issues/new?labels=sig%2Frelease%2C+area%2Frelease-eng%2C+area%2Frelease-team&template=release-team-lead.md&title=Release+Team+Lead+access+for+%3CGH-handle%3E
+[security-release-process]: https://github.com/kubernetes/security/blob/master/security-release-process.md
 [selection]: /release-team/release-team-selection.md
 [Testgrid]: https://testgrid.k8s.io/
-[security-release-process]: https://github.com/kubernetes/security/blob/master/security-release-process.md
-[private-distributors-list]: https://github.com/kubernetes/security/blob/master/private-distributors-list.md

--- a/release-team/role-handbooks/release-team-lead/README.md
+++ b/release-team/role-handbooks/release-team-lead/README.md
@@ -123,9 +123,8 @@ Release Team selection should happen in accordance with the [Release Team select
   - [kubernetes-dev]
   - [kubernetes-sig-release]
   - [kubernetes-release-team]
-  - [kubernetes-release-managers][release-managers-group]
   - [kubernetes-sig-leads]
-  - [release-managers-private]: Request membership for you and your shadow(s) from the [Release Managers group][release-managers-group]
+  - [release-managers][release-managers-group]: Request membership for you and your shadow(s) from the [Release Managers group][release-managers-group]
 
 - While the release team lead has always been a stakeholder in getting security fixes out the door, the Kubernetes security disclosures and response policy has evolved into something more formal. The documents linked below are required reading for an incoming release team lead, who must understand and abide by the embargo policy.
   - [Security in the release process][security-release-process]
@@ -137,7 +136,7 @@ Release Team selection should happen in accordance with the [Release Team select
 - Create the retrospective document and corresponding bit.ly link
 - Begin meeting with SIGs to introduce yourself
 - Begin paying attention to [CI signal][ci-signal], as it may begin degrading soon after the prior release is cut and any slips must be caught and rectified promptly.
-- Request review of this document by the Release Team Lead shadow(s). The shadow(s) should also take all actions in this document around joining groups and requesting access permissions with the esception of release-managers-private.
+- Request review of this document by the Release Team Lead shadow(s). The shadow(s) should also take all actions in this document around joining groups and requesting access permissions.
 
 ### Week 2
 
@@ -274,7 +273,7 @@ Code Freeze will typically fall around Weeks 8 or 9 depending on the length or r
 - Release Retrospective participation
 - Follow-up interviews with the media, the media roundtable.
 - Contact the [Release Managers Google Group][release-managers-group] to remove Release Team Lead and shadows authorization in GCP, as appropriate for Release Team turn over.
-- Ensure self and shadows are removed as members of [release-managers-private].
+- Ensure self and shadows are removed as members of [release-managers-group].
 
 ### Week 14
 
@@ -298,7 +297,6 @@ Code Freeze will typically fall around Weeks 8 or 9 depending on the length or r
 [Prow]: https://prow.k8s.io/
 [release-blocking]: /release-blocking-jobs.md
 [release-managers-group]: https://groups.google.com/a/kubernetes.io/forum/#!forum/release-managers
-[release-managers-private]: https://groups.google.com/a/kubernetes.io/forum/#!forum/release-managers-private
 [selection]: /release-team/release-team-selection.md
 [Testgrid]: https://testgrid.k8s.io/
 [security-release-process]: https://github.com/kubernetes/security/blob/master/security-release-process.md

--- a/release-team/role-handbooks/release-team-lead/README.md
+++ b/release-team/role-handbooks/release-team-lead/README.md
@@ -30,7 +30,6 @@ The release team leader role is responsible for coordinating release activities,
   - [Week 13](#week-13)
   - [Week 14](#week-14)
 
-
 ## Authority and Responsibility
 
 The Release Team Lead should be an arbiter of decisions, and not the primary decision-maker. A lead should constantly search for the best-qualified people or SIGs to guide the decision, not "go it alone", unless it is a very specific concern within the release process itself. When decisions are made they must be weighted in favor of community concerns over those of individuals or specific companies. Leads must also relinquish any favoritism for the company they work for. If there is a conflict of interest, the lead must recuse themselves from that decision. Above all, the release lead is a servant leader to the team and the community.
@@ -110,13 +109,14 @@ Release Team selection should happen in accordance with the [Release Team select
 ## Release Milestone Activities
 
 ### Before Release Begins
-- Attend previous release retro to capture feedback and incorporate it into next release cycle 
+
+- Attend previous release retro to capture feedback and incorporate it into next release cycle
 - Plan release schedule and milestones. Gather feedback as needed.
-- Make sure you have your shadows confirmed 
+- Make sure you have your shadows confirmed
 - Have a handover meeting with SIG Chairs and the outgoing lead to get credentials to SIG Release Zoom and any other needed permissions
 - Request edit access to the [Kubernetes Release Calendar][kubernetes-release-calendar] from the SIG Release Chairs
 
-### Week 1 
+### Week 1
 
 - Start the release cycle
 - Ensure you have joined the following Google Groups:
@@ -126,16 +126,16 @@ Release Team selection should happen in accordance with the [Release Team select
   - [kubernetes-release-managers][release-managers-group]
   - [kubernetes-sig-leads]
   - [release-managers-private]: Request membership for you and your shadow(s) from the [Release Managers group][release-managers-group]
-    
+
 - While the release team lead has always been a stakeholder in getting security fixes out the door, the Kubernetes security disclosures and response policy has evolved into something more formal. The documents linked below are required reading for an incoming release team lead, who must understand and abide by the embargo policy.
-    - [Security in the release process][security-release-process].
-    - [Private distributors and Embargo Policy][private-distributors-list]
+  - [Security in the release process][security-release-process]
+  - [Private distributors and Embargo Policy][private-distributors-list]
 - Ensure the release team is fully filled, with members subscribed to the [kubernetes-release-team] and [kubernetes-sig-release] groups.
 - Ensure top-level OWNERS_ALIASES only includes Release Team personnel from four (4) releases, including the current one.
 - Create and finalize the release schedule, blocking test gates, and role assignments as a pull request in: kubernetes/sig-release/releases/release-x.y/README.md
 - Send an update to [kubernetes-dev] and [kubernetes-sig-leads] mailing list to announce the start of the release cycle, including any notable changes in the release process, key dates, and links to important documents
 - Create the retrospective document and corresponding bit.ly link
-- Begin meeting with SIGs to introduce yourself 
+- Begin meeting with SIGs to introduce yourself
 - Begin paying attention to [CI signal][ci-signal], as it may begin degrading soon after the prior release is cut and any slips must be caught and rectified promptly.
 - Request review of this document by the Release Team Lead shadow(s). The shadow(s) should also take all actions in this document around joining groups and requesting access permissions with the esception of release-managers-private.
 
@@ -172,10 +172,9 @@ Release Team selection should happen in accordance with the [Release Team select
 - Follow up with SIGs on release themes
 - Begin casual observation of [issues](https://git.k8s.io/sig-release/release-team/role-handbooks/bug-triage/README.md), CI signal, test flakes, and critical PRs
 
+---
 
----
-Release Halfway Point
----
+## Release Halfway Point
 
 ### Week 6
 
@@ -198,12 +197,13 @@ Release Halfway Point
 
 #### Code Freeze Day
 
-Code Freeze will typically fall around Weeks 8 or 9 depending on the length or release cycle.  As Code Freeze approaches here are some good practices 
+Code Freeze will typically fall around Weeks 8 or 9 depending on the length or release cycle.  As Code Freeze approaches here are some good practices
+
 - Monitor the enhancements spreadsheet to get an idea of how many PRs are still outstanding leading up to Code Freeze
-- Send a reminder email to [kubernetes-dev] 
+- Send a reminder email to [kubernetes-dev]
 - Monitor [Testgrid] and [Prow] to understand the stability of the release and PRs getting ready to merge. If Prow and Test grid are not in a good state consult folks from SIG Testing on delaying code freeze by a day if needed.  
 - LGTM / Approve and remove the hold on the PR for enabling code freeze. [Example from 1.15 here](https://github.com/kubernetes/test-infra/pull/12808)
-- As needed, assist the Bug Triage Lead and Enhancements Lead removing PRs and enhancements from the milestone that aren't merged in time 
+- As needed, assist the Bug Triage Lead and Enhancements Lead removing PRs and enhancements from the milestone that aren't merged in time
 
 ### Week 8
 
@@ -241,10 +241,9 @@ Code Freeze will typically fall around Weeks 8 or 9 depending on the length or r
 - Work with the CNCF, SIG PM, SIG Docs, and Communications Lead to start the Release Blog post pulling from SIG Themes, the enhancements repo, SIG members, and possibly release notes in specific PRs.
 - Work with the incoming Release Team Lead to establish incoming Release Team.
 
+---
 
----
-Release Day
----
+## Release Day
 
 ### Week 12
 
@@ -280,7 +279,6 @@ Release Day
 ### Week 14
 
 - Help fill the any open positions for the next release milestone
-
 
 [branch-manager]: /release-managers.md#branch-managers
 [build-admins]: /release-managers.md#build-admins

--- a/release-team/role-handbooks/release-team-lead/README.md
+++ b/release-team/role-handbooks/release-team-lead/README.md
@@ -13,6 +13,7 @@ The release team leader role is responsible for coordinating release activities,
 - [Release Milestone Activities](#release-milestone-activities)
   - [Before Release Begins](#before-release-begins)
   - [Week 1](#week-1)
+    - [Starting the release cycle](#starting-the-release-cycle)
   - [Week 2](#week-2)
   - [Week 3](#week-3)
   - [Week 4](#week-4)
@@ -36,7 +37,7 @@ The Release Team Lead should be an arbiter of decisions, and not the primary dec
 
 ## Prerequisites
 
-**Before continuing on to the Release Lead specific requirements listed below, please review and work through the tasks in the [Release Team Onboarding Guide][onboarding].**
+**Before we can grant access to new Release Team Leads, a [Release Team Lead onboarding issue][rtl-onboarding] _MUST_ be opened in this repo. Please take a moment to do that before executing the tasks contained in this handbook.**
 
 ## Skills and Experience Required
 
@@ -118,17 +119,14 @@ Release Team selection should happen in accordance with the [Release Team select
 
 ### Week 1
 
-- Start the release cycle
-- Ensure you have joined the following Google Groups:
-  - [kubernetes-dev]
-  - [kubernetes-sig-release]
-  - [kubernetes-release-team]
-  - [kubernetes-sig-leads]
-  - [release-managers][release-managers-group]: Request membership for you and your shadow(s) from the [Release Managers group][release-managers-group]
+**While the Release Team Lead has always been a stakeholder in getting security fixes out the door, the Kubernetes security disclosures and response policy has evolved into something more formal. The documents linked below are required reading for an incoming Release Team Lead, who must understand and abide by the embargo policy.**
 
-- While the release team lead has always been a stakeholder in getting security fixes out the door, the Kubernetes security disclosures and response policy has evolved into something more formal. The documents linked below are required reading for an incoming release team lead, who must understand and abide by the embargo policy.
-  - [Security in the release process][security-release-process]
-  - [Private distributors and Embargo Policy][private-distributors-list]
+- [Security Release Process][security-release-process]
+- [Private distributors and Embargo Policy][private-distributors-list]
+
+#### Starting the release cycle
+
+- Complete a [Release Team Lead onboarding issue][rtl-onboarding] for the Lead and RT Lead Shadows
 - Ensure the release team is fully filled, with members subscribed to the [kubernetes-release-team] and [kubernetes-sig-release] groups.
 - Ensure top-level OWNERS_ALIASES only includes Release Team personnel from four (4) releases, including the current one.
 - Create and finalize the release schedule, blocking test gates, and role assignments as a pull request in: kubernetes/sig-release/releases/release-x.y/README.md
@@ -150,7 +148,7 @@ Release Team selection should happen in accordance with the [Release Team select
 ### Week 3
 
 - Create the release notes draft file in the release directory per the standard above
-- Prepare for x.y.0-alpha.0 "release", specifically that there is a [Branch Manager][branch-manager] available to support the team, and that master-blocking tests are all green. The alpha.0 artifacts were created already as a part of the prior release. But this synthetic notation is a point to review process with the [Branch Manager][branch-manager]. Optionally request read-only access to GCP for you and your shadow(s) through the [Release Managers Google Group][release-managers-group].
+- Prepare for x.y.0-alpha.0 "release", specifically that there is a [Branch Manager][branch-manager] available to support the team, and that master-blocking tests are all green. The alpha.0 artifacts were created already as a part of the prior release. This synthetic notation is a point to review process with the [Branch Manager][branch-manager].
 - Begin coordination with SIG Cluster Lifecycle for the kubeadm release (they may create an issue in the milestone to track release blocking issues)
 - Identify any other dependent ecosystem projects that need release coordination
 - Announce/email that the following week is Enhancements Freeze and what that means
@@ -271,9 +269,8 @@ Code Freeze will typically fall around Weeks 8 or 9 depending on the length or r
 ### Week 13
 
 - Release Retrospective participation
-- Follow-up interviews with the media, the media roundtable.
-- Contact the [Release Managers Google Group][release-managers-group] to remove Release Team Lead and shadows authorization in GCP, as appropriate for Release Team turn over.
-- Ensure self and shadows are removed as members of [release-managers-group].
+- Follow-up interviews with the media, the media roundtable
+- Contact the [Release Managers Google Group][release-managers-group] to complete the Release Team Lead & Lead Shadows offboarding tasks from the previously-opened onboarding issue
 
 ### Week 14
 
@@ -297,6 +294,7 @@ Code Freeze will typically fall around Weeks 8 or 9 depending on the length or r
 [Prow]: https://prow.k8s.io/
 [release-blocking]: /release-blocking-jobs.md
 [release-managers-group]: https://groups.google.com/a/kubernetes.io/forum/#!forum/release-managers
+[rtl-onboarding]: https://github.com/kubernetes/sig-release/issues/new?labels=sig%2Frelease%2C+area%2Frelease-eng%2C+area%2Frelease-team&template=release-team-lead.md&title=Release+Team+Lead+access+for+%3CGH-handle%3E
 [selection]: /release-team/release-team-selection.md
 [Testgrid]: https://testgrid.k8s.io/
 [security-release-process]: https://github.com/kubernetes/security/blob/master/security-release-process.md


### PR DESCRIPTION
- psc/releng: Update references to the security release process
  - Include security-release-team@ as a contact in release-managers.md

    The Product Security Committee and Release Managers will now
    coordinate security releases using this list.

  - Ensure Branch Manager membership on release-managers-private is
    documented and included in the Release Manager onboarding template
  - Mention the Security Release Process in the Branch Manager handbook
  - Update table of contents in Patch Release Team handbook

- lint: Fix markdown warnings in Release Team Lead handbook

- release-team-lead: Remove reference to the private Release Managers list
  
  Security release coordination now happens between the Product Security
  Committee, Patch Release Team, Branch Managers, and SIG Chairs.

  Information regarding security releases will be disseminated to Release
  Team Leads by Branch Managers on a need-to-know basis.

- release-team-lead: Add onboarding template
  
  Here we add an onboarding template for Release Team Leads and Lead
  Shadows and move information about requisite access from the handbook
  and into the issue template.

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/hold ~(there are few things I want to tweak on the RT Lead handbook before merge)~
cc: @kubernetes/product-security-committee @kubernetes/release-engineering @kubernetes/release-team 
ref: https://github.com/kubernetes/sig-release/issues/896
/area release-eng release-team
/committee product-security
/milestone v1.17
/kind documentation cleanup
/priority important-soon