### PR TITLE
Change release notes template accordingly to generator

### DIFF
--- a/release-team/role-handbooks/release-notes/relnotes-template.md
+++ b/release-team/role-handbooks/release-notes/relnotes-template.md
@@ -22,60 +22,6 @@ feedback!
 
 ### (No, really, you MUST read this before you upgrade)
 
-#### API Machinery
-
-<!-- Add here -->
-
-#### Apps
-
-<!-- Add here -->
-
-#### Auth
-
-<!-- Add here -->
-
-#### Autoscaling
-
-<!-- Add here -->
-
-#### CLI
-
-<!-- Add here -->
-
-#### Cloud Provider
-
-<!-- Add here -->
-
-#### Cluster Lifecycle
-
-<!-- Add here -->
-
-#### Instrumentation
-
-<!-- Add here -->
-
-#### Network
-
-<!-- Add here -->
-
-#### Node
-
-<!-- Add here -->
-
-#### Release
-
-<!-- Add here -->
-
-#### Scheduling
-
-<!-- Add here -->
-
-#### Storage
-
-<!-- Add here -->
-
-#### Windows
-
 <!-- Add here -->
 
 ## Deprecations and Removals
@@ -88,107 +34,55 @@ feedback!
 
 -->
 
-## Metrics Changes
+## Metrics
 
 <!-- Add here -->
 
-### Added metrics
+### Added Metrics
 
 <!-- Add here -->
 
-### Removed metrics
+### Removed Metrics
 
 <!-- Add here -->
 
-### Deprecated/changed metrics
+### Deprecated/Changed Metrics
 
 <!-- Add here -->
 
-## Notable Features
+## Changes by Kind
 
-### Stable
+### API Change
 
-<!-- Add here -->
-
-### Beta
+#### Stable
 
 <!-- Add here -->
 
-### Alpha
+#### Beta
 
 <!-- Add here -->
 
-### Staging Repositories
+#### Alpha
 
 <!-- Add here -->
 
-### CLI Improvements
+### Feature
 
 <!-- Add here -->
 
-### Misc
+### Design
 
 <!-- Add here -->
 
-## API Changes
+### Documentation
 
 <!-- Add here -->
 
-## Other notable changes
-
-### API Machinery
+### Failing Test
 
 <!-- Add here -->
 
-### Apps
-
-<!-- Add here -->
-
-### Auth
-
-<!-- Add here -->
-
-### Autoscaling
-
-<!-- Add here -->
-
-### CLI
-
-<!-- Add here -->
-
-### Cloud Provider
-
-<!-- Add here -->
-
-### Cluster Lifecycle
-
-<!-- Add here -->
-
-### Instrumentation
-
-<!-- Add here -->
-
-### Network
-
-<!-- Add here -->
-
-### Node
-
-<!-- Add here -->
-
-### Release
-
-<!-- Add here -->
-
-### Scheduling
-
-<!-- Add here -->
-
-### Storage
-
-<!-- Add here -->
-
-### Windows
+### Other (Bug, Cleanup of Flake)
 
 <!-- Add here -->
 


### PR DESCRIPTION
As a follow-up of https://github.com/kubernetes/release/pull/923, we
should also improve the release notes template to make the work easier
for the release notes team and have a uniform layout of the release
notes.

/cc @evillgenius75  @justaugustus