### PR TITLE
Release notes role handbook update detailing new process

### DIFF
--- a/release-team/role-handbooks/release-notes/README.md
+++ b/release-team/role-handbooks/release-notes/README.md
@@ -13,6 +13,7 @@
     - [Fork the kubernetes repositories](#fork-the-kubernetes-repositories)
 - [Tasks and Responsibilities](#tasks-and-responsibilities)
   - [Setup the Tools and Generate the Release Notes](#setup-the-tools-and-generate-the-release-notes)
+  - [Periodically review and fix new release notes](#periodically-review-and-fix-new-release-notes)
   - [Attend Release Meetings and follow #sig-release](#attend-Release-Meetings-and-follow-sig-release)
   - [Maintain the _Known Issues_ Issue](#maintain-the-known-issues-issue)
   - [Ensure Major Themes are Reflected in the Notes](#ensure-major-themes-are-reflected-in-the-notes)
@@ -60,6 +61,7 @@ Compared to other release team roles, release notes is one of the least time int
 In the first 8 weeks of the cycle, the Release Notes team should/must, attend weekly release meetings and run the [release-notes subcommand of krel](https://github.com/kubernetes/release/blob/master/docs/krel/release-notes.md) as well as update the [release-notes website](https://github.com/kubernetes-sigs/release-notes) for every `alpha`, `beta` and `rc` to create an early draft of the release notes. This ensures that the overall quality of the release notes can be verified from the beginning of the release cycle.
 
 #### Late release cycle (weeks 9-12+) ~4-10 hours/week
+
 This period has an increase in release team meetings each week and there is also significantly more work to do to ensure the release notes are in good working order for the release.
 
 Once code freeze begins, the release notes draft is transferred to a Google Doc which is made public to the Kubernetes community. The doc will be edited by SIG leads and SIG members but will also be edited for grammar and uniform style by the release notes team. 
@@ -75,10 +77,12 @@ As well as becoming a member of the kubernetes GitHub organization as discussed 
 ### Machine and GitHub Setup
 
 #### Setup krel
+
 Install Go in your machine and follow the [instructions to build the release tools](https://github.com/kubernetes/release/tree/master/docs/krel#installation) in your machine. Check the system requirements in the krel documentation.   
 
 #### Get a GitHub token
-4. Obtain GitHub API Token with the repo scope:
+
+4. Obtain a GitHub Personal Access Token with the repo scope:
 https://github.com/settings/tokens
 - [X] repo
     - [X] repo: status
@@ -87,7 +91,8 @@ https://github.com/settings/tokens
     - [X] repo:invite
 
 #### Fork the kubernetes repositories
-You will need to fork two repositories to you GitHub account:
+
+Fork the following repositories to your GitHub account, and clone them using SSH:
 
  - [`kubernetes/sig-release`](https://github.com/kubernetes/sig-release): This is where you will push regular PRs to keep the Release Notes draft up to date.
  - [`kubernetes-sigs/release-notes`](https://github.com/kubernetes-sigs/release-notes): This repo has the [release notes website](https://relnotes.k8s.io) sources. 
@@ -95,6 +100,7 @@ You will need to fork two repositories to you GitHub account:
 ## Tasks and Responsibilities
 
 ### Setup the Tools and Generate the Release Notes
+
 The main task of the Release Notes team is the generation of the release notes during the release cycle.
 
 At least one member of the Release Notes Team should be responsible for [setting up](https://github.com/kubernetes/release/tree/master/docs/krel#installation) and [running](https://github.com/kubernetes/release/blob/master/docs/krel/release-notes.md) the release-notes subcommand of krel to generate both versions of the release notes after each Patch Release:
@@ -105,25 +111,43 @@ At least one member of the Release Notes Team should be responsible for [setting
 
 Detailed instructions for generating the release notes bundles are in the [krel release-notes subcommand documentation](https://github.com/kubernetes/release/blob/master/docs/krel/release-notes.md).
 
+### Periodically review and fix new release notes
+
+The Release Notes team must make sure that the final document includes well written and 
+informative release notes. To achieve a high-quality document the team should review and edit the
+notes by running `krel release-notes --fix` weekly or as often as development pace
+demands.
+
+This command will enable the team to review each release note and edit the note's data.
+It is recommended that the team splits the work among all members and runs the editing flow
+on a weekly or biweekly basis. More information about the editing flow can be found in
+a separate document detailing the [editing process and tooling](editing-flow.md).
+
 ### Attend Release Meetings and follow #sig-release 
+
 The Release Notes Lead and Shadows attend burn down meetings, SIG Release meetings and follow the [#sig-release](https://kubernetes.slack.com/messages/C2C40FMNF) Slack channel for relevant information throughout the release cycle.
 
 ### Maintain the _Known Issues_ Issue
+
 A ["Known Issues Umbrella Issue"](known-issues-bucket.md) for the release must be created by the release notes team in [kubernetes/kubernetes](https://github.com/kubernetes/kubernetes/issues/new) so issues can be collected for the "Known Issues" section of the release notes. See previous known issues for [v1.19](https://github.com/kubernetes/kubernetes/issues/90304), [v1.18](https://github.com/kubernetes/kubernetes/issues/86882), [v1.17](https://github.com/kubernetes/kubernetes/issues/83683) or [v1.16](https://github.com/kubernetes/kubernetes/issues/81930).
 
 
 ### Ensure Major Themes are Reflected in the Notes
+
 The Communications team will hold meetings to discuss blogposts and media releases regarding the release sometime before code freeze. Ensure that at least one person from the release notes team attends this meeting with the release lead and enhancements lead. The release notes team should ensure that the "Major Themes" identified in this meeting are reflected in the "Major Themes" section of the release notes. If no one is able to attend the meeting, reach out to the communications team, release lead or enhancements lead to ensure messaging around Major Themes is coordinated.
 
 ### Get feedback from SIG Leads
+
 Around Code Freeze, the release notes team will get in touch with the SIG Leads to capture the major themes of their SIGs. The team will also ensure that major issues captured in the release notes are confirmed by the SIG leads before release day.
 
 If gentle nudging of SIG Leads is not effective in retrieving feedback/confirmation, the Release Notes Team can use a reasonable amount of creative liberty in completing the notes
 
 ### Clean up and edit the final document
+
 The confirmed notes are cleaned up and copy edited by the release-notes team to ensure uniform language/style is used.
 
 ### Curate the External Dependencies Section
+
 An "External Dependencies" section should be curated which outlines how external dependency versions have changed since the last release. See [the v1.12 release notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.12.md#external-dependencies) for an example.
 
 Note that there are [plans in the process to formalize and automate the process of aggregating the changes](https://github.com/kubernetes/community/issues/2234), but this is currently [a very manual process](https://github.com/kubernetes/sig-release/pull/398).
@@ -142,6 +166,7 @@ To update an entry in this section the following steps must be performed:
 ## Release Cycle Milestone Activities:
 
 ### Week 1
+
 Begin running release-notes tool for ongoing collection of release notes with the first alpha release, which has been cut directly after the latest minor.
     - Update the `release-notes-draft.md`
     - Update the website

--- a/release-team/role-handbooks/release-notes/editing-flow.md
+++ b/release-team/role-handbooks/release-notes/editing-flow.md
@@ -1,0 +1,251 @@
+# Release Notes Editing Flow
+  - [Introduction](#introduction)
+  - [Motivation](#motivation)
+  - [Workflow Operation](#workflow-operation)
+    - [krel release-notes --fix](#krel-release-notes--fix)
+      - [Starting the interactive mode](#starting-the-interactive-mode)
+      - [Reviewing and editing the release notes](#reviewing-and-editing-the-release-notes)
+      - [Exiting the review loop](#exiting-the-review-loop)
+    - [Submitting changes back](#submitting-changes-back)
+    - [Re-running the workflow](#re-running-the-workflow)
+      - [Modified Release Notes](#modified-release-notes)
+
+
+## Introduction
+
+Ensuring the production of a document comprised of well written and 
+informative release notes is one of the responsibilities of the 
+Release Team each cycle. 
+
+Release Engineering has developed various tools to help the Team 
+complete its duties. One of them is `krel` — the [Kubernetes Release
+Toolbox](https://github.com/kubernetes/release/tree/master/docs/krel).
+Krel has many subcommands that help the release process in many ways,
+among them the `release-notes` subcommand.
+
+This document details how to use krel to review and edit the 
+Kubernetes release notes during the cycle. 
+
+## Motivation
+
+The final Kubernetes Release Notes document is a large document composed of
+hundreds of entries that the contributors write into their Pull Requests. As
+an example, the [release notes document for Kubernetes 1.19](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.19.md)
+has 388 entries.
+
+Before v1.20, the Release Notes Team had to wait until code freeze to review
+and edit each Kubernetes release note in a short time. During the same
+timespan, the Team was expected to contact the sigs and edit the Major themes.
+Work was unbalanced with little to do most of the cycle and a packed 
+agenda during the last few weeks. 
+
+To balance the team's efforts evenly, tooling was developed to enable a new workflow.
+
+## Workflow Operation
+
+Reviewing the release notes involves running krel regularly to review new release
+notes in incoming pull requests, possibly editing some of them, and submitting
+changes back to the `sig-release` repository.
+
+### `krel release-notes --fix`
+
+The main interactive editing flow is started with the `--fix` flag. The interactive
+mode will show the user all release notes that need to be reviewed. After
+reviewing each note, the user can edit the note's attributes using their editor of
+choice.
+
+The `--fix` flag is available when invoking krel with the `--create-draft-pr` option.
+This is an example invocation to edit the release notes for Kubernetes v1.19:
+
+```bash
+krel release-notes --create-draft-pr --org=MyGitHubOrg --fix --tag=v1.19.0
+```
+As with all `krel release-notes` subcommands, a GitHub token must be exported in
+an environment variable called `GITHUB_TOKEN`. The user should supply their GitHub
+organization where krel will push changes and from where it will create pull
+requests.
+
+After invoking the subcommand, krel will clone the `kubernetes/kubernetes` repository
+and query GitHub for all pull requests filed during the specified range. Note that
+this process might take a long time, particularly at the end of the cycle when the
+branch has lots of commits.
+
+Since the note gatherer hits the GitHub API quite heavily, you will get rate limited.
+During a normal operation `krel` will handle them correctly, but you may find yourself
+forced to wait when doing several runs after one another. 
+
+
+#### Starting the interactive mode
+
+When `--fix` is used, krel will switch to interactive mode.
+It will print a short intro and prompt the user before starting:
+
+```
+Welcome to the Kubernetes Release Notes editing tool!
+
+This tool will allow you to review and edit all the release
+notes submitted by the Kubernetes contributors before publishing
+the updated draft.
+
+The flow will show each of the release notes that need to be
+reviewed once and you can choose to edit it or not.
+
+After you choose, it will be marked as reviewed and will not
+be shown during the next sessions unless you choose to do a
+full review of all notes.
+
+You can hit Ctrl+C at any time to exit the review process
+and submit the draft PR with the revisions made so far.
+
+Would you like to continue from the last session? (y/n):
+``` 
+
+#### Reviewing and editing the release notes
+
+Once started, the flow will present the user each release note to
+review. If the user's notices a field that needs to be changed, 
+they might choose to edit that note. Here is an example:
+
+```
+Release Note for PR 92546:
+==========================
+Pull Request URL: https://github.com/kubernetes/kubernetes/pull/92546
+    Author: @liggitt
+    SIGs: [api-machinery]
+    Kinds: [cleanup]
+    Areas: [custom-resources]
+    Feature: false
+    ActionRequired: false
+    ReleaseVersion: 1.19.0
+    Text:
+    │ kube-apiserver: openapi schemas published for custom resources now reference
+    │ standard ListMeta schema definitions
+
+- Fix note for PR #92546? (y/N): 
+
+```
+
+If the user chooses to edit the note when prompted, krel will open the current note
+in the default editor (defined in `$EDITOR`) for the user to edit:
+
+```
+---
+# This is the current map for this Pull Request.
+# The original note content is commented out, if you need to
+# change a field, remove the comment and change the value.
+# To cancel, exit without changing anything or leave the file blank.
+# Important! pr: and releasenote: have to be uncommented.
+#
+# pr: 92546
+# releasenote:
+#   text: 'kube-apiserver: openapi schemas published for custom resources now reference
+#     standard ListMeta schema definitions'
+#   documentation: []
+#   author: liggitt
+#   areas:
+#   - custom-resources
+#   kinds:
+#   - cleanup
+#   sigs:
+#   - api-machinery
+#   feature: false
+#   action_required: false
+#   release_version: 1.19.0
+~
+~                                  
+~                       
+```
+
+By default, all the note's fields are commented out. The user can choose one or more
+fields to uncomment and modify. If at least one field is modified, a [release note map
+file](https://github.com/kubernetes/release/blob/master/docs/release-notes-maps.md) 
+will be created in the release directory after saving the file and exiting the editor.
+
+__Note:__ A valid map file should have at least the PR number and the releasenote struct.
+
+If the user makes an error (a YAML syntax error for example), krel will prompt the user
+to retry editing the note:
+
+```
+ERRO The yaml code does not have a PR number      
+- An error occurred while editing PR #92546. Try again? (y/n)
+```
+
+#### Exiting the review loop
+
+When in the interactive cycle, krel will present the user with every release note that
+has not yet been reviewed. It is not necessary to review all the notes in one go, at
+any time the user may hit Ctrl+C and the interactive flow will exit at that point.
+
+To continue the editing process at a later time, `krel` will save its state
+in the release directory. It will store information about each review session inside of
+the `release-notes/sessions/`. The JSON files include the user's data and the release
+notes reviewed during the session.
+
+At this point, krel will create the current release notes draft. This file is the 
+latest version of the automatically generated release notes and is made public for
+any interested party to review. 
+
+### Submitting changes back
+
+After exiting the interactive mode, krel will prompt the user to create a pull request
+submitting all changes back to the sig-release repository:
+
+```
+INFO Release Notes Draft written to /tmp/k8s-730127624/releases/release-1.19/release-notes-draft.md 
+Create pull request with your changes? (y/n): 
+```
+
+If the user choses so, krel will create the pull request on their behalf by creating a
+branch in their sig-release fork, pushing the changes, and creating the PR in GitHub. 
+
+Note that the PR will include the release notes draft with all changes defined in
+the maps during the editing flow. All the mapping files and session data will be
+submitted in the same PR.
+
+If the user cancels the PR, the local fork of sig-release will be left in a temporary
+directory with all changes done by krel. To submit the changes back to sig-release, 
+the user will be required to push and create the PR manually. To assist them with this
+process, krel will show some instructions:
+
+```
+Create pull request with your changes? (y/n): n
+Pull request creation was canceled. Your local copy of k/sig-release
+has not been deleted for you to review your changes. You may
+push your changes to your fork and create the PR from there.
+
+Your fork of kubernetes/sig-release was cloned here:
+/tmp/k8s-730127624
+
+WARN Pull request canceled. Local changes were not pushed back.
+```
+
+Needless to say, all editing not PR'ed back to sig-release will be lost.
+
+### Re-running the workflow
+
+It is highly recommended that the Release Notes team runs the editing flow
+frequently (say on a weekly basis), alternating team members ensure the
+current user has a reasonable amount of work to do and the editing effort
+is split fairly.
+
+Thanks to the session files, each subsequent run of krel will remember where
+it left off. This means that each user will need to review only new Pull
+Requests that are filed after the last run.
+
+#### Modified Release Notes
+
+During the release cycle, each Pull Request author and/or admins may modify
+the release note and/or flags in GitHub. When this happens, krel will detect
+the change and will present the note again for review, flagging it so that the 
+user knows that the contents have been modified:
+
+```
+Release Note for PR 92546:
+✨ Note contents are modified with a map
+==========================
+Pull Request URL: https://github.com/kubernetes/kubernetes/pull/92546
+    Author: @liggitt
+    SIGs: [api-machinery]
+```
+


### PR DESCRIPTION
#### What type of PR is this:

/kind documentation

#### What this PR does / why we need it:

This PR updates the release notes handbook to add the review/edit process to the team's responsibilities.

It also adds a new file detailing the editing flow with example "screens" and instructions. 

#### Which issue(s) this PR fixes:

Ref: kubernetes/release#1467

#### Special notes for your reviewer:

This update details the new release notes process that will be proposed during the 1.19 retro. Tools mentioned here have not yet merged.

/hold

Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>