### PR TITLE
Update groups permissions to reflect latest changes in k8s.io

### DIFF
--- a/.github/ISSUE_TEMPLATE/lead.md
+++ b/.github/ISSUE_TEMPLATE/lead.md
@@ -75,10 +75,12 @@ As you work through the checklist, use the following PRs as guides:
   - [ ] `kubernetes/release`
   - [ ] `kubernetes/sig-release`
 - [ ] Update Google Groups/GCP IAM membership [(`kubernetes/k8s.io`)](https://git.k8s.io/k8s.io/groups/groups.yaml)
-  - `k8s-infra-release-editors@`
-  - `k8s-infra-release-viewers@`
-  - `release-managers@`
-  - `release-managers-private@`
+  - `leads` (members)
+  - `k8s-infra-release-admins` (members)
+  - `k8s-infra-release-editors` (members)
+  - `release-comms` (owners)
+  - `release-managers` (owners)
+  - `release-managers-private` (owners)
 - [ ] Manually grant permission to post on [kubernetes-announce](https://groups.google.com/forum/#!forum/kubernetes-announce)
 - [ ] Manually add to the [Release Team Google Group](https://groups.google.com/forum/#!forum/kubernetes-release-team)
 - [ ] Update Slack `release-managers` and `release-team-leads` User Group [(`kubernetes/community`)](https://git.k8s.io/community/communication/slack-config/sig-release/usergroups.yaml)

--- a/leads/onboarding.md
+++ b/leads/onboarding.md
@@ -72,10 +72,12 @@ Managers, which are:
 - Have the correct Google Groups/GCP IAM membership in kubernetes/k8s.io:
   https://git.k8s.io/k8s.io/groups/groups.yaml
 
-  - k8s-infra-release-editors@
-  - k8s-infra-release-viewers@
-  - release-managers@
-  - release-managers-private@
+  - leads (members)
+  - k8s-infra-release-admins (members)
+  - k8s-infra-release-editors (members)
+  - release-comms (owners)
+  - release-managers (owners)
+  - release-managers-private (owners)
 
 - Be part of the Slack release-managers and release-team-leads User Group in
   kubernetes/community:


### PR DESCRIPTION

#### What type of PR is this:

/kind cleanup
/kind documentation

#### What this PR does / why we need it:
The latest changes to k8s.io groups/groups.yaml should be now reflected in the onboarding guide as well as the corresponding issue template.
#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:
Follow-up on https://github.com/kubernetes/k8s.io/pull/1080
Refers to https://github.com/kubernetes/sig-release/pull/1123