### PR TITLE
patch release schedule: update "next" numbers

### DIFF
--- a/releases/patch-releases.md
+++ b/releases/patch-releases.md
@@ -59,7 +59,7 @@ releases may also occur in between these.
 
 ### 1.18
 
-Next patch release is **1.18.5**.
+Next patch release is **1.18.6**.
 
 | Patch Release | Cherry-picks deadline | Target date |
 | --- | --- | --- |
@@ -72,7 +72,7 @@ Next patch release is **1.18.5**.
 
 ### 1.17
 
-Next patch release is **1.17.8**.
+Next patch release is **1.17.9**.
 
 | Patch Release | Cherry-picks deadline | Target date |
 | --- | --- | --- |
@@ -88,7 +88,7 @@ Next patch release is **1.17.8**.
 
 ### 1.16
 
-Next patch release is **1.16.12**.
+Next patch release is **1.16.13**.
 
 | Patch Release | Cherry-picks deadline | Target date |
 | --- | --- | --- |


### PR DESCRIPTION
As we get to machine readable content, these updates and consistency
should be more automated.  In the meantime, the recent commit
61b49430e15a2f072288eff595892bca70cc83e7 didn't increment the
eye-catcher "next release" numbers and they all need a +=1.

Signed-off-by: Tim Pepper <tpepper@vmware.com>

/kind documentation