### PR TITLE
added full file path to assets example

### DIFF
--- a/release-team/role-handbooks/release-notes/patch-notes.md
+++ b/release-team/role-handbooks/release-notes/patch-notes.md
@@ -28,9 +28,9 @@ After you successfully run the Release Notes tool, make sure the resulting file 
 
 You'll need to update the Typescript file that filters notes per release -- just add the patch release entry to the list:
 
-Example: `'assets/release-notes-1.15.3.json'`
+Example: `'src/assets/release-notes-1.15.3.json'`
 
-[assets.ts](https://github.com/kubernetes-sigs/release-notes/blob/master/src/environments/assets.ts)
+[src/environments/assets.ts](https://github.com/kubernetes-sigs/release-notes/blob/master/src/environments/assets.ts)
 
 Lastly, prepare (prettify) the JSON file, using the following commands:
 


### PR DESCRIPTION
Made a small update for clarity. Added the full src path to the example in the patch release. The example now lists `src/environments/assets.ts` instead of just `assets.ts` 