### PR TITLE
github/template: update cut issue template to use krel in the release steps

### DIFF
--- a/.github/ISSUE_TEMPLATE/cut-release.md
+++ b/.github/ISSUE_TEMPLATE/cut-release.md
@@ -6,8 +6,8 @@ labels: sig/release, area/release-eng
 ---
 ## Scheduled to happen: <!-- Tue, 2019-02-26 -->
 
-<!-- 
-- Add/Remove items of the checklist as you see fit 
+<!--
+- Add/Remove items of the checklist as you see fit
 - Post bumps or issues encountered along the way
 -->
 
@@ -27,10 +27,10 @@ see template below, example: https://github.com/kubernetes/sig-release/issues/84
 
 | Step | Command | Link | Start | Duration | Succeeded? |
 | --- | --- | --- | --- | --- | --- |
-| Mock stage | `./gcbmgr stage [arguments]` | <!-- link-to-MOCK-gcb-stage-run --> |  |  |  |
-| Mock release | `./gcbmgr release [arguments]` | <!-- link-to-MOCK-gcb-release-run --> |  |  |  |
-| Stage | `./gcbmgr stage [arguments]` | <!-- link-to-REAL-gcb-stage-run --> |  |  |  |
-| Release | `./gcbmgr release [arguments]` | <!-- link-to-REAL-gcb-release-run --> |  |  |  |
+| Mock stage | `krel gcbmgr --stage [arguments]` | <!-- link-to-MOCK-gcb-stage-run --> |  |  |  |
+| Mock release | `krel gcbmgr --release [arguments]` | <!-- link-to-MOCK-gcb-release-run --> |  |  |  |
+| Stage | `krel gcbmgr --stage [arguments]` | <!-- link-to-REAL-gcb-stage-run --> |  |  |  |
+| Release | `krel gcbmgr --release [arguments]` | <!-- link-to-REAL-gcb-release-run --> |  |  |  |
 | Cut packages <!-- not required for pre-releases (alpha, beta, rc) --> | -- | -- |  |  |  |
 | Notify | -- | <!-- link-to-kubernetes-announce-list-thread --> |  | -- |  |
 


### PR DESCRIPTION
#### What type of PR is this:
/kind cleanup

#### What this PR does / why we need it:
Update the cut issue template to use `krel` instead of `./gcbmgr` in the release steps section.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

#### Special notes for your reviewer:

/cc @justaugustus @saschagrunert @hasheddan 