### PR TITLE
Only keep current rt leads

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -28,10 +28,8 @@ aliases:
     - xmudrii # Release Manager Associate
   release-team:
     - alejandrox1 # subproject owner / 1.18 RT Lead
-    - claurence # subproject owner / 1.15 RT Lead
     - guineveresaenger # subproject owner / 1.17 RT Lead
     - justaugustus # subproject owner
-    - lachie83 # subproject owner / 1.16 RT Lead
     - tpepper # subproject owner
     - jeremyrickard / 1.20 RT Lead
   build-admins:
@@ -40,8 +38,6 @@ aliases:
     - ps882
     - sumitranr
   release-team-lead-role:
-    - claurence # 1.15
-    - lachie83 # 1.16
     - guineveresaenger # 1.17
     - alejandrox1 # 1.18
     - onlydole # 1.19 RT Lead


### PR DESCRIPTION
Signed-off-by: alejandrox1 <alarcj137@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this:
/kind cleanup

#### What this PR does / why we need it:
Off-boarding release team leads from releases going out of the support window (1.15 and 1.16) .

/assign @justaugustus @tpepper @jeremyrickard @saschagrunert 