### PR TITLE
release schedule: add April targets for 1.18.1 and 1.18.2

### DIFF
--- a/releases/patch-releases.md
+++ b/releases/patch-releases.md
@@ -41,6 +41,15 @@ for the next patch release.
 
 ## Timelines
 
+### 1.18
+
+Next patch release is **1.18.1**.
+
+| Patch Release | Cherry-picks deadline | Target date |
+| --- | --- | --- |
+| 1.18.2 | 2020-04-13 | 2020-04-16 |
+| 1.18.1 | 2020-04-06 | 2020-04-08 |
+
 ### 1.17
 
 Next patch release is **1.17.5**.


### PR DESCRIPTION
We're on track for a set of .1 bugfixes for 1.18, and then aim to have
that branch sync into the monthly patch release cadence with the other
active branches.

Signed-off-by: Tim Pepper <tpepper@vmware.com>

/kind documentation
/area release-eng