### PR TITLE
releng: Consolidation of Patch Release Team and Branch Managers

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-manager.md
+++ b/.github/ISSUE_TEMPLATE/release-manager.md
@@ -9,9 +9,9 @@ labels: sig/release, area/release-eng
 
 e.g., (at)example_user
 
-### [Release Manager](/release-managers.md) role
+### [Release Manager](https://git.k8s.io/sig-release/release-managers.md) role
 
-e.g., Patch Release Team, Branch Manager, Release Manager Associate
+e.g., Release Manager, Release Manager Associate
 
 ### Tenure
 
@@ -20,7 +20,7 @@ Provide reasoning behind the tenure selection here.
 For temporary access, we should specify a revocation time AND keep the issue open until the temporary Release Manager has been offboarded.
 
 Examples:
-- temporary: Alice is a Release Manager Associate being granted temporary elevated access to execute the Branch Management role. Access should be revoked after the x.y.z-alpha.m release is cut.
+- temporary: Alice is a Release Manager Associate being granted temporary elevated access to cut releases. Access should be revoked after the x.y.z-alpha.m release is cut.
 - temporary: Carmen is a Release Team Lead being granted Release Manager Associate access to observe Release Management during the x.y release cycle. Access should be revoked once the x.y cycle is complete.
 -->
 e.g., permanent, temporary
@@ -53,55 +53,32 @@ As you work through the checklist, use the following PRs as guides:
 -->
 
 <!--
-### Patch Release Team
+### Release Manager
 
 - [ ] Release Manager has agreed to abide by the guidelines set forth in the
   [Security Release Process](https://git.k8s.io/security/security-release-process.md), specifically the embargo on CVE communications.
-  This must be done as an issue comment by the incoming Release Manager.
+  (This must be done as an issue comment by the incoming Release Manager.)
 - [ ] Update GitHub teams [(`kubernetes/org`)](https://git.k8s.io/org/config/kubernetes/sig-release/teams.yaml)
   - `milestone-maintainers`
-  - `patch-release-team`
   - `release-engineering`
   - `release-managers`
-  - `sig-release`
 - [ ] Update `OWNERS`
-  - `kubernetes/sig-release` `OWNERS_ALIASES`
-    - Add entry in the `release-engineering` section
-    - Remove entry in the `branch-managers` section
-  - `kubernetes/release` `OWNERS_ALIASES`
-    - Add entry in the `release-engineering` section
-    - Remove entry in the `branch-managers` section
-  - `kubernetes/test-infra`
-    - Add as reviewer for SIG Release `OWNERS`
-- [ ] Update Google Groups/GCP IAM membership [(`kubernetes/k8s.io`)](https://git.k8s.io/k8s.io/groups/groups.yaml)
-  - `k8s-infra-release-editors@`
-  - `k8s-infra-release-viewers@`
-  - `release-managers@`
-  - `release-managers-private@`
-- [ ] Manually grant permission to post on [kubernetes-announce](https://groups.google.com/forum/#!forum/kubernetes-announce)
-- [ ] Manually remove from the [Release Team Google Group](https://groups.google.com/forum/#!forum/kubernetes-release-team)
-- [ ] Update Slack `release-managers` User Group [(`kubernetes/community`)](https://git.k8s.io/community/communication/slack-config/sig-release/usergroups.yaml)
-- [ ] Manually add to the [#release-private](https://kubernetes.slack.com/archives/GKEA5EL67) Slack channel
--->
-
-<!--
-### Branch Manager
-
-- [ ] Release Manager has agreed (on this issue) to abide by the guidelines set forth in the
-  [Security Release Process](https://git.k8s.io/security/security-release-process.md),
-  specifically the embargo on CVE communications
-- [ ] Update GitHub teams [(`kubernetes/org`)](https://git.k8s.io/org/config/kubernetes/sig-release/teams.yaml)
-  - `milestone-maintainers`
-  - `release-managers`
-  - `release-engineering`
-  - `sig-release`
-- [ ] Update `OWNERS`
-  - `kubernetes/sig-release` `OWNERS_ALIASES`
-    - Add entry in the `branch-managers` section
-  - `kubernetes/release` `OWNERS_ALIASES`
-    - Add entry in the `branch-managers` section
-  - `kubernetes/test-infra`
-    - Add as reviewer for SIG Release `OWNERS`
+  - [ ] `kubernetes/sig-release` `OWNERS_ALIASES`
+    - Add entry in the `release-engineering-reviewers` section
+      (only if they are not already in the `release-engineering-reviewers`
+      or `release-engineering-approvers` section)
+  - [ ] `kubernetes/release` `OWNERS_ALIASES`
+    - Add entry in the `release-engineering-reviewers` section
+      (only if they are not already in the `release-engineering-reviewers`
+      or `release-engineering-approvers` section)
+  - [ ] `kubernetes/test-infra` `OWNERS_ALIASES`
+    - Add entry in the `release-engineering-reviewers` section
+      (only if they are not already in the `release-engineering-reviewers`
+      or `release-engineering-approvers` section)
+  - [ ] `kubernetes/kubernetes` `OWNERS_ALIASES`
+    - Add entry in the `release-engineering-reviewers` section
+      (only if they are not already in the `release-engineering-reviewers`
+      or `release-engineering-approvers` section)
 - [ ] Update Google Groups/GCP IAM membership [(`kubernetes/k8s.io`)](https://git.k8s.io/k8s.io/groups/groups.yaml)
   - `k8s-infra-release-editors@`
   - `k8s-infra-release-viewers@`
@@ -110,6 +87,7 @@ As you work through the checklist, use the following PRs as guides:
 - [ ] Manually grant permission to post on [kubernetes-announce](https://groups.google.com/forum/#!forum/kubernetes-announce)
 - [ ] Manually add to the [Release Team Google Group](https://groups.google.com/forum/#!forum/kubernetes-release-team)
 - [ ] Update Slack `release-managers` User Group [(`kubernetes/community`)](https://git.k8s.io/community/communication/slack-config/sig-release/usergroups.yaml)
+- [ ] Manually add to the [#release-private](https://kubernetes.slack.com/archives/GKEA5EL67) Slack channel
 -->
 
 <!--
@@ -118,7 +96,6 @@ As you work through the checklist, use the following PRs as guides:
 - [ ] Update GitHub teams [(`kubernetes/org`)](https://git.k8s.io/org/config/kubernetes/sig-release/teams.yaml)
   - `milestone-maintainers`
   - `release-engineering`
-  - `sig-release`
 - [ ] Update Google Groups/GCP IAM membership [(`kubernetes/k8s.io`)](https://git.k8s.io/k8s.io/groups/groups.yaml)
   - `k8s-infra-release-viewers@`
   - `release-managers@`

--- a/OWNERS
+++ b/OWNERS
@@ -4,7 +4,7 @@ approvers:
   - sig-release-leads
 reviewers:
   - licensing
-  - release-engineering
+  - release-engineering-approvers
   - release-team
   - release-team-lead-role
 labels:

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -8,14 +8,18 @@ aliases:
     - justaugustus # subproject owner
     - nikhita # subproject owner
     - swinslow # subproject owner
-  release-engineering:
+  release-engineering-approvers:
     - calebamiles # subproject owner
-    - dougm # Patch Release Team
-    - feiskyer # Patch Release Team
-    - hoegaarden # Patch Release Team
-    - idealhack # Patch Release Team
-    - justaugustus # subproject owner / Patch Release Team
-    - tpepper # subproject owner / Patch Release Team
+    - dougm # Release Manager
+    - feiskyer # Release Manager
+    - hoegaarden # Release Manager
+    - idealhack # Release Manager
+    - justaugustus # subproject owner / Release Manager
+    - tpepper # subproject owner / Release Manager
+  release-engineering-reviewers:
+    - cpanato # Release Manager
+    - hasheddan # Release Manager
+    - saschagrunert # Release Manager
   release-team:
     - alejandrox1 # subproject owner / 1.18 RT Lead
     - claurence # subproject owner / 1.15 RT Lead
@@ -23,10 +27,6 @@ aliases:
     - justaugustus # subproject owner
     - lachie83 # subproject owner / 1.16 RT Lead
     - tpepper # subproject owner
-  branch-managers:
-    - cpanato
-    - hasheddan
-    - saschagrunert
   build-admins:
     - aleksandra-malinowska
     - listx

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -19,7 +19,12 @@ aliases:
   release-engineering-reviewers:
     - cpanato # Release Manager
     - hasheddan # Release Manager
+    - jimangel # Release Manager Associate
+    - markyjackson-taulia # Release Manager Associate
     - saschagrunert # Release Manager
+    - sethmccombs # Release Manager Associate
+    - verolop # Release Manager Associate
+    - xmudrii # Release Manager Associate
   release-team:
     - alejandrox1 # subproject owner / 1.18 RT Lead
     - claurence # subproject owner / 1.15 RT Lead

--- a/release-engineering/OWNERS
+++ b/release-engineering/OWNERS
@@ -1,9 +1,10 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-  - release-engineering
+  - release-engineering-approvers
 reviewers:
-  - branch-managers
   - build-admins
+  - release-engineering-approvers
+  - release-engineering-reviewers
 labels:
   - area/release-eng

--- a/release-engineering/packaging.md
+++ b/release-engineering/packaging.md
@@ -10,7 +10,7 @@ _Original document: [Building debs/rpms for Kubernetes
 - [Introduction](#introduction)
 - [Communication](#communication)
 - [Release Steps](#release-steps)
-  - [Dependecy Pre-checks](#dependecy-pre-checks)
+  - [Dependency Pre-checks](#dependency-pre-checks)
   - [Permissions](#permissions)
   - [Clone Release Repository](#clone-release-repository)
   - [Authenticate](#authenticate)
@@ -27,9 +27,9 @@ This guide outlines the process of building debs/rpms for Kubernetes minor and p
 
 ## Communication
 
-The [Patch Release Team][patch-release-team] (patch releases) or [Branch Manager][branch-manager-handbook] (minor releases) will reach out to the [Kubernetes Build Admins][kubernetes-build-admins] via the [Release Managers Google Group][release-managers-group] or [`#release-management`][release-management-slack] (for more synchronous communication) requesting help to build the debs and rpms.
+[Release Managers][release-managers] will reach out to the [Kubernetes Build Admins][kubernetes-build-admins] via the [Release Managers Google Group][release-managers-group] or [`#release-management`][release-management-slack] (for more synchronous communication) requesting help to build the debs and rpms.
 
-Patch Release Team members or Branch Managers requesting debs/rpms should be sure to provide explicit details on the package name(s), version(s), and revision(s) they need built.
+Release Managers requesting debs/rpms should be sure to provide explicit details on the package name(s), version(s), and revision(s) they need built.
 
 **n.b. As much as possible, communications with the Kubernetes Build Admins should happen on public forums (email, Slack public channels), not direct messaging, except in instances where doing so would run contrary to our [security policies][security-release-process] e.g., building packages for a release which addresses an embargoed CVE.**
 
@@ -37,11 +37,11 @@ Patch Release Team members or Branch Managers requesting debs/rpms should be sur
 
 In this process, we are pulling the artifacts published by a Release Manager to the GCS bucket and building debs/rpms to be published to the rapture repository.
 
-Refer to the [Branch Manager handbook][branch-manager-build-and-release] for details on the artifacts that are built by the Branch Manager.
+Refer to the [Branch Manager handbook][branch-manager-handbook] for details on the artifacts that are built by Release Managers.
 
 See also the [rapture documentation][rapture-readme], which contains details on running `rapture` (Google internal packaging tool).
 
-### Dependecy Pre-checks
+### Dependency Pre-checks
 
 Before starting the release process, check for following items in your system.
 
@@ -163,15 +163,14 @@ If any of these tests are broken, the [Release Managers Google Group][release-ma
 If there is continued test failure on this dashboard without intervention from the Release Managers, escalate to the current [Release Team][release-team] and [test-infra on-call][test-infra-oncall].
 
 [branch-manager-handbook]: /release-engineering/role-handbooks/branch-manager.md
-[branch-manager-build-and-release]: /release-engineering/role-handbooks/branch-manager.md#build-and-release
 [kubeadm-install]: https://kubernetes.io/docs/setup/independent/install-kubeadm/#installing-kubeadm-kubelet-and-kubectl
 [kubernetes/release]: https://git.k8s.io/release
 [kubernetes-build-admins]: /release-managers.md#build-admins
-[patch-release-team]: /release-managers.md#patch-release-team
 [rapture]: https://cs.corp.google.com/piper///depot/google3/experimental/users/mehdy/kubernetes/k8s-rapture.sh
 [rapture-readme]: https://g3doc.corp.google.com/cloud/kubernetes/g3doc/release/rapture.md?cl=head
 [release-engineering-dashboard]: https://testgrid.k8s.io/sig-release-misc
 [release-management-slack]: https://kubernetes.slack.com/messages/CJH2GBF7Y
+[release-managers]: /release-managers.md#release-managers
 [release-managers-group]: https://groups.google.com/a/kubernetes.io/forum/#!forum/release-managers
 [release-team]: https://groups.google.com/forum/#!forum/kubernetes-release-team
 [security-release-process]: /security-release-process-documentation/security-release-process.md

--- a/release-engineering/role-handbooks/branch-manager.md
+++ b/release-engineering/role-handbooks/branch-manager.md
@@ -1,5 +1,6 @@
 # Branch Manager Handbook <!-- omit in toc -->
 
+- [Content Notice](#content-notice)
 - [Overview](#overview)
   - [Conventions](#conventions)
   - [Responsibilities](#responsibilities)
@@ -50,6 +51,19 @@
 - [References](#references)
   - [Test Infra references](#test-infra-references)
 - [Background information](#background-information)
+
+## Content Notice
+
+The Patch Release Team and Branch Manager roles have been consolidated into a
+single [Release Managers][release-managers] group.
+
+This means that several areas of this document may currently be out of date.
+While we work to update these documents, please reach out to
+[Release Managers][release-managers] directly for any clarifications on Release
+Engineering processes.
+
+**This notice will be removed when the documentation is no longer under
+construction.**
 
 ## Overview
 
@@ -450,9 +464,7 @@ Update the Slack branch whitelists:
 - Find the current branch whitelist ([`config/prow/plugins.yaml`](https://git.k8s.io/test-infra/config/prow/plugins.yaml), grep for `branch_whitelist:`)
 - Remove the oldest release branch block
 - Add an entry for the newest release branch
-- Add all current [Patch Release Team members](/release-managers.md#patch-release-team) to all `kubernetes/kubernetes` release branches
-- Remove [Branch Managers](/release-managers.md#branch-managers) from any previous release branches
-- Add all current [Branch Managers](/release-managers.md#branch-managers)
+- Ensure only current [Release Managers](/release-managers.md#release-managers) are whitelisted for all `kubernetes/kubernetes` release branches
 
 Here's an [example PR](https://github.com/kubernetes/test-infra/pull/15014).
 
@@ -843,4 +855,5 @@ See the branch management process prior to v1.12 when `anago` was still used.
   Note: To view this document, you will need to join the [kubernetes-dev](https://groups.google.com/forum/#!forum/kubernetes-dev) Google group.
 
 [kubernetes-release-team]: https://groups.google.com/forum/#!forum/kubernetes-release-team
+[release-managers]: /release-managers.md#release-managers
 [release-managers-group]: https://groups.google.com/a/kubernetes.io/forum/#!forum/release-managers

--- a/release-engineering/role-handbooks/patch-release-team.md
+++ b/release-engineering/role-handbooks/patch-release-team.md
@@ -8,6 +8,7 @@ of support in terms of patches for bugfixes and ongoing CI insuring
 the branch's health and the ability to update from 1.X.Y to 1.(X+1).Y,
 for the newest Y on each of those two branches.
 
+- [Content Notice](#content-notice)
 - [Prerequisites for Patch Release Team members](#prerequisites-for-patch-release-team-members)
   - [General Requirements](#general-requirements)
 - [Getting started](#getting-started)
@@ -25,6 +26,19 @@ for the newest Y on each of those two branches.
   - [Hotfix release](#hotfix-release)
   - [Security release](#security-release)
 - [Release Commands Cheat Sheet](#release-commands-cheat-sheet)
+
+## Content Notice
+
+The Patch Release Team and Branch Manager roles have been consolidated into a
+single [Release Managers][release-managers] group.
+
+This means that several areas of this document may currently be out of date.
+While we work to update these documents, please reach out to
+[Release Managers][release-managers] directly for any clarifications on Release
+Engineering processes.
+
+**This notice will be removed when the documentation is no longer under
+construction.**
 
 ---
 

--- a/release-managers.md
+++ b/release-managers.md
@@ -6,8 +6,7 @@ The responsibilities of each role are described below.
 
 - [Contact](#contact)
 - [Handbooks](#handbooks)
-- [Patch Release Team](#patch-release-team)
-- [Branch Managers](#branch-managers)
+- [Release Managers](#release-managers)
 - [Associates](#associates)
 - [Build Admins](#build-admins)
 - [SIG Release Chairs](#sig-release-chairs)
@@ -16,42 +15,41 @@ The responsibilities of each role are described below.
 
 | Mailing List | Slack | Visibility | Usage | Membership |
 |---|---|---|---|---|
-| [release-managers@kubernetes.io](mailto:release-managers@kubernetes.io) | [#release-management](https://kubernetes.slack.com/messages/CJH2GBF7Y) (channel) / @release-managers (user group) | Public | Public discussion for Release Managers | All Release Managers (Patch Release Team, Branch Managers, Associates, Build Admins, SIG Chairs) |
+| [release-managers@kubernetes.io](mailto:release-managers@kubernetes.io) | [#release-management](https://kubernetes.slack.com/messages/CJH2GBF7Y) (channel) / @release-managers (user group) | Public | Public discussion for Release Managers | All Release Managers (including Associates, Build Admins, and SIG Chairs) |
 | [release-managers-private@kubernetes.io](mailto:release-managers-private@kubernetes.io) | [#release-private](https://kubernetes.slack.com/messages/GKEA5EL67) | Private | Private discussion for privileged Release Managers | Patch Release Team, Branch Managers, SIG Chairs |
 | [security-release-team@kubernetes.io](mailto:security-release-team@kubernetes.io) | N/A | Private | Security release coordination with the Product Security Committee | [security-discuss-private@kubernetes.io](mailto:security-discuss-private@kubernetes.io), [release-managers-private@kubernetes.io](mailto:release-managers-private@kubernetes.io) |
 
 ## Handbooks
 
+**NOTE: The Patch Release Team and Branch Manager handbooks will be deduplicated at a later date.**
+
 - [Patch Release Team](/release-engineering/role-handbooks/patch-release-team.md)
 - [Branch Managers](/release-engineering/role-handbooks/branch-manager.md)
 - [Build Admins](/release-engineering/packaging.md)
 
-## Patch Release Team
+## Release Managers
 
-The Patch Release Team is responsible for coordinating patch releases (`x.y.z`, where `z` > 0) of Kubernetes.
+Release Managers are responsible for:
+
+- Coordinating patch releases (`x.y.z`, where `z` > 0) of Kubernetes
+- Minor releases (`x.y.z`, where `z` = 0) of Kubernetes, working with the [Release Team](/release-team/README.md) through each release cycle
+- Mentorship of the [Release Manager Associates](#associates) group
 
 This team at times works in close conjunction with the [Product Security Committee][psc] and therefore should abide by the guidelines set forth in the [Security Release Process][security-release-process].
 
 GitHub Access Controls: [@kubernetes/release-managers](https://github.com/orgs/kubernetes/teams/release-managers)
 
-GitHub Mentions: [@kubernetes/patch-release-team](https://github.com/orgs/kubernetes/teams/patch-release-team)
-
-- Doug MacEachern ([@dougm](https://github.com/dougm))
-- Hannes Hörl ([@hoegaarden](https://github.com/hoegaarden))
-- Pengfei Ni ([@feiskyer](https://github.com/feiskyer))
-- Stephen Augustus ([@justaugustus](https://github.com/justaugustus))
-- Tim Pepper ([@tpepper](https://github.com/tpepper))
-- Yang Li ([@idealhack](https://github.com/idealhack))
-
-## Branch Managers
-
-Branch Managers are responsible for minor releases (`x.y.z`, where `z` = 0) of Kubernetes, working with the [Release Team](/release-team/README.md) through each release cycle.
-
-This team at times works in close conjunction with the [Product Security Committee][psc] and therefore should abide by the guidelines set forth in the [Security Release Process][security-release-process].
+GitHub Mentions: [@kubernetes/release-engineering](https://github.com/orgs/kubernetes/teams/release-engineering)
 
 - Carlos Panato ([@cpanato](https://github.com/cpanato))
 - Daniel Mangum ([@hasheddan](https://github.com/hasheddan))
+- Doug MacEachern ([@dougm](https://github.com/dougm))
+- Hannes Hörl ([@hoegaarden](https://github.com/hoegaarden))
+- Pengfei Ni ([@feiskyer](https://github.com/feiskyer))
 - Sascha Grunert ([@saschagrunert](https://github.com/saschagrunert))
+- Stephen Augustus ([@justaugustus](https://github.com/justaugustus))
+- Tim Pepper ([@tpepper](https://github.com/tpepper))
+- Yang Li ([@idealhack](https://github.com/idealhack))
 
 ## Associates
 

--- a/release-team/role-handbooks/branch-manager/OWNERS
+++ b/release-team/role-handbooks/branch-manager/OWNERS
@@ -1,7 +1,0 @@
-# See the OWNERS docs at https://go.k8s.io/owners
-
-approvers:
-  - release-engineering-approvers
-reviewers:
-  - release-engineering-approvers
-  - release-engineering-reviewers

--- a/release-team/role-handbooks/branch-manager/OWNERS
+++ b/release-team/role-handbooks/branch-manager/OWNERS
@@ -1,6 +1,7 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-  - release-engineering
+  - release-engineering-approvers
 reviewers:
-  - release-engineering
+  - release-engineering-approvers
+  - release-engineering-reviewers

--- a/release-team/role-handbooks/branch-manager/README.md
+++ b/release-team/role-handbooks/branch-manager/README.md
@@ -1,4 +1,0 @@
-This handbook has moved under [Release Engineering](/release-engineering/role-handbooks/branch-manager.md).
-<!--
-This file is a placeholder to preserve links.  Please remove after 6 months or the release of Kubernetes 1.19, whichever comes first.
--->

--- a/release-team/role-handbooks/patch-release-manager/OWNERS
+++ b/release-team/role-handbooks/patch-release-manager/OWNERS
@@ -1,7 +1,0 @@
-# See the OWNERS docs at https://go.k8s.io/owners
-
-approvers:
-  - release-engineering-approvers
-reviewers:
-  - release-engineering-approvers
-  - release-engineering-reviewers

--- a/release-team/role-handbooks/patch-release-manager/OWNERS
+++ b/release-team/role-handbooks/patch-release-manager/OWNERS
@@ -1,6 +1,7 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-  - release-engineering
+  - release-engineering-approvers
 reviewers:
-  - release-engineering
+  - release-engineering-approvers
+  - release-engineering-reviewers

--- a/release-team/role-handbooks/patch-release-manager/README.md
+++ b/release-team/role-handbooks/patch-release-manager/README.md
@@ -1,4 +1,0 @@
-This handbook has moved under [Release Engineering](/release-engineering/role-handbooks/patch-release-team.md).
-<!--
-This file is a placeholder to preserve links.  Please remove after 6 months or the release of Kubernetes 1.19, whichever comes first.
--->

--- a/release-team/role-handbooks/test-infra/OWNERS
+++ b/release-team/role-handbooks/test-infra/OWNERS
@@ -1,6 +1,7 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-  - release-engineering
+  - release-engineering-approvers
 reviewers:
-  - release-engineering
+  - release-engineering-approvers
+  - release-engineering-reviewers


### PR DESCRIPTION
#### What type of PR is this:

/kind cleanup documentation

#### Action items

- [ ] (https://github.com/kubernetes/org/pull/1919) Consolidate GitHub teams
- [ ] Update OWNERS
  - [ ] (https://github.com/kubernetes/sig-release/pull/1106) k/sig-release
  - [ ] (https://github.com/kubernetes/release/pull/1336) k/release
- [ ] (https://github.com/kubernetes/test-infra/pull/17868) Update bot comment for patch releases
- [ ] (https://github.com/kubernetes/website/pull/21548) Update references to the patch release process on k/website
- [ ] (https://github.com/kubernetes/security/pull/90) Update Release Manager roles on k/security

#### What this PR does / why we need it:

From a [note I sent](https://groups.google.com/a/kubernetes.io/d/topic/release-managers/_qqdJre-JQY/discussion) to @kubernetes/release-engineering earlier in the week:

> Hey Release Managers,
> 
> I had a chat with Tim yesterday about something that's been on my mind a bit.
> 
> From an access perspective, the Patch Release Team and Branch Managers are nearly identical:
> 
>     * Authorization/access to stage/release Kubernetes
> 
>     * Write access to kubernetes/kubernetes
> 
>     * In the notification circle for active CVEs and responsible for helping to mitigate CVEs
> 
> 
> I think the Branch Managers (Carlos, Sascha, and Dan) have been stepping up in a big way to provide coverage for patch releases, and I see no real reason to not give them the mandate to cut patch releases on a consistent/official basis.
> 
> That said, I'd like to consolidate the Patch Release Team + Branch Managers into simply "Release Managers", with the Release Manager Associates remaining as the apprentice-level members of the team.
> 
> There are a few things to think through (and we can step through that at a later time), but I figured it'd be good to start the conversation.

/hold for discussion
/assign @tpepper @saschagrunert @cpanato @hasheddan 

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

#### Special notes for your reviewer:
