### PR TITLE
Added schedule of recurring work

### DIFF
--- a/release-engineering/README.md
+++ b/release-engineering/README.md
@@ -1,3 +1,29 @@
 # Release Engineering
 
-Placeholder for Release Engineering subproject
+## Schedule of Recurring Work
+
+These topics recur for release engineering during every release cycle. To keep the team’s workflow more manageable, it’s advisable to account for this work as part of the time/planning budget:
+
+### Quarterly
+
+- New minor releases
+ 
+### Monthly
+
+- Patch releases
+  - Cut the three most recent minor versions
+  - A week before each patch deadline, have an updated status report on all cherry picks
+ 
+### Weekly
+
+- Cherry pick triage and approval
+- Provide status updates at Release Team meetings
+ 
+### Ongoing
+
+- Cut prereleases (alpha, beta, release candidate) for the minor release in development
+ 
+### Ad Hoc
+
+- Update Golang versions in Kubernetes
+- Update core Kubernetes base images


### PR DESCRIPTION
This new section offers details about the recurring work topics that Release Engineering must manage and plan.

/kind documentation
/area/release-eng
/sig/release