### PR TITLE
Add Lachie as EA

### DIFF
--- a/releases/release-1.20/OWNERS
+++ b/releases/release-1.20/OWNERS
@@ -2,6 +2,7 @@
 
 approvers:
   - jeremyrickard         # Release Team Lead
+  - lachie83              # Emeritus Adviser
 
 reviewers:
   - kikisdeliveryservice  # Enhancements

--- a/releases/release-1.20/release-team.md
+++ b/releases/release-1.20/release-team.md
@@ -8,8 +8,8 @@
 | Bug Triage | Vlad Gorodetsky ([@bai](https://github.com/bai) / Slack: `@bai`) | |
 | Docs | Anna Jung ([@annajung](https://github.com/annajung) / Slack: `@annajung`) | |
 | Release Notes | James Laverack ([@JamesLaverack](https://github.com/JamesLaverack) / Slack: `@james.laverack`) | |
-| Communications | Joseph Sandoval ([@jrsapi](https://github.com/jrsapi) / Slack: `@sandoval`) | |
-| Emeritus Adviser | TBD | |
+| Communications | Joseph Sandoval ([@jrsapi](https://github.com/jrsapi) / Slack: `@j-dawg`) | |
+| Emeritus Adviser | Lachlan Evenson ([@lachie83](https://github.com/lachie83) / Slack: `@lachie83`) | -- |
 
 Review the [Release Managers page](/release-managers.md) for up-to-date contact information on Release Engineering personnel.
 


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR adds @lachie83 as the Emeritus Advisor for Kubernetes 1.20 and fixes the slack handle for Joseph Sandoval. 



#### Which issue(s) this PR fixes:

ref: #1185 
/kind cleanup feature
/priority important-soon

/area release-team
/milestone v1.20

Signed-off-by: Jeremy Rickard <rickardj@vmware.com>