### PR TITLE
Update onboarding guide to add release manager associates to milestone-maintainers

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-manager.md
+++ b/.github/ISSUE_TEMPLATE/release-manager.md
@@ -116,6 +116,7 @@ As you work through the checklist, use the following PRs as guides:
 ### Release Manager Associate
 
 - [ ] Update GitHub teams [(`kubernetes/org`)](https://git.k8s.io/org/config/kubernetes/sig-release/teams.yaml)
+  - `milestone-maintainers`
   - `release-engineering`
   - `sig-release`
 - [ ] Update Google Groups/GCP IAM membership [(`kubernetes/k8s.io`)](https://git.k8s.io/k8s.io/groups/groups.yaml)


### PR DESCRIPTION
#### What type of PR is this:

> Uncomment only one `/kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind cleanup
> /kind design

/kind documentation

> /kind feature

#### What this PR does / why we need it:

This PR updates the onboarding guide for release manager associates to mention that they should be added to the milestone maintainers team.

https://github.com/kubernetes/org/pull/1860#issuecomment-625723747

/assign @justaugustus 
