### PR TITLE
Use krel announce instead of release-notify

### DIFF
--- a/release-engineering/role-handbooks/branch-manager.md
+++ b/release-engineering/role-handbooks/branch-manager.md
@@ -176,7 +176,7 @@ At the end of a release, Release Managers will need to announce the new release 
 
 This can be done in one of two ways:
 
-- The `./release-notify` tool -- `sendmail` will need to be configured correctly on your environment for this to work
+- The `krel announce` subcommand -- A [`SENDGRID_API_KEY`](https://sendgrid.com/docs/ui/account-and-settings/api-keys) will need to be configured correctly on your environment for this to work
 - Manually -- Send the email notification manually to [kubernetes-announce][k-announce-list] by taking the contents from the Google Cloud Bucket: `gs://kubernetes-release/archive/anago-vX.Y.0-{alpha,beta,rc}.z`:
   - [Example subject](https://gcsweb.k8s.io/gcs/kubernetes-release/archive/anago-v1.17.0-rc.2/announcement-subject.txt)
   - [Example body](https://gcsweb.k8s.io/gcs/kubernetes-release/archive/anago-v1.17.0-rc.2/announcement.html)
@@ -196,8 +196,8 @@ Public build artifacts are published and an email notification goes out to the c
 
 ```shell
 # Only for the official release: Inform the Google team to complete the corresponding Deb and RPM builds
-./release-notify vX.Y.0-{alpha,beta,rc}.Z
-./release-notify vX.Y.0-{alpha,beta,rc}.Z --nomock --mailto=${{YOUREMAILADDRESS}}[a][b]
+export SENDGRID_API_KEY=<API_KEY>
+krel announce --tag vX.Y.0-{alpha,beta,rc}.Z
 ```
 
 There are more examples of the release process under the [References](#references) section.

--- a/release-engineering/role-handbooks/patch-release-team.md
+++ b/release-engineering/role-handbooks/patch-release-team.md
@@ -520,7 +520,8 @@ to yourself to visual confirm its content:
 
 ```bash
 ~$ cd src/k8s.io/release
-~$ ./release-notify v1.13.2 --nomock --mailto=you@somewhere.com
+~$ export SENDGRID_API_KEY=<API_KEY>
+~$ krel announce --tag v1.13.2 --nomock
 ```
 
 If the mock build and release goes well and CI tests show the branch
@@ -531,7 +532,8 @@ packages are successfully published.  Then announce the release:
 
 ```bash
 ~$ cd src/k8s.io/release
-~$ ./release-notify v1.13.2 --nomock
+~$ export SENDGRID_API_KEY=<API_KEY>
+~$ krel announce --tag v1.13.2 --nomock
 ```
 
 This will automatically send the formatted announcement to the
@@ -589,15 +591,15 @@ For more information in how to run `krel gcbmgr` please check the [command docum
 | Mock build staging success? | Visually confirm yes |
 | Mock release | For the command execution [see](https://github.com/kubernetes/release/blob/master/docs/krel/gcbmgr.md#official-release) |
 | Mock release success? | Visually confirm yes |
-| Mock email notify test | ```./release-notify v1.13.3-beta.1 --mailto=me@some.com``` |
+| Mock email notify test | ```krel announce --tag v1.13.3-beta.1``` |
 | Check mail arrives, list has expected commits? | manual/visual |
 | Official build staging | For the command execution [see](https://github.com/kubernetes/release/blob/master/docs/krel/gcbmgr.md#official-stage). The only difference here is we are using the flag `--nomock` |
 | Official build staging success? | Visually confirm yes |
 | Official release | For the command execution [see](https://github.com/kubernetes/release/blob/master/docs/krel/gcbmgr.md#official-release). The only difference here is we are using the flag `--nomock` |
-| Official email notify test | ```./release-notify v1.13.3 --nomock --mailto=me@some.com``` |
+| Official email notify test | ```krel announce --tag v1.13.3 --nomock``` |
 | Check mail arrives, list has expected commits? | manual/visual |
 | Package creation (needs its own improved workflow; work starting on that) | Ping [Build Admins](https://git.k8s.io/sig-release/release-managers.md#build-admins) by name on Slack for package building |
 | Package testing (needs improvement) | Visually validate [yum repo](https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64/repodata/primary.xml) and [apt repo](https://packages.cloud.google.com/apt/dists/kubernetes-xenial/main/binary-amd64/Packages) have entries for "1.13.3" in package NVRs (Name-Version-Release) |
-| Official email notify | ```./release-notify v1.13.3 --nomock``` |
+| Official email notify | ```krel announce --tag v1.13.3 --nomock``` |
 | Check mail arrives | manual/visual check that [k-announce](https://groups.google.com/forum/#!forum/kubernetes-announce) and [k-dev](https://groups.google.com/forum/#!forum/kubernetes-dev) got mail OK |
 | Completion | n/a |


### PR DESCRIPTION
#### What type of PR is this:

/kind documentation

#### What this PR does / why we need it:
We should now use the new `krel announce` subcommand instead of the
release-notify script. For that we change the branch management and
patch release team handbooks.
#### Which issue(s) this PR fixes:
Refers to https://github.com/kubernetes/release/pull/1315

#### Special notes for your reviewer:
None