### PR TITLE
Fix broken link to milestone-maintainers team in CI Signal handbook

### DIFF
--- a/release-team/role-handbooks/ci-signal/README.md
+++ b/release-team/role-handbooks/ci-signal/README.md
@@ -59,9 +59,9 @@ Additionally, the following qualifications make a candidate more suitable for th
 
 In addition to the above requirements for Shadows, most of which become prerequisites, CI Signal Leads must:
 
-- Have the ability to add a milestone to issues, so must be a member of the [milestone maintainers](https://github.com/orgs/kubernetes/teams/kubernetes-milestone-maintainers)
+- Have the ability to add a milestone to issues, so must be a member of the [milestone maintainers](https://github.com/orgs/kubernetes/teams/milestone-maintainers)
 - Have a working knowledge of our various test infrastructure tools, such as Testgrid, Triage, Spyglass, gubernator, Prow, and Tide.
-- Signal lead need to understand what tests matter and generally how our testing infra is wired together.
+- Signal lead needs to understand what tests matter and generally how our testing infra is wired together.
   - He/she can ask previous CI Signal leads for advice
   - He/she can ask SIG-Testing for guidance
 


### PR DESCRIPTION
Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this:

/kind cleanup

#### What this PR does / why we need it:

Fixes broken link in CI Signal handbook to `milestone-maintainers` which was previously `kubernetes-milestone-maintainers`

