### PR TITLE
ci-signal: Fix the sig-release-releng-informing link in the README

### DIFF
--- a/release-team/role-handbooks/ci-signal/README.md
+++ b/release-team/role-handbooks/ci-signal/README.md
@@ -5,7 +5,7 @@
 CI Signal lead assumes the responsibility of the quality gate for the release. This person is responsible for:
 - Continuously monitoring various e2e tests in sig-release dashboards ([master-blocking](https://k8s-testgrid.appspot.com/sig-release-master-blocking), [master-informing](https://k8s-testgrid.appspot.com/sig-release-master-informing), `release-x.y-blocking/informing` (x.y being the current release)) throughout the release cycle
 - Hunting flakes on presubmits that could potentially block the Kubernetes master branch ([presubmits-kubernetes-blocking](https://testgrid.k8s.io/presubmits-kubernetes-blocking))
-- Monitoring all the jobs in [sig-release-releng-blocking](https://testgrid.k8s.io/sig-release-releng-blocking) and [sig-release-releng-informing](sig-release-releng-informing) dashboards.
+- Monitoring all the jobs in [sig-release-releng-blocking](https://testgrid.k8s.io/sig-release-releng-blocking) and [sig-release-releng-informing](https://testgrid.k8s.io/sig-release-releng-informing) dashboards.
 - Providing early and ongoing signals on release and test health to both Release team and various SIGs
 - Ensuring that all release blocking tests provide a clear Go/No-Go signal for the release
 - Flagging regressions as close to source as possible i.e., as soon as the offending code was merged


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this:

This PR is a minor documentation fix

> Uncomment only one `/kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind cleanup
> /kind design

/kind documentation

> /kind feature

#### What this PR does / why we need it:

The PR fixes sig-release-releng-informing testgrid dashboard link in the README

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### Special notes for your reviewer:

/cc @hasheddan 
