### PR TITLE
April 2020 patch release schedule

### DIFF
--- a/releases/patch-releases.md
+++ b/releases/patch-releases.md
@@ -43,10 +43,11 @@ for the next patch release.
 
 ### 1.17
 
-Next patch release is **1.17.4**.
+Next patch release is **1.17.5**.
 
 | Patch Release | Cherry-picks deadline | Target date |
 | --- | --- | --- |
+| 1.17.5 | 2020-04-13 | 2020-04-16 |
 | 1.17.4 | 2020-03-09 | 2020-03-12 |
 | 1.17.3 | 2020-02-07 | 2020-02-11 |
 | 1.17.2 | [No-op release](https://groups.google.com/d/topic/kubernetes-dev/Mhpx-loSBns/discussion) | 2020-01-21 |
@@ -54,10 +55,11 @@ Next patch release is **1.17.4**.
 
 ### 1.16
 
-Next patch release is **1.16.8**.
+Next patch release is **1.16.9**.
 
 | Patch Release | Cherry-picks deadline | Target date |
 | --- | --- | --- |
+| 1.16.9 | 2020-04-13 | 2020-04-16 |
 | 1.16.8 | 2020-03-09 | 2020-03-12 |
 | 1.16.7 | 2020-02-07 | 2020-02-11 |
 | 1.16.6 | [No-op release](https://groups.google.com/d/topic/kubernetes-dev/Mhpx-loSBns/discussion) | 2020-01-21 |
@@ -69,10 +71,11 @@ Next patch release is **1.16.8**.
 
 ### 1.15
 
-Next patch release is **1.15.11**.
+Next patch release is **1.15.12**.
 
 | Patch Release | Cherry-picks deadline | Target date |
 | --- | --- | --- |
+| 1.15.12 | 2020-04-13 | 2020-04-16 |
 | 1.15.11 | 2020-03-09 | 2020-03-12 |
 | 1.15.10 | 2020-02-07 | 2020-02-11 |
 | 1.15.9 | [No-op release](https://groups.google.com/d/topic/kubernetes-dev/Mhpx-loSBns/discussion) | 2020-01-21 |


### PR DESCRIPTION
Update schedule for next month's patch release targets.  Likely at least
a 1.18.1 (if not also 1.18.2) will come in also during this time.  And
this is probably the last patch release for 1.15.x.

Signed-off-by: Tim Pepper <tpepper@vmware.com>

/kind documentation
/area release-eng