### PR TITLE
Clarify that release notes team members should join k-sigs

### DIFF
--- a/release-team/release-team-onboarding.md
+++ b/release-team/release-team-onboarding.md
@@ -20,7 +20,7 @@ The Kubernetes Community [defines](https://github.com/kubernetes/community/blob/
 
 The requirements for becoming a member are enumerated in the [k/community repo documentation](https://github.com/kubernetes/community/blob/master/community-membership.md#member). Generally, you'll need a few public contributions and some existing community members to sponsor you. The Release Team is a great place to meet members of the community that might be able to meet sponsors!
 
-For new shadows, it's not always necessary to become a member of the GitHub organization right away. Talk to the lead for the Release Team role you're shadowing for the definitive answer. For some roles (Enhancements for example) it is important for Shadows to be members of the GitHub organization because they have to maintain milestones in the [k/enhancements](https://github.com/kubernetes/enhancements) repo. For other roles (Release Notes for example), it's less urgent for new Shadows to be members of the GitHub organization. Your mileage may vary, but you should try to become an official member of the Kubernetes Community as soon as possible.
+For new shadows, it's not always necessary to become a member of the GitHub organization right away. Talk to the lead for the Release Team role you're shadowing for the definitive answer. For some roles (Enhancements for example) it is important for Shadows to be members of the GitHub organization because they have to maintain milestones in the [k/enhancements](https://github.com/kubernetes/enhancements) repo. For other roles it's less urgent for new Shadows to be members of the GitHub organization. Your mileage may vary, but you should try to become an official member of the Kubernetes Community as soon as possible.
 
 ## All Members
 

--- a/release-team/role-handbooks/release-notes/README.md
+++ b/release-team/role-handbooks/release-notes/README.md
@@ -70,7 +70,7 @@ The `release-notes` subcommand of `krel` must continue to be run on the release 
 
 ### GitHub Organization Membership
 
-As well as becoming a member of the kubernetes GitHub organization as discussed in the [Release Team Onboarding Guide](/release-team/release-team-onboarding.md), release notes members should ensure that they become members of the kubernetes-sigs GitHub organization. The tooling used by the release notes team creates pull requests kubernetes and kubernetes-sigs repositories, so membership of both is needed to streamline reviews.
+As well as becoming a member of the kubernetes GitHub organization as discussed in the [Release Team Onboarding Guide](/release-team/release-team-onboarding.md), release notes members should ensure that they [become members of the kubernetes-sigs GitHub organization](https://github.com/kubernetes/community/blob/master/community-membership.md#kubernetes-ecosystem). The tooling used by the release notes team creates pull requests kubernetes and kubernetes-sigs repositories, so membership of both is needed to streamline reviews.
 
 ### Machine and GitHub Setup
 

--- a/release-team/role-handbooks/release-notes/README.md
+++ b/release-team/role-handbooks/release-notes/README.md
@@ -68,6 +68,10 @@ The Release Notes team should use the [template](relnotes-template.md) to organi
 
 The `release-notes` subcommand of `krel` must continue to be run on the release branch (for `beta` and `rc` releases) in order to pull in any outstanding PRs that are merged between the beginning of code freeze and the release.
 
+### GitHub Organization Membership
+
+As well as becoming a member of the kubernetes GitHub organization as discussed in the [Release Team Onboarding Guide](/release-team/release-team-onboarding.md), release notes members should ensure that they become members of the kubernetes-sigs GitHub organization. The tooling used by the release notes team creates pull requests kubernetes and kubernetes-sigs repositories, so membership of both is needed to streamline reviews.
+
 ### Machine and GitHub Setup
 
 #### Setup krel


### PR DESCRIPTION
Also remove release notes as an example of a team that does not need org membership right away, as you do.

<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this:

/kind documentation

#### What this PR does / why we need it:

Release notes team members (within the release team) generally open pull requests to both [kubernetes/release](https://github.com/kubernetes/sig-release) and [kubernetes-sigs/release-notes](https://github.com/kubernetes-sigs/release-notes) as part of their duties. Becoming members of both organisations streamlines reviews for these changes.

#### Which issue(s) this PR fixes:

None.

#### Special notes for your reviewer:

None.