### PR TITLE
Update SIG Docs release handbook

### DIFF
--- a/release-team/role-handbooks/docs/README.md
+++ b/release-team/role-handbooks/docs/README.md
@@ -11,7 +11,7 @@ This document covers the responsibilities, time commitments, and timeline for Do
 | [current release]    | Active Kubernetes release                   | 1.13                                                     |
 | [future release]     | Release that the team is actively composing | 1.14                                                     |
 | [integration branch] | A PR [WIP] merging dev branch into master   | [link](https://github.com/kubernetes/website/pull/11401) |
-| ⚠️                    | Stresses extra importance                   |                                                          |
+|  ⚠️                   | Stresses extra importance                   |                                                          |
 
 ## Docs Lead Responsibilities
 
@@ -24,7 +24,7 @@ Responsibilities include:
 * Working with contributors to modify existing docs to accurately represent any upcoming changes
 * Providing weekly updates to the Release Team about the current state of release-bound docs
 * Introducing and mentoring Docs Lead Shadows to this process and empowering them with the knowledge needed to be future Docs Leads
-* Reviewing documentation PRs to ensure quality following our [Documentation Style Guide](https://kubernetes.io/docs/contribute/style/style-guide/)
+* Reviewing documentation PRs to ensure quality following the website [Style Guide](https://kubernetes.io/docs/contribute/style/style-guide/)
 * Migrating the old website [version] documentation and updating it with the new release
 * Communicating changes with all of the localization branches in order to stay synced across repositories
 * Updating these instructions with each release
@@ -41,9 +41,9 @@ A release is usually 12 weeks long. In general, there's a lot of work in the fir
 
 General time requirements for leads and shadows are:
 
-- 1/2 hour to 2 hours a day, reviewing incoming enhancements, tracking documentation PRs, and monitoring Slack
-- 1-2 hours a week to attend the majority of Release Team (weekly) and Burndown meetings (daily during Code Freeze), subject to time zone appropriateness
-- 1 hour weekly to attend [SIG Docs meetings](https://github.com/kubernetes/community/tree/master/sig-docs#meetings) for status reports
+- ½ hour to 2 hours a day, reviewing incoming enhancements, tracking documentation PRs, and monitoring Slack
+- Between 1 and 2 hours a week to attend the majority of Release Team (weekly) and Burndown meetings (daily during Code Freeze), subject to time zone appropriateness
+- Up to 1 hour weekly to attend [SIG Docs meetings](https://github.com/kubernetes/community/tree/master/sig-docs#meetings) for status reports
 
 > Note: that the time commitment becomes greater closer to the release deadline, peaking during the final release day.
 
@@ -186,21 +186,54 @@ Find .5-1 hour of time to meet with shadows and explain the release process. Wal
 
 1. Add contacts to the shadows release docs, e.g: [https://bit.ly/k8s114-contacts](https://docs.google.com/spreadsheets/d/1BiGSLuCqjglQS1bJvpKk6rKFMciebPkUndzgDRnJsns/edit?ts=5c3bd42a#gid=0)
 
+#### Ensure access is set yp
+
 1. Make sure all shadows have edit access to the enhancement spreadsheet.
 
 1. As a lead, make sure you are part of the [milestone-maintainers](https://github.com/orgs/kubernetes/teams/milestone-maintainers) and [sig-docs-en-owners](https://github.com/orgs/kubernetes/teams/sig-docs-en-owners).
 
 1. You need push access to the Kubernetes website repo (contact a SIG Docs chair if you don't have it)
 
-    ⚠️ Open the [integration branch] by creating a pull request against `master` referencing the `dev-[future release]` branch. **This should be done by the Docs Lead**, e.g: the [Release 1.14](https://github.com/kubernetes/website/pull/13174) PR uses the branch `dev-1.14`.
+   ⚠️ Open the [integration branch] by creating a pull request against `master` referencing the `dev-[future release]` branch. **This should be done by the Docs Lead**, e.g: the [Release 1.14](https://github.com/kubernetes/website/pull/13174) PR uses the branch `dev-1.14`.
 
-    This release pull request (also known as the [integration branch]) serves as the base for individual, component enhancement PRs of the release. A [integration branch] lets you bundle and merge multiple PRs simultaneously.
+   This release pull request (also known as the [integration branch]) serves as the base for individual, component enhancement PRs of the release. A [integration branch] lets you bundle and merge multiple PRs simultaneously.
 
-    ⚠️ Add the label `do-not-merge/hold` to the PR.
+   ⚠️ Add the label `do-not-merge/hold` to the PR.
 
 1. First PR in `dev-[future release]`: Update config.toml to show `[future release]` as the current version and add the `[future release]` entry to the drop-down, e.g: [config.toml diff](https://github.com/kubernetes/website/commit/851ef58fa8413e47bb18a15de53d9556be8c53dd#diff-618063036395fe9ee107f22b46c9eade)
 
     The intent is that your new branch should be showing as the current version IN the new branch...
+
+#### Update the website configuration ahead of the release
+
+Update the main `config.toml` based on the version in _master_, ready for the pending release. PR those changes it against `dev-[future release]` branch (which should already exist - this is a good check!)
+
+```shell
+# Step 1
+# Do this on a fresh local clone OF YOUR FORK
+# It's OK to use SSH for the git URL if you know how to do that
+git clone https://github.com/yourGitHubUsername/website.git kubernetes-website
+cd kubernetes-website
+# Step 2
+# Add the upstream repo as a remote
+git remote add upstream https://github.com/kubernetes/website.git
+git checkout --track master
+git checkout -b config-toml-1.14 # change for the release you're making
+# Step 3
+# Edit config.toml to make the changes described above
+# save your changes
+git add config.toml
+git commit -m "Updated config.toml for 1.14 release"
+# Step 4
+# Check things look right
+git status
+git remote -v
+# Step 5
+# Push this new branch to your fork
+git push origin config-toml-1.14
+```
+
+Now create a pull request that targets the next release (here: _dev-1.14_) **not** _master_.
 
 ---
 
@@ -232,7 +265,7 @@ Keep the enhancement tracking spreadsheet up to date with review progress and me
 
 The spreadsheet can be used to track the current health of the docs for release. For example:
 
-![](pics/enhancement-tracking.png)
+![Sample spreadsheet](pics/enhancement-tracking.png)
 
 On the "Feature Stats" tab, a table was created to track the Doc Stats and then based on their category, in the other tab, assign a status "Green / Yellow /Red."
 
@@ -248,38 +281,47 @@ Reach out to release notes team to see if there's anything that might need docs 
 
 This allows us to avoid merge conflicts on release day with `dev-[future release]`.
 
-##### Periodically merge `master` into `dev-[future release]`
+##### ⚠️  Periodically merge `master` into `dev-[future release]`.
 
-⚠️ To merge `master` into `dev-[future release]` on your local fork:
+To merge `master` into `dev-[future release]` on your local fork:
 
-```
-$ git remote add upstream https://github.com/kubernetes/website.git
-$ git fetch upstream
-$ git checkout --track upstream/dev-[future release]
-$ git merge upstream/master
-$ git checkout -b merged-master-dev-[future release]
-$ git commit -m "merged master into dev-[future release] to keep in sync"
+```bash
+# Step 0 (if you don't already have a remote called "upstream")
+git remote add upstream https://github.com/kubernetes/website.git
+# Step 1
+git fetch upstream master
+# Step 2
+git checkout --track upstream/dev-[future release]
+# Step 3
+git pull --ff-only # make sure you're up to date
+# Step 4. You might see merge conflicts at this point.
+git merge upstream/master
 ## if needed: https://help.github.com/articles/resolving-a-merge-conflict-using-the-command-line/
 ## git add ...
-## git commit -m "resolving conflicts"
-$ git push origin merged-master-dev-[future release]
+## git merge --continue
+# Step 5
+git checkout -b merged-master-dev-[future release]
+# Step 6
+git commit -m "Merge master into dev-[future release] to keep in sync"
+# Step 6
+git push origin merged-master-dev-[future release]
 ```
 
-Submit a PR against upstream `dev-[future release]`  from your fork  `merged-master-dev-[future release]`. e.g [merge master into future release](https://github.com/kubernetes/website/pull/16225)
+Submit a PR against upstream `dev-[future release]` from your fork's branch `merged-master-dev-[future release]`. e.g. [merge master into future release](https://github.com/kubernetes/website/pull/16225).
 
-You may need to fix conflicts manually. If somebody has improved a page on master, and at the same time it has been updated in dev-1.14, we may need to figureout how to make those changes work together.
+You may need to fix conflicts manually. If somebody has improved a page on _master_, and at the same time it has been updated in the dev branch for the next release, we may need to figure out how to make those changes work together. If something comes up which isn't obvious, you can always abort the merge and reach out to SIG Docs for help.
 
-If something comes up which isn't obvious, you can always abort the merge and reach out to SIG Docs for help.
+When you have completed resolving the differences manually, run `git merge --continue` to complete the merge. Then carry on from step 5.
+
+⚠️  **Make sure that GitHub shows the PR passing tests**.
 
 #### Monitor PRs
-
-Monitor PRs raised against dev-[future release]
 
 Make a query showing all PRs raised against dev-[future release] and monitor that regularly, e.g: [1.14 search](https://github.com/kubernetes/website/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Aopen+base%3Adev-1.14+label%3Alanguage%2Fen)
 
 #### Enforce deadlines
 
-⚠️ Enforce deadlines. Communicate with SIGs via Slack and email lists to keep up to date on status.
+Enforce deadlines. Communicate with SIGs via Slack and email lists to keep up to date on status.
 
 #### Communicate major deadlines
 
@@ -306,7 +348,7 @@ Example notice:
 >
 > Thanks! Important dates for v1.14: https://github.com/kubernetes/sig-release/blob/master/releases/release-1.14/README.md#tldr
 >
-> ![](pics/meme-deadline.jpg)
+> ![Bring out your docs](pics/meme-deadline.jpg)
 
 #### Review PRs
 
@@ -316,11 +358,11 @@ Also review each PR for:
 
 - Check that the PR is in the `[future release]` milestone
 - Check that the KEP / enhancement is likely to land in `[future release]`.
-- Review PR commit histories, and make sure that PR commit histories contain only changes to files. It's especially important to **avoid revert commits**.Encourage developers to rebase any PRs with complicated commit histories.
-- Check that the PR has a technical LGTM
+- Review PR commit histories, and make sure that PR commit histories contain only changes to files. It's especially important to **avoid revert commits**. Encourage developers to rebase any PRs with complicated commit histories.
+- Check that the PR has a technical LGTM.
 - If no LGTM, assign `sig/*` labels (listed in the enhancement tracking spreadsheet) to help find technical reviewers.
 
-Style Guide Checklist (High to Low Level)
+##### Style Guide Checklist (High to Low Level)
 
 The [style guide](https://kubernetes.io/docs/contribute/style/style-guide/) consists of guidelines, not rules.
 
@@ -334,9 +376,9 @@ The [style guide](https://kubernetes.io/docs/contribute/style/style-guide/) cons
     - [Shortcodes](https://kubernetes.io/docs/contribute/style/style-guide/#shortcodes) for notes, cautions, and warnings
 - Make sure the content makes sense
     - Check spelling
-    - Consider the Style Guide's [best practices](https://kubernetes.io/docs/contribute/style/style-guide/#content-best-practices) and [patterns to avoid(https://kubernetes.io/docs/contribute/style/style-guide/#patterns-to-avoid)
+    - Consider the Style Guide's [best practices](https://kubernetes.io/docs/contribute/style/style-guide/#content-best-practices) and [patterns to avoid](https://kubernetes.io/docs/contribute/style/style-guide/#patterns-to-avoid)
 
-> Note: Most PR owners are **not** writers, and many are non-native / secondary English speakers. Missing commas or passive voice should **not** block a/LGTM if the content is accurate. If something really bugs you, make a note and open a PR to fix it later.
+> Note: Most PR owners are **not** writers, and many are non-native / secondary English speakers. Missing commas or passive voice should **not** block a /lgtm if the content is accurate. If something really bugs you, make a note and open a PR to fix it later.
 
 Once the above is met, comment the following on the PR:
 
@@ -345,18 +387,22 @@ Once the above is met, comment the following on the PR:
 /approve
 ```
 
+(you might already have /lgtm from the technical review stage; another /lgtm is fine if the prerequisites are already met).
+
 If you need help reviewing PRs, ask SIG Docs (#sig-docs channel on Slack) for help. The weekly [PR Wrangler](https://github.com/kubernetes/website/wiki/PR-Wranglers) is your best resource.
 
-> Note: PR's against the dev branch can merged at anytime assuming they meet the criteria. Be careful though that you don't merge a feature that might be pushed out to the next release. If that happens, you can revert - but it's better to avoid the mess all together.
+> Note: PR's against the dev branch can merged at any time assuming they meet the criteria. Be careful though that you don't merge a feature that might be pushed out to the next release. If that happens, you can revert - but it's better to avoid the mess all together.
+>
+> You can add /hold to mark a PR that should not merge until the matching code changes are already in.
 
 #### Nominate a Docs Lead for the Next Release
 
-⚠️ During Code Freeze pick a successor who has demonstrated the ability and understanding of the process.
+⚠️ During Code Freeze, pick a successor who has demonstrated the ability and understanding of the process.
 
 **Usually this is a Docs Lead Shadow that has beenon the team for 2 releases with a desire to continue with the SIG Docs.**
 
 - Reach out to the person you have in mind and confirm they are able to commit the time and effort for a successful release.
--  Once confirmed, inform the Release Team and the SIG-Docs Team.
+- Once confirmed, inform the Release Team and the SIG-Docs Team.
 
 If no suitable candidates are available, you may choose to lead again or nominate someone outside of the current release team (e.g: a recent Docs Lead).
 
@@ -371,6 +417,10 @@ If you need help in building the reference documentation, reach out on Slack #si
 
 #### Generate the reference documentation
 
+Update the generated documentation using a Python script ([Generating Reference Pages for Kubernetes Components and Tools](https://kubernetes.io/docs/contribute/generate-ref-docs/kubernetes-components/)). Before running the script, modify `reference.yml` to checkout the Kubernetes future release branch.
+
+![Update kubernetes release branch](pics/reference-yaml.png)
+
 The first step is to famialiarize yourself with the `website/updated-imported-docs/update-imported-docs.py` script
 and the instructions for ([Generating Reference Pages for Kubernetes Components and Tools](https://kubernetes.io/docs/contribute/generate-ref-docs/quickstart/)).
 
@@ -378,9 +428,11 @@ The reference documentation build depends upon a valid release tag.
 When a Kubernetes release candidate version tag such as `v1.19-rc.2` is created, you can consider building
 the reference documentation. Next:
 
-- Create a branch for this work based off of the dev-<release_num> branch.
+- Create a branch for this work based off of the dev-\<release_num\> branch.
 - Run the `update-imported-docs.py` script providing the release tag to build the reference documentation.
 - Commit the generated files.
+
+![Copy and rename screenshot](pics/copy-rename-dir.png)
 
 You can expect to maintain this branch with periodic updates to the reference documentation using the latest `rc` tag.
 Merge your branch to the dev-<release_num> branch just before the final release.
@@ -391,21 +443,20 @@ Note: You should not have to build the reference documentation for every release
 
 #### Update minor verison in api index page
 
-Update the <MINOR_VERSION> in `content/en/docs/reference/kubernetes-api/api-index.md` for the future release.
+#### Update minor verisons in api
 
-   ![update-api-index](pics/update-api-index.png)
+Update the `<MINOR_VERSION>` in `content/en/docs/reference/kubernetes-api/api-index.md` for the future release.
 
-#### Touch base with SIG Cluster Lifecycle (Kubeadm)
+   ![Update API index](pics/update-api-index.png)
 
-Validate that sig-cluster-lifecycle has all of the docs in place for the upcoming release. These are mainly Kubeadm docs (upgrading, installing, changes, etc). If unsure, send a message to their [Slack](https://kubernetes.slack.com/messages/sig-cluster-lifecycle/).
+#### Touch base with SIG Cluster Lifecycle (kubeadm)
 
-#### Stage "Sunset" PRs
+Validate that SIG Cluster Lifecycle has all of the docs in place for the upcoming release. These are mainly kubeadm docs (upgrading, installing, changes, etc). If unsure, send a message to their [Slack](https://kubernetes.slack.com/messages/sig-cluster-lifecycle/) channel.
 
-⚠️ Create the PRs needed to roll the docs to the new version on the dev branch
 
-#####  Update 4 past config.toml's
+##### Update 4 past config.toml's
 
-Create the updated config.toml's for the 4 previous releases. These need to be 4 PRs because they are all separate `release-` branches. **Make sure to update**  ```release-[current release]``` config.toml chinese localization configuration with ```deprecated = false```. e.g [chinese localization current](https://github.com/kubernetes/website/pull/16131)
+Create the updated `config.toml` files for the 4 previous releases. These need to be 4 separate PRs because each release has its own `release-` branch. ⚠️  **Make sure to update**  ```release-[current release]``` config.toml Chinese localization configuration with ```deprecated = false```. e.g [Chinese localization current](https://github.com/kubernetes/website/pull/16131)
 
 See this for example (1.13 was the "future release"):
 * 1.9 https://github.com/kubernetes/website/pull/11493
@@ -413,25 +464,15 @@ See this for example (1.13 was the "future release"):
 * 1.11 https://github.com/kubernetes/website/pull/11496
 * 1.12 https://github.com/kubernetes/website/pull/11497
 
-Also update the main `config.toml` in master for the pending release and PR it against `dev-[future release]`
+⚠️  DO NOT MERGE **ANY** OF THE `config.toml` PULL REQUESTS FOR PREVIOUS UNTIL THE RELEASE IS CONFIRMED
 
-```
-# ON LOCAL FORK
-$ git clone https://github.com/jimangel/website.git website-docs
-$ cd website-docs
-$ git remote add upstream https://github.com/kubernetes/website.git
-$ git checkout master
-$ git fetch upstream
-$ merge upstream/master
-$ checkout -b config-toml-1.14
-$ vi config.toml
-$ git add config.toml
-$ git commit -m "updated config.toml for 1.14"
-$ git remote -v
-$ git push origin config-toml-1.14
-```
+##### Deprecate links
 
-⚠️ DO NOT MERGE ANY OF THE CONFIG.TOML PRs UNTIL AFTER RELEASE
+- Deprecate the oldest API link in the reference docs, e.g: https://github.com/kubernetes/website/pull/13467
+- Update the index for the API reference docs, e.g: https://github.com/kubernetes/website/pull/14139
+
+> Note: These first two steps can be combined into one single PR. If done in a single PR, please update this handbook with examples.
+
 
 ---
 
@@ -447,7 +488,7 @@ Creating the release branch lets you snapshot the current docs in a new branch, 
 
 - From [k/website](https://github.com/kubernetes/website) click on `master` branch.
 - Type the name of the release branch.
-- **click** Create branch release-x.xx from master
+- **click** Create branch _release-x.xx_ from master
 
 ![](pics/new-branch.png)
 
@@ -455,19 +496,28 @@ Creating the release branch lets you snapshot the current docs in a new branch, 
 
 To merge `master` into `release-[current release]` on your local fork:
 
+```shell
+# Step 0 (if you don't already have a remote called "upstream")
+git remote add upstream https://github.com/kubernetes/website.git
+# Step 1
+git fetch upstream master
+# Step 2
+git checkout --track upstream/release-[current release]
+# Step 3
+git merge upstream/master
+# Step 4
+git checkout -b merged-master-release-[current release]
+# Step 5
+git commit -m "Merge master into release-[current release] to keep in sync"
+# Step 6
+git push origin merged-master-release-[current release]
 ```
-$ git remote add upstream https://github.com/kubernetes/website.git
-$ git fetch upstream
-$ git checkout --track upstream/release-[current release]
-$ git merge upstream/master
-$ git checkout -b merged-master-release-[current release]
-$ git commit -m "merged master into release-[current release] to keep in sync"
-$ git push origin merged-master-release-[current release]
-```
+
+Now create a pull request to merge the new branch you've made into the _release-[current-release]_ branch on [k/website](https://github.com/kubernetes/website).
 
 #### Update Netlify
 
-Update the Netlify configuration. (A [SIG Docs chair](https://github.com/kubernetes/community/tree/master/sig-docs#leadership) can assist you with access):
+Update the Netlify configuration. (A SIG Docs [chair](https://github.com/kubernetes/community/tree/master/sig-docs#leadership) or tech lead can assist you with access):
 
 Login to [Netlify](https://app.netlify.com/) and navigate to the Sites tab.
 
@@ -479,10 +529,10 @@ Login to [Netlify](https://app.netlify.com/) and navigate to the Sites tab.
 
 #### Freeze Kubernetes website
 
-24 hours before the release, freeze the repo. No PRs allowed to merge AT ALL until the release PR has successfully merged.
+24 hours before the release, freeze the repo: ⚠️  no PRs allowed to merge AT ALL until the release PR has successfully merged.
 
 - Submit an issue with `tide/merge-blocker` label.
-- Submit a freeze announcement following [our protocol](#communicate-major-deadlines)
+- Submit a freeze announcement following our [protocol](#communicate-major-deadlines)
 
 #### Inform localization teams
 
@@ -498,11 +548,12 @@ Review milestone for completion and outstanding PRs. For PRs that won't make the
 
 ### Release Day
 
+⚠️  Everything in this section is important. It's OK to ask for advice if you're not sure.
 ---
 
 This process takes approximately 4 hours.
 
-Coordinate with the Release team for the exact timing. Typically the release is 'officially' built, then you merge the docs, and then you approve the blog post to "make it official." For 1.14 we merged docs at 2:30 EST and the blog was approved at 3 EST - marking the release "complete."
+Coordinate with the Release team for the exact timing. Typically the release is 'officially' built, then you merge the docs, and then you approve the blog post to "make it official." For 1.14 we merged docs at 2:30 EST and the blog was approved at 3 EST - marking the release "complete".
 
 #### Merge `master`
 
@@ -514,16 +565,22 @@ Coordinate with the Release team for the exact timing. Typically the release is 
 
 Tag the commit hash before the [integration branch] as the final commit for [current release].
 
-> Note: This can be done at anytime post release.
+> Note: This can be done at any time post release.
 
+```shell
+git clone https://github.com/kubernetes/website/
+cd website
+git checkout master
 ```
-$ git clone <k/website>
-
-$ git checkout master
+```
 Switched to branch 'master'
 Your branch is up to date with 'origin/master'.
-
-$ git log --pretty=format:"%h - %an, %ar : %s"
+```
+Check the commit log
+```shell
+git log --pretty=format:"%h - %an, %ar : %s"
+```
+```
 6c41db7e6 - Lubomir I. Ivanov, 2 hours ago : kubeadm-ts: add entry about patching kube-proxy in CCM scenarios (#13033)
 6b8e14642 - Patrick Lang, 4 hours ago : Fix markdown around \ for file paths (#13404)
 f024de7d3 - Noah Kantrowitz, 4 hours ago : Typo fix in a docs link. (#13405)
@@ -531,11 +588,12 @@ f024de7d3 - Noah Kantrowitz, 4 hours ago : Typo fix in a docs link. (#13405)
 ef6c80a0e - Kaitlyn Barnard, 5 hours ago : 1.14 Blog Post (#13400)
 851ef58fa - Jim Angel, 5 hours ago : Official 1.14 Release Docs (#13174)
 28dd4d515 - evilyeti, 7 hours ago : Fixed broken link in E2E Testing blog
-
-$ git tag -a snapshot-final-v1.13 28dd4d515 -m "Release 1.13 final snapshot"
-$ git tag -a snapshot-initial-v1.14 851ef58fa -m "Release 1.14 initial snapshot"
-
-$ git push --tags origin master
+```
+If that looks how you expect:
+```shell
+git tag -a snapshot-final-v1.13 28dd4d515 -m "Release 1.13 final snapshot"
+git tag -a snapshot-initial-v1.14 851ef58fa -m "Release 1.14 initial snapshot"
+git push --tags origin master
 ```
 
 After creating the tags, you can create a release based off of a tag very easily. Follow the naming conventions as done before and update: https://github.com/kubernetes/website/releases
@@ -545,7 +603,7 @@ After creating the tags, you can create a release based off of a tag very easily
 
 #### Unfreeze
 
-Unfreeze the repo as done earlier (remove the `tide/merge-blocker` and close issue)
+Unfreeze the repo as done earlier (remove the `tide/merge-blocker` label and close issue).
 
 #### Close the [future release] milestone.
 
@@ -553,6 +611,7 @@ Unfreeze the repo as done earlier (remove the `tide/merge-blocker` and close iss
 - Create a PR to update k/website's release notes
   - ex: https://raw.githubusercontent.com/kubernetes/kubernetes/master/CHANGELOG-1.14.md will be merged into content/en/docs/setup/release/notes.md
   - ex PR: https://github.com/kubernetes/website/pull/13416
+- Find the open milestone for [future release] and close it.
 
 ---
 
@@ -582,22 +641,23 @@ Manually update the Kubernetes website release notes changelog from the actual [
 
 ⚠️ Create a working branch (Named `dev-[future FUTURE release]`, for example `dev-1.15`) locally, based on master. Push it to upstream.
 
-```
+```shell
+# This example is for a future release version 1.15
 git clone https://github.com/kubernetes/website.git
 git checkout -b dev-1.15
-git commit --allow-empty -m "initial commit"
+git commit --allow-empty -m "Tracking commit for v1.15 docs"
 git push -u origin dev-1.15
 ```
 
-Enable branch protection on the new `dev-` branch and deprecate the older one, e.g: https://github.com/kubernetes/test-infra/pull/11984
+Enable branch protection on the new `dev-` branch, and deprecate the older one; for an example, see: https://github.com/kubernetes/test-infra/pull/11984
 
-#### Create milstone
+#### Create milestone
 
-Create milestone for NEW upcoming release. Depending on your permissions, you might need to contact a SIG Docs maintainer. Move anything missed for the current release to the new milestone.
+Create a milestone for NEW upcoming release. Depending on your permissions, you might need to contact a SIG Docs maintainer. Move anything missed for the current release to the new milestone.
 
 #### Update Netlify
 
-Update  Netlify (contact a [SIG Docs chair](https://github.com/kubernetes/community/tree/master/sig-docs#leadership) if you do not have access and they can assist with this):
+Update Netlify (contact a SIG Docs [chair](https://github.com/kubernetes/community/tree/master/sig-docs#leadership) if you do not have access and they can assist with this):
 
 Login to [Netlify](https://app.netlify.com/) and navigate to the Sites tab.
 
@@ -615,13 +675,9 @@ Login to [Netlify](https://app.netlify.com/) and navigate to the Sites tab.
 
 Announce that `[future release]` branch is open for new feature docs on slack #sig-docs.
 
-#### Update template
-
-Make a PR against master to edit the [pull request template](https://github.com/kubernetes/kubernetes.github.io/blob/master/.github/PULL_REQUEST_TEMPLATE.md) to give advice about raising `[future release]`-related PRs against the `[future release]` branch. Example: https://github.com/kubernetes/website/pull/8057
-
 #### Reassign issues
 
-⚠️ Assign any issues / feature / PRs (that missed the release) to the new Docs Lead
+⚠️  Assign any issues / feature / PRs (that missed the release) to the new Docs Lead
 
 ### Celebrate! 🎉
 
@@ -636,6 +692,7 @@ Special thanks to contibutors to this document, including:
 * Jared Bhatti
 * Jennifer Rondeau
 * Misty Linville
+* Tim Bannister
 * Tim Fogarty
 * Zach Arnold
 * Zach Corleissen

--- a/release-team/role-handbooks/docs/README.md
+++ b/release-team/role-handbooks/docs/README.md
@@ -186,7 +186,7 @@ Find .5-1 hour of time to meet with shadows and explain the release process. Wal
 
 1. Add contacts to the shadows release docs, e.g: [https://bit.ly/k8s114-contacts](https://docs.google.com/spreadsheets/d/1BiGSLuCqjglQS1bJvpKk6rKFMciebPkUndzgDRnJsns/edit?ts=5c3bd42a#gid=0)
 
-#### Ensure access is set yp
+#### Ensure access is set up
 
 1. Make sure all shadows have edit access to the enhancement spreadsheet.
 
@@ -194,7 +194,7 @@ Find .5-1 hour of time to meet with shadows and explain the release process. Wal
 
 1. You need push access to the Kubernetes website repo (contact a SIG Docs chair if you don't have it)
 
-   ⚠️ Open the [integration branch] by creating a pull request against `master` referencing the `dev-[future release]` branch. **This should be done by the Docs Lead**, e.g: the [Release 1.14](https://github.com/kubernetes/website/pull/13174) PR uses the branch `dev-1.14`.
+   ⚠️ (**This should be done by the Docs Lead**) Open the [integration branch] by creating a pull request against `master` referencing the `dev-[future release]` branch e.g., the [Release 1.14](https://github.com/kubernetes/website/pull/13174) PR uses the branch `dev-1.14`.
 
    This release pull request (also known as the [integration branch]) serves as the base for individual, component enhancement PRs of the release. A [integration branch] lets you bundle and merge multiple PRs simultaneously.
 
@@ -206,7 +206,7 @@ Find .5-1 hour of time to meet with shadows and explain the release process. Wal
 
 #### Update the website configuration ahead of the release
 
-Update the main `config.toml` based on the version in _master_, ready for the pending release. PR those changes it against `dev-[future release]` branch (which should already exist - this is a good check!)
+Update the main `config.toml` based on the version on the `master` branch. Open a PR for these changes against the `dev-[future release]` branch (which should already exist - this is a good check!)
 
 ```shell
 # Step 1
@@ -233,7 +233,7 @@ git remote -v
 git push origin config-toml-1.14
 ```
 
-Now create a pull request that targets the next release (here: _dev-1.14_) **not** _master_.
+Now create a pull request that targets the next release (here: `dev-1.14`) **not** `master`.
 
 ---
 
@@ -307,21 +307,21 @@ git commit -m "Merge master into dev-[future release] to keep in sync"
 git push origin merged-master-dev-[future release]
 ```
 
-Submit a PR against upstream `dev-[future release]` from your fork's branch `merged-master-dev-[future release]`. e.g. [merge master into future release](https://github.com/kubernetes/website/pull/16225).
+Submit a PR against upstream `dev-[future release]` from your fork's branch `merged-master-dev-[future release]`. e.g., [merge master into future release](https://github.com/kubernetes/website/pull/16225).
 
-You may need to fix conflicts manually. If somebody has improved a page on _master_, and at the same time it has been updated in the dev branch for the next release, we may need to figure out how to make those changes work together. If something comes up which isn't obvious, you can always abort the merge and reach out to SIG Docs for help.
+You may need to fix conflicts manually. If somebody has improved a page on `master`, and at the same time it has been updated in the dev branch for the next release, we may need to figure out how to make those changes work together. If something comes up which isn't obvious, you can always abort the merge and reach out to SIG Docs for help.
 
 When you have completed resolving the differences manually, run `git merge --continue` to complete the merge. Then carry on from step 5.
 
-⚠️  **Make sure that GitHub shows the PR passing tests**.
+⚠️  **Ensure the PR is passing tests on GitHub**.
 
 #### Monitor PRs
 
-Make a query showing all PRs raised against dev-[future release] and monitor that regularly, e.g: [1.14 search](https://github.com/kubernetes/website/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Aopen+base%3Adev-1.14+label%3Alanguage%2Fen)
+Make a query showing all PRs raised against dev-[future release] and monitor that regularly e.g., [1.14 search](https://github.com/kubernetes/website/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Aopen+base%3Adev-1.14+label%3Alanguage%2Fen)
 
 #### Enforce deadlines
 
-Enforce deadlines. Communicate with SIGs via Slack and email lists to keep up to date on status.
+Enforce deadlines. Communicate with SIGs via Slack and email lists to keep everyone up-to-date on status.
 
 #### Communicate major deadlines
 
@@ -402,7 +402,7 @@ If you need help reviewing PRs, ask SIG Docs (#sig-docs channel on Slack) for he
 **Usually this is a Docs Lead Shadow that has beenon the team for 2 releases with a desire to continue with the SIG Docs.**
 
 - Reach out to the person you have in mind and confirm they are able to commit the time and effort for a successful release.
-- Once confirmed, inform the Release Team and the SIG-Docs Team.
+- Once confirmed, inform the Release Team and the SIG Docs Team.
 
 If no suitable candidates are available, you may choose to lead again or nominate someone outside of the current release team (e.g: a recent Docs Lead).
 
@@ -428,7 +428,7 @@ The reference documentation build depends upon a valid release tag.
 When a Kubernetes release candidate version tag such as `v1.19-rc.2` is created, you can consider building
 the reference documentation. Next:
 
-- Create a branch for this work based off of the dev-\<release_num\> branch.
+- Create a branch for this work based off of the dev-[future branch].
 - Run the `update-imported-docs.py` script providing the release tag to build the reference documentation.
 - Commit the generated files.
 
@@ -441,9 +441,9 @@ and merge to the master branch.
 
 Note: You should not have to build the reference documentation for every release candidate version.
 
-#### Update minor verison in api index page
+#### Update minor version on API index page
 
-#### Update minor verisons in api
+#### Update minor versions in API
 
 Update the `<MINOR_VERSION>` in `content/en/docs/reference/kubernetes-api/api-index.md` for the future release.
 
@@ -454,7 +454,7 @@ Update the `<MINOR_VERSION>` in `content/en/docs/reference/kubernetes-api/api-in
 Validate that SIG Cluster Lifecycle has all of the docs in place for the upcoming release. These are mainly kubeadm docs (upgrading, installing, changes, etc). If unsure, send a message to their [Slack](https://kubernetes.slack.com/messages/sig-cluster-lifecycle/) channel.
 
 
-##### Update 4 past config.toml's
+##### Update the `config.toml`s for the past four releases
 
 Create the updated `config.toml` files for the 4 previous releases. These need to be 4 separate PRs because each release has its own `release-` branch.
 
@@ -468,8 +468,8 @@ See this for example (1.13 was the "future release"):
 
 ##### Deprecate links
 
-- Deprecate the oldest API link in the reference docs, e.g: https://github.com/kubernetes/website/pull/13467
-- Update the index for the API reference docs, e.g: https://github.com/kubernetes/website/pull/14139
+- Deprecate the oldest API link in the reference docs e.g., https://github.com/kubernetes/website/pull/13467
+- Update the index for the API reference docs e.g., https://github.com/kubernetes/website/pull/14139
 
 > Note: These first two steps can be combined into one single PR. If done in a single PR, please update this handbook with examples.
 
@@ -488,7 +488,7 @@ Creating the release branch lets you snapshot the current docs in a new branch, 
 
 - From [k/website](https://github.com/kubernetes/website) click on `master` branch.
 - Type the name of the release branch.
-- **click** Create branch _release-x.xx_ from master
+- **click** Create branch `release-x.yy` from `master`
 
 ![](pics/new-branch.png)
 
@@ -513,11 +513,11 @@ git commit -m "Merge master into release-[current release] to keep in sync"
 git push origin merged-master-release-[current release]
 ```
 
-Now create a pull request to merge the new branch you've made into the _release-[current-release]_ branch on [k/website](https://github.com/kubernetes/website).
+Now create a pull request to merge the new branch you've made into the `release-[current-release]` branch on [k/website](https://github.com/kubernetes/website).
 
 #### Update Netlify
 
-Update the Netlify configuration. (A SIG Docs [chair](https://github.com/kubernetes/community/tree/master/sig-docs#leadership) or tech lead can assist you with access):
+Update the Netlify configuration. (A [SIG Docs Chair or Technical Lead](https://git.k8s.io/community/sig-docs#leadership) can assist you with access):
 
 Login to [Netlify](https://app.netlify.com/) and navigate to the Sites tab.
 
@@ -529,10 +529,10 @@ Login to [Netlify](https://app.netlify.com/) and navigate to the Sites tab.
 
 #### Freeze Kubernetes website
 
-24 hours before the release, freeze the repo: ⚠️  no PRs allowed to merge AT ALL until the release PR has successfully merged.
+24 hours before the release, freeze the repo: ⚠️  no PRs should be allowed to merge AT ALL until the release PR has successfully merged.
 
 - Submit an issue with `tide/merge-blocker` label.
-- Submit a freeze announcement following our [protocol](#communicate-major-deadlines)
+- Submit a freeze announcement following our [protocols](#communicate-major-deadlines)
 
 #### Inform localization teams
 
@@ -553,7 +553,7 @@ Review milestone for completion and outstanding PRs. For PRs that won't make the
 
 This process takes approximately 4 hours.
 
-Coordinate with the Release team for the exact timing. Typically the release is 'officially' built, then you merge the docs, and then you approve the blog post to "make it official." For 1.14 we merged docs at 2:30 EST and the blog was approved at 3 EST - marking the release "complete".
+Coordinate with the Release Team for the exact timing. Typically the release is 'officially' built, then you merge the docs, and then you approve the blog post to "make it official". For 1.14, we merged docs at 2:30 EST and the blog was approved at 3 EST - marking the release "complete".
 
 #### Merge `master`
 
@@ -565,7 +565,7 @@ Coordinate with the Release team for the exact timing. Typically the release is 
 
 Tag the commit hash before the [integration branch] as the final commit for [current release].
 
-> Note: This can be done at any time post release.
+> Note: This can be done at any time post-release.
 
 ```shell
 git clone https://github.com/kubernetes/website/
@@ -657,7 +657,7 @@ Create a milestone for NEW upcoming release. Depending on your permissions, you 
 
 #### Update Netlify
 
-Update Netlify (contact a SIG Docs [chair](https://github.com/kubernetes/community/tree/master/sig-docs#leadership) if you do not have access and they can assist with this):
+Update Netlify (contact a [SIG Docs Chair or Technical Lead](https://git.k8s.io/community/sig-docs#leadership) if you do not have access and they can assist with this):
 
 Login to [Netlify](https://app.netlify.com/) and navigate to the Sites tab.
 

--- a/release-team/role-handbooks/docs/README.md
+++ b/release-team/role-handbooks/docs/README.md
@@ -456,7 +456,7 @@ Validate that SIG Cluster Lifecycle has all of the docs in place for the upcomin
 
 ##### Update 4 past config.toml's
 
-Create the updated `config.toml` files for the 4 previous releases. These need to be 4 separate PRs because each release has its own `release-` branch. ⚠️  **Make sure to update**  ```release-[current release]``` config.toml Chinese localization configuration with ```deprecated = false```. e.g [Chinese localization current](https://github.com/kubernetes/website/pull/16131)
+Create the updated `config.toml` files for the 4 previous releases. These need to be 4 separate PRs because each release has its own `release-` branch.
 
 See this for example (1.13 was the "future release"):
 * 1.9 https://github.com/kubernetes/website/pull/11493


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind cleanup
> /kind design

/kind documentation
> /kind feature

**What this PR does / why we need it**:
This PR started out as one kind of cleanup, things happened, and now it's more general tidying.
Notably, the update to `config.toml` for the next release's dev branch now happens early in the cycle, it's one of the first tasks for a new docs release lead.


**Special notes for your reviewer**:
