### PR TITLE
update ref to checkout for packaging debs/rpms

### DIFF
--- a/release-engineering/packaging.md
+++ b/release-engineering/packaging.md
@@ -73,7 +73,7 @@ cd release
 **IMPORTANT: You must checkout a `kubernetes/release` tag >= [`v0.3.3`](https://github.com/kubernetes/release/releases/tag/v0.3.3) to address a [CVE for CNI plugins](https://github.com/kubernetes/kubernetes/issues/91507).**
 
 ```shell
-git checkout v0.3.3
+git checkout master
 ```
 
 ### Authenticate


### PR DESCRIPTION
This is a temporary fix; we should also move these docs to
github.com/kubernetes/release as well so that the tools and the
instructions are versioned together.

#### What type of PR is this:

/kind documentation

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

#### Special notes for your reviewer:

/cc @BenTheElder