### PR TITLE
Add krel version to release cut issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/cut-release.md
+++ b/.github/ISSUE_TEMPLATE/cut-release.md
@@ -25,6 +25,20 @@ see template below, example: https://github.com/kubernetes/sig-release/issues/84
 
 ## Release steps
 
+[krel](https://github.com/kubernetes/release/tree/master/docs/krel) version:
+<!-- 
+Replace with output of `krel version` then uncomment.
+```
+GitVersion:    v0.2.7
+GitCommit:     191ddd0b0b49af1adb04a98e45cebdd36cae9307
+GitTreeState:  clean
+BuildDate:     2020-04-16T09:45:37Z
+GoVersion:     go1.13.4
+Compiler:      gc
+Platform:      linux/amd64
+```
+-->
+
 | Step | Command | Link | Start | Duration | Succeeded? |
 | --- | --- | --- | --- | --- | --- |
 | Mock stage | `krel gcbmgr --stage [arguments]` | <!-- link-to-MOCK-gcb-stage-run --> |  |  |  |


### PR DESCRIPTION


Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this:

/kind feature

#### What this PR does / why we need it:

We have observed differences in stage and release behavior because a different version of krel was used to run the steps. This adds the krel version information to the issue template so that it can be referenced after completed releases.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

N/A

#### Special notes for your reviewer:

None
