### PR TITLE
Use absolute image url to fix k8s.dev/resources/release

### DIFF
--- a/releases/release-1.19/README.md
+++ b/releases/release-1.19/README.md
@@ -10,7 +10,7 @@ description: |
 
 # Kubernetes 1.19: Accentuate The Paw-sitive
 
-<img src="accentuate-the-pawsitive.png" height=400 width=auto>
+<img src="https://raw.githubusercontent.com/kubernetes/sig-release/master/releases/release-1.19/accentuate-the-pawsitive.png" height=400 width=auto>
 
 All of you inspired this Kubernetes 1.19 release logo! This release was a bit more of a marathon and a testament to when the world is a wild place, we can come together and do unbelievable things. 
 


### PR DESCRIPTION
Theoretically the importer that generates k8s.dev could have some logic to download images, etc

For now it looks like it's easier to just use an absolute URL. Fixes: kubernetes-sigs/contributor-site#161

/kind documentation
