### PR TITLE
Simplify release notes template to match current layout

### DIFF
--- a/release-team/role-handbooks/release-notes/relnotes-template.md
+++ b/release-team/role-handbooks/release-notes/relnotes-template.md
@@ -1,6 +1,6 @@
-<!-- TODO: change the version number -->
+<!-- TODO: change the previous version number -->
 
-# Kubernetes vX.XX.0 Release Notes
+## Changelog since v1.x.0
 
 A complete changelog for the release notes is now hosted in a customizable
 format at [https://relnotes.k8s.io][1]. Check it out and please give us your
@@ -8,7 +8,7 @@ feedback!
 
 <!-- TODO: change the version number -->
 
-[1]: https://relnotes.k8s.io/?releaseVersions=X.XX.0
+[1]: https://relnotes.k8s.io/?releaseVersions=1.x.0
 
 ## What’s New (Major Themes)
 
@@ -18,73 +18,18 @@ feedback!
 
 <!-- Add issues from known issues bucket (known-issues-bucket.md) here -->
 
+<!-- Insert the generated release notes here. Usually they look like:
 ## Urgent Upgrade Notes
-
 ### (No, really, you MUST read this before you upgrade)
-
-<!-- Add here -->
-
-## Deprecations and Removals
-
-<!-- Add in the format
-
-- Component
-  - deprecation
-  - removal
-
--->
-
-## Metrics
-
-<!-- Add here -->
-
-### Added Metrics
-
-<!-- Add here -->
-
-### Removed Metrics
-
-<!-- Add here -->
-
-### Deprecated/Changed Metrics
-
-<!-- Add here -->
-
 ## Changes by Kind
-
+### Deprecation
 ### API Change
-
-#### Stable
-
-<!-- Add here -->
-
-#### Beta
-
-<!-- Add here -->
-
-#### Alpha
-
-<!-- Add here -->
-
 ### Feature
-
-<!-- Add here -->
-
 ### Design
-
-<!-- Add here -->
-
 ### Documentation
-
-<!-- Add here -->
-
 ### Failing Test
-
-<!-- Add here -->
-
-### Other (Bug, Cleanup of Flake)
-
-<!-- Add here -->
+### Other (Bug, Cleanup or Flake)
+-->
 
 ## Dependencies
 


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

We now use mostly the generated layout, but still keep section like the
major themes or the known issues.

**Which issue(s) this PR fixes**:

None

**Special notes for your reviewer**:
/cc @kubernetes/sig-release 