### PR TITLE
add a release blog outline & template for comms team

### DIFF
--- a/release-team/role-handbooks/communications/README.md
+++ b/release-team/role-handbooks/communications/README.md
@@ -226,4 +226,5 @@ There is a channel on the Kubernetes Slack workspace, `release-comms`, which is 
     </tr>
 </table>
 
-
+## Release Blog Outline & Template
+To support you in the creation of the release blog this [outline](/release-team/role-handbooks/communications/release-blog.md) summarize ideas for sections and gives you a template for easier release blog creation.

--- a/release-team/role-handbooks/communications/release-blog.md
+++ b/release-team/role-handbooks/communications/release-blog.md
@@ -1,0 +1,139 @@
+# Outline for the Kubernetes Release Blog
+This outline can be used as reference for writing up the release blog. The following sections should give you an idea what can be consider for the blog, but for sure you don't/can't include all sections:
+
+* Introduction to release
+    * The first paragraph of the release blog announcement introduces the release, its focus, and its importance.
+* Major Themes (Enhancements)
+    * Order release features by impact, maturity, vision.
+    * This section lists out the key features (even if they are not being recommended to be used in production or are alphas).
+        * When we describe something in the alpha state, we are highlighting what is going on (in/to) the community.
+        * Release cycles are so short, just because it is alpha right now, it will be stable soon. Position it as “this is what is coming.”
+    * Include additional features and what's next section following the key release features.
+        * This is the vision and brand new thing you can do in-production right now.
+    * Blog posts should highlight the main features and include mention of the 5-day blog series.
+    * Everything else is included in the release notes.
+* Release notes
+    * Release notes are always included in the blog announcement.
+* Availability of release
+    * Link to where the release can be downloaded on GitHub.
+    * Include interactive tutorials on the current release or how to get started with Kubernetes when relevant.
+* Release Team
+    * Mention job of release team
+    * Important to highlight company contributions in a way that is respectful to the entire community – including a copy of the release team in relation to the project and their work
+    * Mention efforts of community
+    * Mention the growth of the community
+    * List of contributors to the spec should go in the 5 Day blog series
+* User Highlights
+* Project Velocity
+    * Growth since the last release
+    * Number of companies involved in the release
+    * Other relevant velocity numbers from DevStats
+* Ecosystem Updates
+* Event Updates
+    * Relevant KubeCon dates and information
+    * Conferences where the release will be discussed
+* Upcoming release webinar
+    * CNCF hosts a release webinar 30 days after the release is available. Webinar is conducted by the release team and discusses the current release. Include information on the webinar in the release announcement blog to encourage attendance.
+* Get Involved
+    * SIGs
+    * Community Meeting
+    * Where to host questions (or answer questions) 
+    * Advocates
+    * Twitter
+    * Slack
+    * Kubernetes blog
+
+## Latest Release Blogs as Reference
+* [Kubernetes 1.18: Fit & Finish](https://kubernetes.io/blog/2020/03/25/kubernetes-1-18-release-announcement/)
+* [Kubernetes 1.17: Stability](https://kubernetes.io/blog/2019/12/09/kubernetes-1-17-release-announcement/)
+* [Kubernetes 1.16: Custom Resources, Overhauled Metrics, and Volume Extensions](https://kubernetes.io/blog/2019/09/18/kubernetes-1-16-release-announcement/)
+
+## Release Blog Template
+
+The template should give you some boilerplate. However, each release has its own story to tell, there will be always something special around and exactly this flavour must be brought and individualized into the relase blog. Don't be just a copy cat.
+
+```md
+---
+layout: blog
+title: 'Kubernetes 1.XX: <Release Name>'
+date: 2020-03-25
+slug: kubernetes-1-XX-release-announcement
+---
+
+**Authors:** [Kubernetes 1.XX Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.XX/release_team.md)
+
+<INTRO>
+
+
+## Major Themes
+
+### <THEME 1>
+
+### <THEME 2>
+
+### <THEME 3>
+
+### <THEME 4>
+
+### <THEME 5>
+
+## Other Updates
+
+### Graduated to Stable
+
+- [<Enhancement Name>](<LINKE TO ENHANCEMENT>)
+- [...](...)
+
+### Major Changes
+
+- [<Enhancement Name>](<LINKE TO ENHANCEMENT>)
+- [...](...)
+
+### Release Notes
+
+Check out the full details of the Kubernetes 1.XX release in our [release notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.XX.md).
+
+### Availability
+
+Kubernetes 1.XX is available for download on [GitHub](https://github.com/kubernetes/kubernetes/releases/tag/v1.XX.0). To get started with Kubernetes, check out these [interactive tutorials](https://kubernetes.io/docs/tutorials/) or run local Kubernetes clusters using Docker container “nodes” with [kind](https://kind.sigs.k8s.io/). You can also easily install 1.XX using [kubeadm](https://kubernetes.io/docs/setup/independent/create-cluster-kubeadm/). 
+
+### Release Team
+
+<FIND AN INDIVIDUAL TEXT, EACH RELEASE TEAM HAS ITS OWN STORY, TELL IT!>
+
+### User Highlights
+
+<ADD RECENTLY/LAST 3 MONTHES PUBLISHED END USER USE CASES AND GIVE THEM SOME WORDS>
+
+### Ecosystem Updates
+
+<ADD LATEST SURVEY, CNCF COURSES/TRAININGS OR OTHER CNCF RELEVANT ANNOUNCEMENTS>
+
+### Project Velocity
+
+<CHECKOUT THE DEVSTATS AND HIGHLIGHT SOME INTRESTING NUMBERS https://k8s.devstats.cncf.io/d/12/dashboards?orgId=1&refresh=15m>
+
+<AS EXAMPLE>
+This past quarter, 641 different companies and over 6,409 individuals contributed to Kubernetes. [Check out DevStats](https://k8s.devstats.cncf.io/d/11/companies-contributing-in-repository-groups?orgId=1&var-period=m&var-repogroup_name=All) to learn more about the overall velocity of the Kubernetes project and community.
+
+### Event Update
+
+<THERE WILL BE ALWAYS A KUBECON/CLOUDNATIVECON AROUND, GIVE THE LATEST INFORMATION>
+
+### Upcoming Release Webinar
+
+<RELEASE WEBINARE WILL TAKE PLACE NORMALLY 30 DAYS AFTER RELEASE, ALIGN WITH CNCF TO HIGHLIGHT THE WEBINAR>
+
+### Get Involved
+<THIS COMMUNITY LIVES BY ITS GREAT COMMUNITY, GET THEM INVOLVED!>
+The simplest way to get involved with Kubernetes is by joining one of the many [Special Interest Groups](https://github.com/kubernetes/community/blob/master/sig-list.md) (SIGs) that align with your interests. Have something you’d like to broadcast to the Kubernetes community? Share your voice at our weekly [community meeting](https://github.com/kubernetes/community/tree/master/communication), and through the channels below. Thank you for your continued feedback and support.
+
+- Follow us on Twitter [@Kubernetesio](https://twitter.com/kubernetesio) for latest updates
+- Join the community discussion on [Discuss](https://discuss.kubernetes.io/)
+- Join the community on [Slack](http://slack.k8s.io/)
+- Post questions (or answer questions) on [Stack Overflow](http://stackoverflow.com/questions/tagged/kubernetes)
+- Share your Kubernetes [story](https://docs.google.com/a/linuxfoundation.org/forms/d/e/1FAIpQLScuI7Ye3VQHQTwBASrgkjQDSS5TP0g3AXfFhwSM9YpHgxRKFA/viewform)
+- Read more about what’s happening with Kubernetes on the [blog](https://kubernetes.io/blog/)
+- Learn more about the [Kubernetes Release Team](https://github.com/kubernetes/sig-release/tree/master/release-team)
+```
+


### PR DESCRIPTION
This PRs md file covers a legacy document, passed from release to release, to outline potential sections for the release blog, and a template for an uncomplicated release blog creation.

#### What type of PR is this:
/kind documentation

#### What this PR does / why we need it:
Supporting the comms & release team by boilerplate the scaffold for the release blog.

/cc @onlydole @mrbobbytables @jeremyrickard 
/cc @RCantw3ll @mkhaas @jrsapi
