### PR TITLE
schedule: add release schedule in yaml machine readable format

### DIFF
--- a/releases/schedule.yaml
+++ b/releases/schedule.yaml
@@ -1,0 +1,103 @@
+schedules:
+- release: 1.18
+  next: 1.18.7
+  cherryPickDeadline: 2020-08-07
+  targetDate: 2020-08-12
+  endOfLifeDate: TBD
+  previousPatches:
+    - release: 1.18.6
+      cherryPickDeadline: 2020-07-10
+      targetDate: 2020-07-15
+    - release: 1.18.5
+      cherryPickDeadline: 2020-06-25
+      targetDate: 2020-06-26
+    - release: 1.18.4
+      cherryPickDeadline: 2020-06-12
+      targetDate: 2020-06-17
+    - release: 1.18.3
+      cherryPickDeadline: 2020-05-15
+      targetDate: 2020-05-20
+    - release: 1.18.2
+      cherryPickDeadline: 2020-04-13
+      targetDate: 2020-04-16
+    - release: 1.18.1
+      cherryPickDeadline: 2020-04-06
+      targetDate: 2020-04-08
+- release: 1.17
+  next: 1.17.10
+  cherryPickDeadline: 2020-08-07
+  targetDate: 2020-08-12
+  endOfLifeDate: TBD
+  previousPatches:
+    - release: 1.17.9
+      cherryPickDeadline: 2020-07-10
+      targetDate: 2020-07-15
+    - release: 1.17.8
+      cherryPickDeadline: 2020-06-25
+      targetDate: 2020-06-26
+    - release: 1.17.7
+      cherryPickDeadline: 2020-06-12
+      targetDate: 2020-06-17
+    - release: 1.17.6
+      cherryPickDeadline: 2020-05-15
+      targetDate: 2020-05-20
+    - release: 1.17.5
+      cherryPickDeadline: 2020-04-13
+      targetDate: 2020-04-16
+    - release: 1.17.4
+      cherryPickDeadline: 2020-03-09
+      targetDate: 2020-03-12
+    - release: 1.17.3
+      cherryPickDeadline: 2020-02-07
+      targetDate: 2020-02-11
+    - release: 1.17.2
+      cherryPickDeadline: "No-op release https://groups.google.com/d/topic/kubernetes-dev/Mhpx-loSBns/discussion"
+      targetDate: 2020-01-21
+    - release: 1.17.1
+      cherryPickDeadline: 2020-01-10
+      targetDate: 2020-01-14
+- release: 1.16
+  next: 1.16.14
+  cherryPickDeadline: 2020-08-07
+  targetDate: 2020-08-12
+  endOfLifeDate: TBD
+  previousPatches:
+    - release: 1.16.13
+      cherryPickDeadline: 2020-07-10
+      targetDate: 2020-07-15
+    - release: 1.16.12
+      cherryPickDeadline: 2020-06-25
+      targetDate: 2020-06-26
+    - release: 1.16.11
+      cherryPickDeadline: 2020-06-12
+      targetDate: 2020-06-17
+    - release: 1.16.10
+      cherryPickDeadline: 2020-05-15
+      targetDate: 2020-05-20
+    - release: 1.16.9
+      cherryPickDeadline: 2020-04-13
+      targetDate: 2020-04-16
+    - release: 1.16.8
+      cherryPickDeadline: 2020-03-09
+      targetDate: 2020-03-12
+    - release: 1.16.7
+      cherryPickDeadline: 2020-02-07
+      targetDate: 2020-02-11
+    - release: 1.16.6
+      cherryPickDeadline: "No-op release https://groups.google.com/d/topic/kubernetes-dev/Mhpx-loSBns/discussion"
+      targetDate: 2020-01-21
+    - release: 1.16.5
+      cherryPickDeadline: 2020-01-10
+      targetDate: 2020-01-14
+    - release: 1.16.4
+      cherryPickDeadline: 2019-12-06
+      targetDate: 2019-12-11
+    - release: 1.16.3
+      cherryPickDeadline: 2019-11-08
+      targetDate: 2019-11-13
+    - release: 1.16.2
+      cherryPickDeadline: 2019-10-11
+      targetDate: 2019-10-15
+    - release: 1.16.1
+      cherryPickDeadline: 2019-09-27
+      targetDate: 2019-10-02


### PR DESCRIPTION
#### What type of PR is this:
/kind documentation

#### What this PR does / why we need it:
Adds the schedule of the patch release in the YAML format to make it easier to machines read and parse.

Will open a second PR again k/release to add a small command-line tool to convert from YAML to markdown format to help to publish the schedule [here](https://github.com/kubernetes/sig-release/blob/master/releases/patch-releases.md#timelines)

TODO:
- [ ] Add missing dates for the EOL for the existing releases.

#### Which issue(s) this PR fixes:
 - Fixes https://github.com/kubernetes/sig-release/issues/718

#### Special notes for your reviewer:


/cc @justaugustus @tpepper  @kubernetes/release-managers 