### PR TITLE
1.19: Update release cycle timelines (post-KubeCon release)

### DIFF
--- a/releases/release-1.19/README.md
+++ b/releases/release-1.19/README.md
@@ -28,14 +28,14 @@
 The 1.19 release cycle is proposed as follows:
 
 - **Monday, April 13**: Week 1 - Release cycle begins
-- **Tuesday, May 12**: Week 5 - [Enhancements Freeze]
-- **Tuesday, June 9**: Week 9 - [Code Freeze]
-- **Tuesday, June 22**: Week 11 - Docs must be completed and reviewed
-- **Tuesday, July 21**: Week 15 - Kubernetes v1.19.0 released
+- **Tuesday, May 19**: Week 6 - [Enhancements Freeze]
+- **Thursday, June 18**: Week 10 - [Code Freeze]
+- **Monday, July 13**: Week 14 - Docs must be completed and reviewed
+- **Tuesday, August 25**: Week 20 - Kubernetes v1.19.0 released
+- **Thursday, September 3**: Week 21 - Release Retrospective
 
 
 ## Timeline
-
 
 | **What** | **Who** | **When** | **WEEK** | **CI SIGNAL** |
 |---|---|---|---|---|
@@ -46,27 +46,28 @@ The 1.19 release cycle is proposed as follows:
 | 1.19.0-alpha.2 released | Branch Manager | Tue, April 21 | week 2 | |
 | Start Release Notes Draft | Release Notes Lead | Tue, April 28 | week 3 | |[master-blocking], [master-informing] |
 | 1.19.0-alpha.3 released | Branch Manager | Tue, May 5 | week 4 | |
-| release-1.15 jobs removed | Branch Manager | Tue, May 5 | week 4 | |
-| **Begin [Enhancements Freeze]** (EOD PST) | Enhancements Lead | Tue, May 12 | week 5 |
+| **Begin [Enhancements Freeze]** (EOD PST) | Enhancements Lead | Tue, May 19 | week 6 |
 | 1.19.0-beta.0 released | Branch Manager | Tue, May 19 | week 6 | |
 | 1.19.0-beta.1 released | Branch Manager | Tue, May 26 | week 7 | |
 | **Begin [Burndown]** (MWF meetings) | Lead | Mon, June 1 | week 8 | [1.19-blocking], [master-blocking], [master-informing] |
 | **Call for [Exceptions][Exception]** | Lead | Mon, June 1 | week 8 | |
-| Brace Yourself, Code Freeze is Coming | Comms / Bug Triage | Mon, June 1 | week 8 | |
 | 1.19.0-beta.2 released | Branch Manager | Tue, June 2 | week 8 | |
-| Docs deadline - Open placeholder PRs | Docs Lead | Fri, June 5 | week 8 | |
-| **Begin [Code Freeze]** (EOD PST) | Branch Manager | Tue, June 9 | week 9 | |
-| 1.19.0-rc.1 released | Branch Manager | Tue, June 9 | week 9 | |
-| release-1.19 branch created | Branch Manager | Tue, June 9 | week 9 | |
-| release-1.19 jobs created | Branch Manager | Tue, June 9 | week 9 | |
-| Burndown Meetings daily| Lead | Mon, June 15 | week 10 | |
-| Docs deadline - PRs ready for review | Docs Lead | Mon, June 15 | week 10 | |
-| 1.19.0-rc.2 released | Branch Manager | Tue, June 23 | week 11 | |
-| Docs complete - All PRs reviewed and ready to merge | Docs Lead | Mon, June 22 | week 11 | |
-| **Cherry Pick Deadline** (EOD PST) | Branch Manager | Thu, June 25 | week 11 | |
-| 1.19.0-rc.3 released | Branch Manager | Tue, July 7 | week 13 | |
-| **v1.19.0 released** | Branch Manager | Tue, July 21 | week 15 | |
-| Release retrospective | Community | Thu, July 30 | week 16 | |
+| Brace Yourself, Code Freeze is Coming | Comms / Bug Triage | Mon, June 8 | week 9 | |
+| Docs deadline - Open placeholder PRs | Docs Lead | Fri, June 12 | week 9 | |
+| **Begin [Code Freeze]** (EOD PST) | Branch Manager | Thu, June 18 | week 10 | |
+| 1.19.0-rc.1 released | Branch Manager | Thu, June 18 | week 10 | |
+| release-1.19 branch created | Branch Manager | Thu, June 18 | week 10 | |
+| release-1.19 jobs created | Branch Manager | Thu, June 18 | week 10 | |
+| Docs deadline - PRs ready for review | Docs Lead | Mon, June 29 | week 12 | |
+| 1.19.0-rc.2 released | Branch Manager | Tue, July 7 | week 13 | |
+| Docs complete - All PRs reviewed and ready to merge | Docs Lead | Mon, July 13 | week 14 | |
+| 1.19.0-rc.3 released | Branch Manager | Tue, July 21 | week 15 | |
+| Burndown Meetings daily | Lead | Mon, July 27 | week 16 | |
+| **Cherry Pick Deadline** (EOD PST) | Branch Manager | Thu, July 30 | week 16 | |
+| 1.19.0-rc.4 released | Branch Manager | Tue, August 4 | week 17 | |
+| **Release Blackout - KubeCon** | Community | Mon, August 10 - Fri, August 21 | week 18 - week 19 | |
+| **v1.19.0 released** | Branch Manager | Tue, August 25 | week 20 | |
+| **Release Retrospective** | Community | Thu, September 3 | week 21 | |
 
 ## Phases
 

--- a/releases/release-1.19/README.md
+++ b/releases/release-1.19/README.md
@@ -28,10 +28,10 @@
 The 1.19 release cycle is proposed as follows:
 
 - **Monday, April 13**: Week 1 - Release cycle begins
-- **Tuesday, May 5**: Week 4 - [Enhancements Freeze]
-- **Thursday, June 11**: Week 9 - [Code Freeze]
-- **Tuesday, June 23**: Week 11 - Docs must be completed and reviewed
-- **Tuesday, June 30**: Week 12 - Kubernetes v1.19.0 released
+- **Tuesday, May 12**: Week 5 - [Enhancements Freeze]
+- **Tuesday, June 9**: Week 9 - [Code Freeze]
+- **Tuesday, June 22**: Week 11 - Docs must be completed and reviewed
+- **Tuesday, July 21**: Week 15 - Kubernetes v1.19.0 released
 
 
 ## Timeline
@@ -41,12 +41,13 @@ The 1.19 release cycle is proposed as follows:
 |---|---|---|---|---|
 | Start of Release Cycle | Lead | Mon, April 13 | week 1 | [master-blocking] |
 | Start Enhancements Tracking | Enhancements Lead | Tue, April  14 | week 1 | |
-| Schedule finalized | Lead | Fri, April  17 | week 1 | |
-| Team finalized | Lead | Fri, April  17 | week 1 | |
-| 1.19.0-alpha.2 released | Branch Manager | Tue, April  21 | week 2 | |
-| Start Release Notes Draft | Release Notes Lead | Tue, April  28 | week 3 | |
-| **Begin [Enhancements Freeze]** (EOD PST) | Enhancements Lead | Tue, May 5 | week 4 | [master-blocking], [master-informing] |
+| Schedule finalized | Lead | Fri, April 17 | week 1 | |
+| Team finalized | Lead | Fri, April 17 | week 1 | |
+| 1.19.0-alpha.2 released | Branch Manager | Tue, April 21 | week 2 | |
+| Start Release Notes Draft | Release Notes Lead | Tue, April 28 | week 3 | |[master-blocking], [master-informing] |
 | 1.19.0-alpha.3 released | Branch Manager | Tue, May 5 | week 4 | |
+| release-1.15 jobs removed | Branch Manager | Tue, May 5 | week 4 | |
+| **Begin [Enhancements Freeze]** (EOD PST) | Enhancements Lead | Tue, May 12 | week 5 |
 | 1.19.0-beta.0 released | Branch Manager | Tue, May 19 | week 6 | |
 | 1.19.0-beta.1 released | Branch Manager | Tue, May 26 | week 7 | |
 | **Begin [Burndown]** (MWF meetings) | Lead | Mon, June 1 | week 8 | [1.19-blocking], [master-blocking], [master-informing] |
@@ -54,19 +55,18 @@ The 1.19 release cycle is proposed as follows:
 | Brace Yourself, Code Freeze is Coming | Comms / Bug Triage | Mon, June 1 | week 8 | |
 | 1.19.0-beta.2 released | Branch Manager | Tue, June 2 | week 8 | |
 | Docs deadline - Open placeholder PRs | Docs Lead | Fri, June 5 | week 8 | |
-| **Begin [Code Freeze]** (EOD PST) | Branch Manager | Thu, June 11 | week 9 | |
-| 1.19.0-rc.1 released | Branch Manager | Thu, June 11 | week 9 | |
-| release-1.19 branch created | Branch Manager | Thu, June 11 | week 9 | |
-| release-1.19 jobs created | Branch Manager | Thu, June 11 | week 9 | |
-| release-1.15 jobs removed | Branch Manager | Thu, June 11 | week 9 | |
+| **Begin [Code Freeze]** (EOD PST) | Branch Manager | Tue, June 9 | week 9 | |
+| 1.19.0-rc.1 released | Branch Manager | Tue, June 9 | week 9 | |
+| release-1.19 branch created | Branch Manager | Tue, June 9 | week 9 | |
+| release-1.19 jobs created | Branch Manager | Tue, June 9 | week 9 | |
 | Burndown Meetings daily| Lead | Mon, June 15 | week 10 | |
 | Docs deadline - PRs ready for review | Docs Lead | Mon, June 15 | week 10 | |
-| 1.19.0-rc.2 released | Branch Manager | Tue, June 16 | week 10 | |
+| 1.19.0-rc.2 released | Branch Manager | Tue, June 23 | week 11 | |
 | Docs complete - All PRs reviewed and ready to merge | Docs Lead | Mon, June 22 | week 11 | |
-| 1.19.0-rc.3 released | Branch Manager | Tue, June 23 | week 11 | |
 | **Cherry Pick Deadline** (EOD PST) | Branch Manager | Thu, June 25 | week 11 | |
-| **v1.19.0 released** | Branch Manager | Tue, June 30 | week 12 | |
-| Release retrospective | Community | Thu, July 9 | week 13 | |
+| 1.19.0-rc.3 released | Branch Manager | Tue, July 7 | week 13 | |
+| **v1.19.0 released** | Branch Manager | Tue, July 21 | week 15 | |
+| Release retrospective | Community | Thu, July 30 | week 16 | |
 
 ## Phases
 

--- a/releases/release-1.19/README.md
+++ b/releases/release-1.19/README.md
@@ -64,6 +64,7 @@ The 1.19 release cycle is proposed as follows:
 | 1.19.0-rc.3 released | Branch Manager | Tue, July 21 | week 15 | |
 | Burndown Meetings daily | Lead | Mon, July 27 | week 16 | |
 | **Cherry Pick Deadline** (EOD PST) | Branch Manager | Thu, July 30 | week 16 | |
+| **Test Freeze** (EOD PST) | Branch Manager | Thu, July 30 | week 16 | |
 | 1.19.0-rc.4 released | Branch Manager | Tue, August 4 | week 17 | |
 | **Release Blackout - KubeCon** | Community | Mon, August 10 - Fri, August 21 | week 18 - week 19 | |
 | **v1.19.0 released** | Branch Manager | Tue, August 25 | week 20 | |


### PR DESCRIPTION
#### What type of PR is this:

/kind cleanup documentation

#### What this PR does / why we need it:

- Move Enhancements Freeze to week 6 (was week 4)
- Move most releases to Tuesdays
- RCs get released on a biweekly cadence (week 9, 11, 13, 15)
- Move 1.19.0 release date to week 20 (was week 12)
- Move retro to week 21 (was week 13)
- Move Code Freeze to week 10
- Move Cherry Pick Deadline to week 16
- Add a Release Blackout for the weeks surrounding KubeCon
- Push Docs deadlines
- Push daily Burndown meetings

/assign @tpepper @onlydole 
cc: @kubernetes/release-team-leads @kubernetes/release-team 
cc: @jimangel @zacharysarah @savitharaghunathan (for Docs timeline feedback)
cc: @kubernetes/enhancements-admins @palnabarun (for Enhancements timeline feedback)

#### Special notes for your reviewer:

Email to follow to the community: https://groups.google.com/d/topic/kubernetes-dev/IVpiIOZ4WcM/discussion

**Explicit hold until after the [4/21 SIG Release meeting](https://docs.google.com/document/d/1Fu6HxXQu8wl6TwloGUEOXVzZ1rwZ72IAhglnaAMCPqA/edit#heading=h.w0vv6i8v0evt) and some review time**:
/hold

Email sent to the community with updated timeline: https://groups.google.com/d/msg/kubernetes-dev/IVpiIOZ4WcM/P981J6InAgAJ

**Lazy consensus timeout sent for Friday, April 24, 5pm US ET.**