### PR TITLE
1.19: Update release cycle timelines (pre-KubeCon release)

### DIFF
--- a/releases/release-1.19/README.md
+++ b/releases/release-1.19/README.md
@@ -28,45 +28,45 @@
 The 1.19 release cycle is proposed as follows:
 
 - **Monday, April 13**: Week 1 - Release cycle begins
-- **Tuesday, May 5**: Week 4 - [Enhancements Freeze]
-- **Thursday, June 11**: Week 9 - [Code Freeze]
-- **Tuesday, June 23**: Week 11 - Docs must be completed and reviewed
-- **Tuesday, June 30**: Week 12 - Kubernetes v1.19.0 released
+- **Tuesday, May 19**: Week 6 - [Enhancements Freeze]
+- **Thursday, June 25**: Week 11 - [Code Freeze]
+- **Thursday, July 9**: Week 14 - Docs must be completed and reviewed
+- **Tuesday, August 4**: Week 17 - Kubernetes v1.19.0 released
+- **Thursday, August 20**: Week 19 - Release Retrospective
 
 
 ## Timeline
-
 
 | **What** | **Who** | **When** | **WEEK** | **CI SIGNAL** |
 |---|---|---|---|---|
 | Start of Release Cycle | Lead | Mon, April 13 | week 1 | [master-blocking] |
 | Start Enhancements Tracking | Enhancements Lead | Tue, April  14 | week 1 | |
-| Schedule finalized | Lead | Fri, April  17 | week 1 | |
-| Team finalized | Lead | Fri, April  17 | week 1 | |
-| 1.19.0-alpha.2 released | Branch Manager | Tue, April  21 | week 2 | |
-| Start Release Notes Draft | Release Notes Lead | Tue, April  28 | week 3 | |
-| **Begin [Enhancements Freeze]** (EOD PST) | Enhancements Lead | Tue, May 5 | week 4 | [master-blocking], [master-informing] |
+| Schedule finalized | Lead | Fri, April 17 | week 1 | |
+| Team finalized | Lead | Fri, April 17 | week 1 | |
+| 1.19.0-alpha.2 released | Branch Manager | Tue, April 21 | week 2 | |
+| Start Release Notes Draft | Release Notes Lead | Tue, April 28 | week 3 | | [master-blocking], [master-informing] |
 | 1.19.0-alpha.3 released | Branch Manager | Tue, May 5 | week 4 | |
+| **Begin [Enhancements Freeze]** (EOD PST) | Enhancements Lead | Tue, May 19 | week 6 |
 | 1.19.0-beta.0 released | Branch Manager | Tue, May 19 | week 6 | |
-| 1.19.0-beta.1 released | Branch Manager | Tue, May 26 | week 7 | |
 | **Begin [Burndown]** (MWF meetings) | Lead | Mon, June 1 | week 8 | [1.19-blocking], [master-blocking], [master-informing] |
 | **Call for [Exceptions][Exception]** | Lead | Mon, June 1 | week 8 | |
-| Brace Yourself, Code Freeze is Coming | Comms / Bug Triage | Mon, June 1 | week 8 | |
-| 1.19.0-beta.2 released | Branch Manager | Tue, June 2 | week 8 | |
-| Docs deadline - Open placeholder PRs | Docs Lead | Fri, June 5 | week 8 | |
-| **Begin [Code Freeze]** (EOD PST) | Branch Manager | Thu, June 11 | week 9 | |
-| 1.19.0-rc.1 released | Branch Manager | Thu, June 11 | week 9 | |
-| release-1.19 branch created | Branch Manager | Thu, June 11 | week 9 | |
-| release-1.19 jobs created | Branch Manager | Thu, June 11 | week 9 | |
-| release-1.15 jobs removed | Branch Manager | Thu, June 11 | week 9 | |
-| Burndown Meetings daily| Lead | Mon, June 15 | week 10 | |
-| Docs deadline - PRs ready for review | Docs Lead | Mon, June 15 | week 10 | |
-| 1.19.0-rc.2 released | Branch Manager | Tue, June 16 | week 10 | |
-| Docs complete - All PRs reviewed and ready to merge | Docs Lead | Mon, June 22 | week 11 | |
-| 1.19.0-rc.3 released | Branch Manager | Tue, June 23 | week 11 | |
-| **Cherry Pick Deadline** (EOD PST) | Branch Manager | Thu, June 25 | week 11 | |
-| **v1.19.0 released** | Branch Manager | Tue, June 30 | week 12 | |
-| Release retrospective | Community | Thu, July 9 | week 13 | |
+| 1.19.0-beta.1 released | Branch Manager | Tue, June 2 | week 8 | |
+| Brace Yourself, Code Freeze is Coming | Comms / Bug Triage | Mon, June 8 | week 9 | |
+| Docs deadline - Open placeholder PRs | Docs Lead | Fri, June 12 | week 9 | |
+| 1.19.0-beta.2 released | Branch Manager | Tue, June 9 | week 9 | |
+| **Begin [Code Freeze]** (EOD PST) | Branch Manager | Thu, June 25 | week 11 | |
+| 1.19.0-rc.1 released | Branch Manager | Thu, June 25 | week 11 | |
+| release-1.19 branch created | Branch Manager | Thu, June 25 | week 11 | |
+| release-1.19 jobs created | Branch Manager | Thu, June 25 | week 11 | |
+| Docs deadline - PRs ready for review | Docs Lead | Mon, June 29 | week 12 | |
+| 1.19.0-rc.2 released | Branch Manager | Tue, July 7 | week 13 | |
+| Docs complete - All PRs reviewed and ready to merge | Docs Lead | Thu, July 9 | week 13 | |
+| 1.19.0-rc.3 released | Branch Manager | Tue, July 21 | week 15 | |
+| Burndown Meetings daily | Lead | Mon, July 27 | week 16 | |
+| **Cherry Pick Deadline** (EOD PST) | Branch Manager | Thu, July 30 | week 16 | |
+| **Test Freeze** (EOD PST) | Branch Manager | Thu, July 30 | week 16 | |
+| **v1.19.0 released** | Branch Manager | Tue, August 4 | week 17 | |
+| **Release Retrospective** | Community | Thu, August 20 | week 19 | |
 
 ## Phases
 


### PR DESCRIPTION
#### What type of PR is this:

/kind cleanup documentation

#### What this PR does / why we need it:

This is an alternative pre-KubeCon release schedule (compared to https://github.com/kubernetes/sig-release/pull/1058).

- Move Enhancements Freeze to week 6 (was week 4)
- Move Code Freeze to week 11 (was week 9)
  
  **Deviation from SIG Release meeting:**
  We give an extra week in the dev cycle to shorten Code Freeze to 6 weeks.
  Several comments on the previous proposal said that Code Freeze was too long.

- RCs get released on a biweekly cadence (week 11, 13, 15)
- Move Cherry Pick Deadline to week 16 (was week 11)
- Move 1.19.0 release date to week 17 (was week 12)

  _This is the week before KubeCon._

- Move retro to week 19 (was week 12)

  _This is the week after KubeCon._

- Push Docs deadlines
- Add a Test Freeze milestone to coincide with Cherry Pick deadline

  From @spiffxp [on previous review](https://github.com/kubernetes/sig-release/pull/1058#issuecomment-617426898):
  "Specific request from SIG Arch conformance: typically code freeze is
  the date by which no new conformance tests are accepted, so as not to
  disrupt CI Signal and force them to chase the stability of a moving
  target. Can we get a test freeze date later in the cycle, to allow
  addition of new tests beforehand, but force fixing/reverting tests
  afterward for CI Signal stability?"

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/assign @tpepper @onlydole 
cc: @kubernetes/release-team-leads @kubernetes/release-team 

#### Special notes for your reviewer:

**Lazy consensus timeout set for Friday, April 24, 5pm US ET.**
/hold

**Week comparison across release cycles:**

|  | 1.16 | 1.17 | 1.18 | 1.19 (current) | 1.19 (revised - pre-KubeCon) |
|---|---|---|---|---|---|
| Release Start | 1 | 1 | 1 | 1 | 1 |
| Enhancements Freeze | 5 | 4 | 4 | 4 | 6 |
| Code Freeze | 9 | 8 | 9 | 9 | 11 |
| Docs Complete | 11 | 9 | 11 | 11 | 13 |
| Cherry Pick Deadline | 11 | 11 | 11 | 11 | 16 |
| Release | 12 | 12 | 12 | 12 | 17 |
| Retrospective | 12 | 12 | 12 | 12 | 19 |
