### PR TITLE
Update the release-team-onboarding-guide

### DIFF
--- a/release-team/release-team-onboarding.md
+++ b/release-team/release-team-onboarding.md
@@ -34,7 +34,7 @@ There are a few mailing lists that you should be aware of. Depending on your rel
 
 #### Release Team Mailing List
 
-All members of the current release team should be apart of this list. If you're on the Release Team, please join this list: https://groups.google.com/forum/#!forum/kubernetes-release-team
+All members of the current release team should be apart of this list. If you're on the Release Team and cannot access: https://groups.google.com/forum/#!forum/kubernetes-release-team, please tell your role lead or the Release Team lead that you need access. The Release Team Lead, as well as Lead Shadows, can manage list membership. 
 
 #### SIG Release Mailing List
 

--- a/release-team/release-team-onboarding.md
+++ b/release-team/release-team-onboarding.md
@@ -34,7 +34,7 @@ There are a few mailing lists that you should be aware of. Depending on your rel
 
 #### Release Team Mailing List
 
-All members of the current release team should be apart of this list. If you're on the Release Team and cannot access: https://groups.google.com/forum/#!forum/kubernetes-release-team, please tell your role lead or the Release Team lead that you need access. The Release Team Lead, as well as Lead Shadows, can manage list membership. 
+All members of the current release team should be apart of this list. If you're on the Release Team and cannot access: https://groups.google.com/forum/#!forum/kubernetes-release-team, please tell your role lead or the Release Team lead that you need access. The Release Lead, as well as Relase Lead shadows, can manage list membership. 
 
 #### SIG Release Mailing List
 


### PR DESCRIPTION
In the `release-team/release-team-onboarding.md` guide, we instructed people to join https://groups.google.com/forum/#!forum/kubernetes-release-team. Joining this list requires that someone be invited, however, so this PR updates the guidance to instruct the prospective group member to reach out to their role lead. Currently, RT lead and lead shadows have manager access and can invite people to the list. 

Signed-off-by: Jeremy Rickard <rickardj@vmware.com>