### PR TITLE
Automatically cc release manager in release cut issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/cut-release.md
+++ b/.github/ISSUE_TEMPLATE/cut-release.md
@@ -82,7 +82,9 @@ to get these questions answered.
 
 /milestone <!-- v1.x e.g. v1.14 -->
 /assign <!-- @ the Release Manager responsible for this release -->
-<!-- cc: shadows (optional)-->
+/cc @kubernetes/release-managers
+/priority important-soon
+/kind documentation
 
 <!-- Example template for screenshots comment:
 


### PR DESCRIPTION
#### What type of PR is this:

/kind documentation

#### What this PR does / why we need it:
We now automatically cc the release managers which should be a necessary
step. Beside that, we correctly set the priority and kind of the issue.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #
or
None
-->
None

#### Special notes for your reviewer:
None
