### PR TITLE
patch release schedule: active and non-active branch description

### DIFF
--- a/releases/patch-releases.md
+++ b/releases/patch-releases.md
@@ -55,7 +55,7 @@ releases may also occur in between these.
 | December 2020 | 2020-12-09 |
 | January 2021 | 2021-01-13 |
 
-## Detailed Release History
+## Detailed Release History for Active Branches
 
 ### 1.18
 
@@ -103,7 +103,7 @@ Next patch release is **1.16.12**.
 | 1.16.2 | 2019-10-11 | 2019-10-15 |
 | 1.16.1 | 2019-09-27 | 2019-10-02 |
 
-### 1.15 and older
+## Non-Active Branch History
 
 These releases are no longer supported.
 


### PR DESCRIPTION
Between this document and the k8s.io website it remains less than fully
clear what are the current active branches, especially when 1.19 comes
out.  The website is getting some clarification in the 1.19 branch at
https://github.com/kubernetes/website/pull/21928#issuecomment-649688854

A follow change here for 1.19 and newer would be to add additional
mention of through when we're expecting a currently active branch to go
EOL and non-active.

Signed-off-by: Tim Pepper <tpepper@vmware.com>

/kind documentation