### PR TITLE
Assemble the 1.20 Release Team Leads

### DIFF
--- a/releases/release-1.20/release-team.md
+++ b/releases/release-1.20/release-team.md
@@ -1,0 +1,16 @@
+# Kubernetes 1.20 Release Team
+
+| **Role** | **Name** (**GitHub / Slack ID**) | **Shadow Name(s) (GitHub / Slack ID)** |
+|---|---|---|
+| Lead | Jeremy Rickard ([@jeremyrickard](https://github.com/jeremyrickard) / Slack: `@jerickar`) | Daniel Mangum ([@hasheddan](https://github.com/hasheddan) / Slack: `@hasheddan`), Nabarun Pal ([@palnabarun](https://github.com/palnabarun) / Slack: `@palnabarun`), Savitha Raghunathan ([@savitharaghunathan](https://github.com/savitharaghunathan) / Slack: `@sraghunathan`) |
+| Enhancements | Kirsten Garrison ( [@kikisdeliveryservice](https://github.com/kikisdeliveryservice) / Slack: `@oikiki`) | |
+| CI Signal | Robert Kielty ([@RobertKielty](https://github.com/RobertKielty) / Slack: `@RobKielty`) | |
+| Bug Triage | Vlad Gorodetsky ([@bai](https://github.com/bai) / Slack: `@bai`) | |
+| Docs | Anna Jung ([@annajung](https://github.com/annajung) / Slack: `@annajung`) | |
+| Release Notes | James Laverack ([@JamesLaverack](https://github.com/JamesLaverack) / Slack: `@james.laverack`) | |
+| Communications | Joseph Sandoval ([@jrsapi](https://github.com/jrsapi) / Slack: `@sandoval`) | |
+| Emeritus Adviser | TBD | |
+
+Review the [Release Managers page](/release-managers.md) for up-to-date contact information on Release Engineering personnel.
+
+The schedule for all patch releases can be found at [Patch Releases page](/releases/patch-releases.md). It will be updated to include 1.19, once the 1.19 release cycle concludes.


### PR DESCRIPTION
#### What this PR does / why we need it:

Add 1.20 Release Folder and adds the `release-team.md` file to identify the 1.20 leads. 

ref: #1185 

/kind feature cleanup
/priority important-soon

/area release-team
/milestone v1.20
/cc @onlydole @tpepper @justaugustus @alejandrox1 

Signed-off-by: Jeremy Rickard <rickardj@vmware.com>