### PR TITLE
Add saschagrunert and alejandrox1 as SIG Release admins 

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,7 +1,8 @@
 aliases:
   sig-release-leads:
-    - calebamiles
+    - alejandrox1
     - justaugustus
+    - saschagrunert
     - tpepper
   licensing:
     - dims # subproject owner


### PR DESCRIPTION
#### What type of PR is this:

/kind documentation

#### What this PR does / why we need it:
To fulfill the role as new technical lead we need to be part of the SIG
release admin role.
#### Which issue(s) this PR fixes:
Ref https://github.com/kubernetes/community/pull/4867

#### Special notes for your reviewer:
None