### PR TITLE
Use markdown headers for pull request and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -10,15 +10,15 @@ labels: kind/bug, sig/release
 If the matter is security related, please disclose it privately via https://kubernetes.io/security/
 -->
 
-**What happened**:
+#### What happened:
 
-**What you expected to happen**:
+#### What you expected to happen:
 
-**How to reproduce it (as minimally and precisely as possible)**:
+#### How to reproduce it (as minimally and precisely as possible):
 
-**Anything else we need to know?**:
+#### Anything else we need to know?:
 
-**Environment**:
+#### Environment:
 
 - Cloud provider or hardware configuration:
 - OS (e.g: `cat /etc/os-release`):

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -6,6 +6,6 @@ labels: kind/feature, sig/release
 ---
 <!-- Please only use this template for submitting feature requests -->
 
-**What would you like to be added**:
+#### What would you like to be added:
 
-**Why is this needed**:
+#### Why is this needed:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,21 +7,24 @@ https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-k
 - If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
 -->
 
-**What type of PR is this?**
-> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
+#### What type of PR is this:
+
+> Uncomment only one `/kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
 >
 > /kind cleanup
 > /kind design
 > /kind documentation
 > /kind feature
 
-**What this PR does / why we need it**:
+#### What this PR does / why we need it:
 
-**Which issue(s) this PR fixes**:
+#### Which issue(s) this PR fixes:
+
 <!--
 *Automatically closes linked issue when PR is merged.
 Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
 -->
+
 Fixes #
 
-**Special notes for your reviewer**:
+#### Special notes for your reviewer:


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

This allows a better automatic formatting without having the need of
taking manually added newlines into account.

For example, it looks weird if I do not add a newline after the "headers", like:
```markdown
**What this PR does / why we need it**:
My explanation
```
renders:
https://gist.github.com/saschagrunert/843ce4256e0d21420c8b70b24aac7c43

If we now use real markdown headers, then we have some sort of auto-linebreak:
```
#### Which issue(s) this PR fixes:
Fixes #
```
renders:
https://gist.github.com/saschagrunert/fafe1797c4f97d0a3e1d660229f0d94e

This should result in much cleaner PRs from a layout perspective. 
We already use it in CRI-O, demo: https://github.com/cri-o/cri-o/pull/3383

**Which issue(s) this PR fixes**:

Relates to https://github.com/kubernetes/release/pull/1166

**Special notes for your reviewer**:

None

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```
