### PR TITLE
Quarterly OWNERS updates

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -17,15 +17,12 @@ aliases:
     - justaugustus # subproject owner / Patch Release Team
     - tpepper # subproject owner / Patch Release Team
   release-team:
-    - aishsundar # 1.13 RT Lead
-    - alejandrox1 # 1.18 RT Lead
-    - claurence # 1.15 RT Lead
-    - guineveresaenger # 1.17 RT Lead
-    - jberkus # 1.11 RT Lead
+    - alejandrox1 # subproject owner / 1.18 RT Lead
+    - claurence # subproject owner / 1.15 RT Lead
+    - guineveresaenger # subproject owner / 1.17 RT Lead
     - justaugustus # subproject owner
-    - lachie83 # 1.16 RT Lead
-    - spiffxp # 1.14 RT Lead
-    - tpepper # subproject owner / 1.12 RT Lead
+    - lachie83 # subproject owner / 1.16 RT Lead
+    - tpepper # subproject owner
   branch-managers:
     - cpanato
     - hasheddan

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -9,7 +9,6 @@ aliases:
     - nikhita # subproject owner
     - swinslow # subproject owner
   release-engineering:
-    - aleksandra-malinowska # Patch Release Team
     - calebamiles # subproject owner
     - dougm # Patch Release Team
     - feiskyer # Patch Release Team

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -28,6 +28,7 @@ aliases:
     - tpepper # subproject owner / 1.12 RT Lead
   branch-managers:
     - cpanato
+    - hasheddan
     - saschagrunert
   build-admins:
     - aleksandra-malinowska

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -37,31 +37,39 @@ aliases:
     - lachie83 # 1.16
     - guineveresaenger # 1.17
     - alejandrox1 # 1.18
+    - onlydole # 1.19 RT Lead
+    - tpepper # 1.19 Emeritus Adviser
   ci-signal-role:
     - alejandrox1 # 1.16 / 1.15
     - alenkacz # 1.17
     - droslean # 1.18
+    - hasheddan # 1.19
   enhancements-role:
     - kacole2 # 1.16 / 1.15 / 1.13
     - mrbobbytables # 1.17
     - jeremyrickard # 1.18
+    - palnabarun # 1.19
   bug-triage-role:
     - soggiest # 1.15
     - xmudrii # 1.16
     - josiahbjorgaard # 1.17
     - smourapina # 1.18
+    - markyjackson-taulia # 1.19
   docs-role:
     - MAKOSCAFEE # 1.15
     - simplytunde # 1.16
     - daminisatya # 1.17
     - VineethReddy02 # 1.18
+    - savitharaghunathan # 1.19
   release-notes-role:
     - onyiny-ang # 1.15
     - saschagrunert # 1.16
     - cartyc # 1.17
     - Evillgenius75 # 1.18
+    - puerco # 1.19
   communications-role:
     - castrojo # 1.15
     - onlydole # 1.16
     - rawkode # 1.17
     - karenhchu # 1.18
+    - mkorbi # 1.19

--- a/release-managers.md
+++ b/release-managers.md
@@ -51,6 +51,7 @@ Branch Managers are responsible for minor releases (`x.y.z`, where `z` = 0) of K
 This team at times works in close conjunction with the [Product Security Committee][psc] and therefore should abide by the guidelines set forth in the [Security Release Process][security-release-process].
 
 - Carlos Panato ([@cpanato](https://github.com/cpanato))
+- Daniel Mangum ([@hasheddan](https://github.com/hasheddan))
 - Sascha Grunert ([@saschagrunert](https://github.com/saschagrunert))
 
 ## Associates
@@ -58,7 +59,6 @@ This team at times works in close conjunction with the [Product Security Committ
 Release Manager Associates are apprentices to the Branch Managers, formerly referred to as Branch Manager shadows.
 
 - Ace Eldeib ([@alexeldeib](https://github.com/alexeldeib))
-- Daniel Mangum ([@hasheddan](https://github.com/hasheddan))
 - Jim Angel ([@jimangel](https://github.com/jimangel))
 - Kendrick Coleman ([@kacole2](https://github.com/kacole2))
 - Marko Mudrinić ([@xmudrii](https://github.com/xmudrii))

--- a/releases/release-1.19/OWNERS
+++ b/releases/release-1.19/OWNERS
@@ -1,0 +1,13 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - onlydole              # Release Team Lead
+  - tpepper               # Emeritus Adviser
+
+reviewers:
+  - palnabarun            # Enhancements
+  - hasheddan             # CI Signal
+  - markyjackson-taulia   # Bug Triage
+  - savitharaghunathan    # Docs
+  - puerco                # Release Notes
+  - mkorbi                # Communications


### PR DESCRIPTION
#### What type of PR is this:

/kind cleanup

#### What this PR does / why we need it:

- releng: Remove @aleksandra-malinowska from Patch Release Team (ref: https://github.com/kubernetes/sig-release/issues/987)
- releng: Promote @hasheddan to Branch Manager (ref: https://github.com/kubernetes/sig-release/issues/1041)
- Prune Release Team subproject OWNERS to only include in-support releases
- release-team: Seed OWNERS for 1.19 (ref: https://github.com/kubernetes/sig-release/issues/1031)

/assign @tpepper 
cc: @onlydole @kubernetes/release-managers @kubernetes/sig-release-admins 
/hold