### PR TITLE
Adding 1.20 OWNERS

### DIFF
--- a/releases/release-1.20/OWNERS
+++ b/releases/release-1.20/OWNERS
@@ -1,0 +1,12 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - jeremyrickard         # Release Team Lead
+
+reviewers:
+  - kikisdeliveryservice  # Enhancements
+  - robertkielty          # CI Signal
+  - bai                   # Bug Triage
+  - annajung              # Docs
+  - jameslaverack         # Release Notes
+  - jrsapi                # Communications


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this:


/kind feature cleanup
/priority important-soon

/area release-team
/milestone v1.20

#### What this PR does / why we need it:

This PR adds the incoming 1.20 release leads as `OWNERS` for `release-1.20` so that we can approve/review. We have not yet identified the 1.20 Emeritus Advisor, so a follow up PR will be opened to update this once they have accepted! 

#### Which issue(s) this PR fixes:
ref: #1185 

Signed-off-by: Jeremy Rickard <rickardj@vmware.com>

