### PR TITLE
Update to Release Notes Handbook

### DIFF
--- a/release-team/role-handbooks/release-notes/README.md
+++ b/release-team/role-handbooks/release-notes/README.md
@@ -24,7 +24,7 @@ intensive roles.
 For the first few weeks, attending meetings and running the
 [release-notes tool](https://github.com/kubernetes/release/tree/master/cmd/release-notes) as well as updating the [release-notes website](https://github.com/kubernetes-sigs/release-notes) weekly to create an early draft of the release notes is all that is absolutely required of the release team. 
 
-The release lead will be responsible for introducing shadows to the team and the release notes tool and may ask shadows to run it and make the weekly update PR. The release notes lead should indicate pain points and known issues to the shadows (if there are any) and work on strategies for overcoming them to avoid their coalescence during the later weeks. 
+The Release Notes Lead will be responsible for introducing shadows to the team and the release notes tool and may ask shadows to run it and make the weekly update PR. The Release Notes Lead should indicate pain points and known issues to the shadows (if there are any) and work on strategies for overcoming them to prevent the team from encountering them during the later weeks. 
 
 If there are potential fixes to the issues indicated and team members are keen, this time
 can be used to address them. Fixes and automation of the process is very welcome but not expected.

--- a/release-team/role-handbooks/release-notes/README.md
+++ b/release-team/role-handbooks/release-notes/README.md
@@ -4,6 +4,10 @@
 
 The Release Notes role is responsible for collecting and fine-tuning release-notes from the many contributions to Kubernetes between release cycles. This role is likely to find that work during the first several weeks of the release cycle is very laid back with the bulk of the tasks being completed at the end, once the release is firmed up.
 
+The release lead will be responsible for introducing shadows to the team and the release notes tool and may ask shadows to run it and make the weekly update PR. The release notes lead should indicate pain points and known issues to the shadows (if there are any) and work on strategies for overcoming them to avoid their coalescence during the later weeks. 
+
+If there are potential fixes to the issues indicated and team members are keen, fixes and automation of the process is very welcome but not expected.
+
 ## Prerequisites for Release Notes Lead and Shadows
 
 ### General Requirements
@@ -21,20 +25,14 @@ The Release Notes role is responsible for collecting and fine-tuning release-not
 Compared to other release team roles, release notes is one of the least time
 intensive roles.
 #### Early and mid release cycle (weeks 1-8) ~1-5 hours/week
-For the first few weeks, attending meetings and running the
-[release-notes tool](https://github.com/kubernetes/release/tree/master/cmd/release-notes) as well as updating the [release-notes website](https://github.com/kubernetes-sigs/release-notes) weekly to create an early draft of the release notes is all that is absolutely required of the release team. 
-
-The Release Notes Lead will be responsible for introducing shadows to the team and the release notes tool and may ask shadows to run it and make the weekly update PR. The Release Notes Lead should indicate pain points and known issues to the shadows (if there are any) and work on strategies for overcoming them to prevent the team from encountering them during the later weeks. 
-
-If there are potential fixes to the issues indicated and team members are keen, this time
-can be used to address them. Fixes and automation of the process is very welcome but not expected.
+In the first 8 weeks of the cycle, the Release Notes team should/must, attend weekly release meetings and run the [release-notes tool](https://github.com/kubernetes/release/tree/master/cmd/release-notes) as well as update the [release-notes website](https://github.com/kubernetes-sigs/release-notes) weekly to create an early draft of the release notes. 
 
 #### Late release cycle (weeks 9-12+) ~4-10 hours/week
 This period has an increase in release team  meetings each week and there is
 also significantly more work to do to ensure the release notes are in good
 working order for the release. 
 
-Once Code Freeze begins, the release notes draft
+Once code freeze begins, the release notes draft
 is transferred to a google doc which is made public to the Kubernetes community.
 The doc will be edited by SIG leads and SIG members but will also be edited for
 grammar and uniform style by the release notes team. 
@@ -94,7 +92,6 @@ Update this section at the end of each release for the next Release Notes Team.
 ### Post 1.16 TODOs
 
 #### High Priority
-- Include previous release notes (1.14 and prior) in [Release notes website](https://relnotes.k8s.io)
 - Investigate opportunities to improve release notes collection by changing the
   PR boilerplate and/or creating new labels to indicate deprecations and
   dependencies (as per [#668](https://github.com/kubernetes/sig-release/issues/668))
@@ -148,8 +145,7 @@ Update this section at the end of each release for the next Release Notes Team.
 - Release day
 - Copy notes from Google Doc to HackMD in markdown
 - Final version of release notes committed for release
-
-**Release notes must be merged into the `master` branch of `kubernetes/sig-release`, prior to the staging of the `x.y.0` release. If this is not done, the release will NOT include the finalized version of the release notes. Please coordinate closely with the [Branch Managers](/release-managers.md#branch-managers) and Release Team Lead to ensure activities are aligned throughout the day.**
+- Release Notes must be merged into master prior to the release. If this is not done the release will include the latest draft.
 
 ### Week 13
 

--- a/release-team/role-handbooks/release-notes/README.md
+++ b/release-team/role-handbooks/release-notes/README.md
@@ -148,7 +148,8 @@ Update this section at the end of each release for the next Release Notes Team.
 - Release day
 - Copy notes from Google Doc to HackMD in markdown
 - Final version of release notes committed for release
-- Release Notes must be merged into master prior to the release. If this is not done the release will include the latest draft.
+
+**Release notes must be merged into the `master` branch of `kubernetes/sig-release`, prior to the staging of the `x.y.0` release. If this is not done, the release will NOT include the finalized version of the release notes. Please coordinate closely with the [Branch Managers](/release-managers.md#branch-managers) and Release Team Lead to ensure activities are aligned throughout the day.**
 
 ### Week 13
 

--- a/release-team/role-handbooks/release-notes/README.md
+++ b/release-team/role-handbooks/release-notes/README.md
@@ -34,7 +34,7 @@ This period has an increase in release team  meetings each week and there is
 also significantly more work to do to ensure the release notes are in good
 working order for the release. 
 
-Once code freeze begins, the release notes draft
+Once Code Freeze begins, the release notes draft
 is transferred to a google doc which is made public to the Kubernetes community.
 The doc will be edited by SIG leads and SIG members but will also be edited for
 grammar and uniform style by the release notes team. 

--- a/release-team/role-handbooks/release-notes/README.md
+++ b/release-team/role-handbooks/release-notes/README.md
@@ -22,31 +22,27 @@ Compared to other release team roles, release notes is one of the least time
 intensive roles.
 #### Early and mid release cycle (weeks 1-8) ~1-5 hours/week
 For the first few weeks, attending meetings and running the
-[release-notes tool](https://github.com/kubernetes/release/tree/master/cmd/release-notes)
-as well as updating the
-[release-notes website](https://github.com/kubernetes-sigs/release-notes)
-weekly to create an early draft of the release notes is all that is absolutely
-required of the release team. The release lead will be responsible for introducing
-shadows to the team and the release notes tool and may ask shadows to run it
-and make the weekly update PR. The release notes lead should indicate pain
-points and known issues to the shadows (if there are any) and work on strategies
-for overcoming them to avoid their coalescence during the later weeks. If there
-are potential fixes to the issues indicated and team members are keen, this time
-can be used to address them. Fixes and automation of the process is very welcome
-but not expected.
+[release-notes tool](https://github.com/kubernetes/release/tree/master/cmd/release-notes) as well as updating the [release-notes website](https://github.com/kubernetes-sigs/release-notes) weekly to create an early draft of the release notes is all that is absolutely required of the release team. 
+
+The release lead will be responsible for introducing shadows to the team and the release notes tool and may ask shadows to run it and make the weekly update PR. The release notes lead should indicate pain points and known issues to the shadows (if there are any) and work on strategies for overcoming them to avoid their coalescence during the later weeks. 
+
+If there are potential fixes to the issues indicated and team members are keen, this time
+can be used to address them. Fixes and automation of the process is very welcome but not expected.
 
 #### Late release cycle (weeks 9-12+) ~4-10 hours/week
 This period has an increase in release team  meetings each week and there is
 also significantly more work to do to ensure the release notes are in good
-working order for the release. Once code freeze begins, the release notes draft
+working order for the release. 
+
+Once code freeze begins, the release notes draft
 is transferred to a google doc which is made public to the Kubernetes community.
 The doc will be edited by SIG leads and SIG members but will also be edited for
-grammar and uniform style by the release notes team. The Release Notes team
-should use the [template](relnotes-template.md) to organize the raw generated release notes
-in the Google doc as best as possible and help to guide SIG leads and members in their further
-editing of the release notes. The final edited release notes should follow this
-template. The changelog must also be generated and the release notes tool must continue to be run on the release
-branch in order to pull in any outstanding PRs that are merged between the
+grammar and uniform style by the release notes team. 
+
+The Release Notes team should use the [template](relnotes-template.md) to organize the raw generated release notes in the Google doc as best as possible and help to guide SIG leads and members in their further editing of the release notes. The final edited release notes should follow this
+template. 
+
+The changelog must also be generated and the release notes tool must continue to be run on the release branch in order to pull in any outstanding PRs that are merged between the
 beginning of code freeze and the release. The same applies to the website, which
 should always represent the same state as the markdown document.
 
@@ -87,6 +83,7 @@ should always represent the same state as the markdown document.
 
 - [Release notes tool](https://github.com/kubernetes/release/tree/master/cmd/release-notes)
 - [Release notes website](https://relnotes.k8s.io)
+- [go-modiff](https://github.com/saschagrunert/go-modiff)
 - [Hackmd](https://hackmd.io/)
 - [LWKD](http://lwkd.info) *(consider contributing to LWKD as part of your role)*
 
@@ -151,6 +148,7 @@ Update this section at the end of each release for the next Release Notes Team.
 - Release day
 - Copy notes from Google Doc to HackMD in markdown
 - Final version of release notes committed for release
+- Release Notes must be merged into master prior to the release. If this is not done the release will include the latest draft.
 
 ### Week 13
 


### PR DESCRIPTION
Cleaned up some formatting in the markdown, added go-modiff (awesome work @saschagrunert ) to tools list and added a line about the need for Release Notes to be merged before the release button is pushed.