### PR TITLE
role handbooks: add kubernetes-release-team-shadows list

### DIFF
--- a/release-team/role-handbooks/emeritus-adviser/README.md
+++ b/release-team/role-handbooks/emeritus-adviser/README.md
@@ -52,6 +52,7 @@ Once most of the Role Leads are selected, the EA should solicit candidates for S
 4. Close the Shadow Application around 7-10 days after the initial announcement.
 5. Chat with each of the incoming Role Leads about selecting their shadows, and make sure that they stay on schedule for it.
 6. Once all role leads select their shadows the EA will send out a notification to all applicants not selected for this release cycle 
+7. Ensure the outgoing EA or one of the SIG Release co-chairs has added you in as an owner of the [kubernetes-release-team-shadows](https://groups.google.com/forum/#!forum/kubernetes-release-team-shadows) Google Group.
 
 The most time-consuming part of this is helping the Role Leads select shadows.  In addition to the usual dilemmas of too many good candidates, the EA needs to give advice that makes sure that a diverse pool of shadows is selected, and that the Role Lead doesn't take on more shadows than they can effectively mentor.
 
@@ -61,7 +62,9 @@ Occasionally, a role may not get enough qualified candidates, in which case it's
 
 Weeks: 1 to 12
 
-First, have a "shadow orientation" meeting sometime in week 2 or week 3, after all shadows are selected.  This meeting will likely have to be split for time zone reasons and held twice.  In this meeting, go over the information in the main Shadow docs, give information about the release team and SIG Release, and then open things for questions or discussion. Make sure that Shadows know they can come to you if they have problems during their apprenticeship.
+Remove prior release shadows from the [kubernetes-release-team-shadows](https://groups.google.com/forum/#!forum/kubernetes-release-team-shadows) Google Group and add the current release shadows.  This list can facilitate easier communication between what at times is 2-3 dozen shadows.
+
+Poll the new shadows (eg: [Doodle](Doodle.com)) for their availability to have a "shadow orientation" meeting sometime in week 2 or week 3, after all shadows are selected.  This meeting will likely have to be split for time zone reasons and held twice.  In this meeting, go over the information in the main Shadow docs, give information about the release team and SIG Release, and then open things for questions or discussion. Make sure that Shadows know they can come to you if they have problems during their apprenticeship.
 
 **For leads, ensure they have enough support for their role, and to be an effective mentor to their shadows.**
 

--- a/release-team/role-handbooks/release-team-lead/README.md
+++ b/release-team/role-handbooks/release-team-lead/README.md
@@ -176,6 +176,10 @@ Coordinate with SIG-Release Chairs (who have access to the CNCF Service Desk as 
   only give access to the [kubernetes-release-team]. Communicate with section
   leads to add their shadows so that you and your shadows can add them to the
   [kubernetes-release-team].
+- Ensure SIG Release co-chairs replace the outgoing Emeritus Advisor with
+  the new Emeritus Advisor as an owner of the
+  [kubernetes-release-team-shadows](https://groups.google.com/forum/#!forum/kubernetes-release-team-shadows)
+  Google Group.
 - Ensure top-level OWNERS_ALIASES only includes Release Team personnel from four (4) releases, including the current one.
 - Create and finalize the release schedule, blocking test gates, and role assignments as a pull request in: kubernetes/sig-release/releases/release-x.y/README.md **Note: Do not ship the release on a Monday, to avoid preparing for the release on a weekend. Aim for Tuesday.**
 - Send an update to [kubernetes-dev] and [kubernetes-sig-leads] mailing list to announce the start of the release cycle, including any notable changes in the release process, key dates, and links to important documents

--- a/release-team/shadows.md
+++ b/release-team/shadows.md
@@ -27,6 +27,7 @@ The first week should be used to get Shadows set up with all of the "paperwork" 
 * Join the [sig-release](https://groups.google.com/forum/#!forum/kubernetes-sig-release) and [release-team](https://groups.google.com/forum/#!forum/kubernetes-release-team) Google Groups and calendars.
 * Add all contact information to their Release Team's contact sheet.
 * Get invited to the weekly Release Team Meeting and add the [sig-release calendar](https://calendar.google.com/calendar/embed?src=kipmnllvl17vl9m98jen6ujcrs%40group.calendar.google.com) to their calendar
+* Get added to the [kubernetes-release-team-shadows](https://groups.google.com/forum/#!forum/kubernetes-release-team-shadows) Google Group by the Emeritus Advisor.
 
 Becoming a Release Team Shadow is considered sufficient contribution to become a Kubernetes Org Member, and membership is needed for several tasks, especially having the Github bots obey the Shadow's commands. As such, each Shadow who is not already an org member should [apply to become one](https://github.com/kubernetes/community/blob/master/community-membership.md#member) with their mentoring role lead, the Release Lead, and/or the Emeritus Advisor as their sponsors.
 


### PR DESCRIPTION
Given the Emeritus Advisor role's responsibility to interact with the
release team role shadows regularly during the release cycle and engage
in mentoring and feedback, it would be easier if this was done via a
shadow-specific list with each release's role shadow members cycled in
and out of the list.

Signed-off-by: Tim Pepper <tpepper@vmware.com>

/priority important-soon
/kind documentation