### PR TITLE
Fix filename

### DIFF
--- a/releases/release-1.20/release-team.md
+++ b/releases/release-1.20/release-team.md
@@ -1,16 +1,1 @@
-# Kubernetes 1.20 Release Team
-
-| **Role** | **Name** (**GitHub / Slack ID**) | **Shadow Name(s) (GitHub / Slack ID)** |
-|---|---|---|
-| Lead | Jeremy Rickard ([@jeremyrickard](https://github.com/jeremyrickard) / Slack: `@jerickar`) | Daniel Mangum ([@hasheddan](https://github.com/hasheddan) / Slack: `@hasheddan`), Nabarun Pal ([@palnabarun](https://github.com/palnabarun) / Slack: `@palnabarun`), Savitha Raghunathan ([@savitharaghunathan](https://github.com/savitharaghunathan) / Slack: `@sraghunathan`) |
-| Enhancements | Kirsten Garrison ( [@kikisdeliveryservice](https://github.com/kikisdeliveryservice) / Slack: `@oikiki`) | |
-| CI Signal | Robert Kielty ([@RobertKielty](https://github.com/RobertKielty) / Slack: `@RobKielty`) | |
-| Bug Triage | Vlad Gorodetsky ([@bai](https://github.com/bai) / Slack: `@bai`) | |
-| Docs | Anna Jung ([@annajung](https://github.com/annajung) / Slack: `@annajung`) | |
-| Release Notes | James Laverack ([@JamesLaverack](https://github.com/JamesLaverack) / Slack: `@james.laverack`) | |
-| Communications | Joseph Sandoval ([@jrsapi](https://github.com/jrsapi) / Slack: `@j-dawg`) | |
-| Emeritus Adviser | Lachlan Evenson ([@lachie83](https://github.com/lachie83) / Slack: `@lachie83`) | -- |
-
-Review the [Release Managers page](/release-managers.md) for up-to-date contact information on Release Engineering personnel.
-
-The schedule for all patch releases can be found at [Patch Releases page](/releases/patch-releases.md). It will be updated to include 1.19, once the 1.19 release cycle concludes.
+# MOVED to https://github.com/kubernetes/sig-release/blob/master/releases/release-1.20/release_team.md

--- a/releases/release-1.20/release_team.md
+++ b/releases/release-1.20/release_team.md
@@ -1,0 +1,16 @@
+# Kubernetes 1.20 Release Team
+
+| **Role** | **Name** (**GitHub / Slack ID**) | **Shadow Name(s) (GitHub / Slack ID)** |
+|---|---|---|
+| Lead | Jeremy Rickard ([@jeremyrickard](https://github.com/jeremyrickard) / Slack: `@jerickar`) | Daniel Mangum ([@hasheddan](https://github.com/hasheddan) / Slack: `@hasheddan`), Nabarun Pal ([@palnabarun](https://github.com/palnabarun) / Slack: `@palnabarun`), Savitha Raghunathan ([@savitharaghunathan](https://github.com/savitharaghunathan) / Slack: `@sraghunathan`) |
+| Enhancements | Kirsten Garrison ( [@kikisdeliveryservice](https://github.com/kikisdeliveryservice) / Slack: `@oikiki`) | |
+| CI Signal | Robert Kielty ([@RobertKielty](https://github.com/RobertKielty) / Slack: `@RobKielty`) | |
+| Bug Triage | Vlad Gorodetsky ([@bai](https://github.com/bai) / Slack: `@bai`) | |
+| Docs | Anna Jung ([@annajung](https://github.com/annajung) / Slack: `@annajung`) | |
+| Release Notes | James Laverack ([@JamesLaverack](https://github.com/JamesLaverack) / Slack: `@james.laverack`) | |
+| Communications | Joseph Sandoval ([@jrsapi](https://github.com/jrsapi) / Slack: `@j-dawg`) | |
+| Emeritus Adviser | Lachlan Evenson ([@lachie83](https://github.com/lachie83) / Slack: `@lachie83`) | -- |
+
+Review the [Release Managers page](/release-managers.md) for up-to-date contact information on Release Engineering personnel.
+
+The schedule for all patch releases can be found at [Patch Releases page](/releases/patch-releases.md). It will be updated to include 1.19, once the 1.19 release cycle concludes.


### PR DESCRIPTION


#### What type of PR is this:
/kind cleanup

#### What this PR does / why we need it:

This PR updates the 1.20 `release-team.md` file to be `release_team.md` to follow the pattern in previous releases to make it easier to jump from one release team to another when reviewing team membership. The old file is updated with a link to the correct file, in case anyone uses the old link (it was in an email). We can remove this file at some later point in the release when we have cleaned up all references. 

#### Special notes for your reviewer:



Signed-off-by: Jeremy Rickard <rickardj@vmware.com>

