### PR TITLE
Remove inactive members from OWNERS files

### DIFF
--- a/releases/release-1.11/OWNERS
+++ b/releases/release-1.11/OWNERS
@@ -8,5 +8,5 @@ reviewers:
   - calebamiles
   - jdumars
   - tpepper
-  - nickchase
   - AishSundar
+  # - nickchase (release notes lead)

--- a/releases/release-1.12/OWNERS
+++ b/releases/release-1.12/OWNERS
@@ -5,5 +5,5 @@ approvers:
   - AishSundar # RT Lead Shadow
 reviewers:
   - justaugustus
-  - nickchase
   - marpaia
+  # - nickchase (release notes lead)


### PR DESCRIPTION
Ref: kubernetes/org#2076

As a part of cleaning up inactive members (who haven't been active since
beginning of 2019) from OWNERS files, this commit comments out nickchase
from the list of reviewers for release-1.11 and release-1.12.

Note: the `emeritus_approvers` field is only used for approvers. To
ensure that we still acknowledge contributions from leads in previous
release teams, this commit only comments out the inactive members in
OWNERS files, instead of removing them entirely.

cc @nickchase @mrbobbytables 
/kind cleanup