### PR TITLE
Update references to the Kubernetes Release Team and Kubernetes Release Team Shadows Google Group

### DIFF
--- a/.github/ISSUE_TEMPLATE/lead.md
+++ b/.github/ISSUE_TEMPLATE/lead.md
@@ -23,7 +23,7 @@ hold and only released once approved by a SIG Release (subproject) owner.**
 - [ ] Ensure new Chair/Technical Lead:
   - [ ] Has joined the following mailing lists:
     - [kubernetes-sig-release](https://groups.google.com/forum/#!forum/kubernetes-sig-release)
-    - [kubernetes-release-team](https://groups.google.com/forum/#!forum/kubernetes-release-team)
+    - [kubernetes-release-team](https://groups.google.com/a/kubernetes.io/g/release-team)
     - [kubernetes-dev](https://groups.google.com/forum/#!forum/kubernetes-dev)
     - [kubernetes-announce](https://groups.google.com/forum/#!forum/kubernetes-announce)
     - [release-managers](https://groups.google.com/a/kubernetes.io/forum/#!forum/release-managers)
@@ -82,7 +82,7 @@ As you work through the checklist, use the following PRs as guides:
   - `release-managers` (owners)
   - `release-managers-private` (owners)
 - [ ] Manually grant permission to post on [kubernetes-announce](https://groups.google.com/forum/#!forum/kubernetes-announce)
-- [ ] Manually add to the [Release Team Google Group](https://groups.google.com/forum/#!forum/kubernetes-release-team)
+- [ ] Manually add to the [Release Team Google Group](https://groups.google.com/a/kubernetes.io/g/release-team)
 - [ ] Update Slack `release-managers` and `release-team-leads` User Group [(`kubernetes/community`)](https://git.k8s.io/community/communication/slack-config/sig-release/usergroups.yaml)
 - [ ] Manually add to the [#release-private](https://kubernetes.slack.com/archives/GKEA5EL67) Slack channel
 -->

--- a/.github/ISSUE_TEMPLATE/release-manager.md
+++ b/.github/ISSUE_TEMPLATE/release-manager.md
@@ -85,7 +85,7 @@ As you work through the checklist, use the following PRs as guides:
   - `release-managers@`
   - `release-managers-private@`
 - [ ] Manually grant permission to post on [kubernetes-announce](https://groups.google.com/forum/#!forum/kubernetes-announce)
-- [ ] Manually add to the [Release Team Google Group](https://groups.google.com/forum/#!forum/kubernetes-release-team)
+- [ ] Manually add to the [Release Team Google Group](https://groups.google.com/a/kubernetes.io/g/release-team)
 - [ ] Update Slack `release-managers` User Group [(`kubernetes/community`)](https://git.k8s.io/community/communication/slack-config/sig-release/usergroups.yaml)
 - [ ] Manually add to the [#release-private](https://kubernetes.slack.com/archives/GKEA5EL67) Slack channel
 -->

--- a/.github/ISSUE_TEMPLATE/release-team-lead.md
+++ b/.github/ISSUE_TEMPLATE/release-team-lead.md
@@ -75,7 +75,7 @@ As you work through the checklist, use the following PRs as guides:
   - `k8s-infra-release-viewers@`
   - `release-managers@`
 - [ ] Manually remove from the following Google Groups:
-  - [kubernetes-release-team](https://groups.google.com/forum/#!forum/kubernetes-release-team) (Add as Manager)
+  - [kubernetes-release-team](https://groups.google.com/a/kubernetes.io/g/release-team) (Add as Manager)
   - [kubernetes-sig-leads](https://groups.google.com/forum/#!forum/kubernetes-sig-leads) (Add as Member)
 
 cc: @kubernetes/release-engineering @kubernetes/release-team

--- a/leads/onboarding.md
+++ b/leads/onboarding.md
@@ -13,7 +13,7 @@ To ensure quality communication SIG Release Chairs and Technical Leads should:
   - kubernetes-sig-release:
     https://groups.google.com/forum/#!forum/kubernetes-sig-release
   - kubernetes-release-team:
-    https://groups.google.com/forum/#!forum/kubernetes-release-team
+    https://groups.google.com/a/kubernetes.io/g/release-team
   - kubernetes-dev:
     https://groups.google.com/forum/#!forum/kubernetes-dev
   - kubernetes-announce:

--- a/release-engineering/role-handbooks/branch-manager.md
+++ b/release-engineering/role-handbooks/branch-manager.md
@@ -854,6 +854,6 @@ See the branch management process prior to v1.12 when `anago` was still used.
 
 >  Note: To view this document, you will need to join the [kubernetes-dev](https://groups.google.com/forum/#!forum/kubernetes-dev) Google group.
 
-[kubernetes-release-team]: https://groups.google.com/forum/#!forum/kubernetes-release-team
+[kubernetes-release-team]: https://groups.google.com/a/kubernetes.io/g/release-team
 [release-managers]: /release-managers.md#release-managers
 [release-managers-group]: https://groups.google.com/a/kubernetes.io/forum/#!forum/release-managers

--- a/release-team/release-team-onboarding.md
+++ b/release-team/release-team-onboarding.md
@@ -34,7 +34,7 @@ There are a few mailing lists that you should be aware of. Depending on your rel
 
 #### Release Team Mailing List
 
-All members of the current release team should be apart of this list. If you're on the Release Team and cannot access: https://groups.google.com/forum/#!forum/kubernetes-release-team, please tell your role lead or the Release Team lead that you need access. The Release Lead, as well as Relase Lead shadows, can manage list membership. 
+All members of the current release team should be apart of this list. If you're on the Release Team and cannot access: https://groups.google.com/a/kubernetes.io/g/release-team, please tell your role lead or the Release Team lead that you need access. The Release Lead, as well as Relase Lead shadows, can manage list membership.
 
 #### SIG Release Mailing List
 

--- a/release-team/role-handbooks/docs/README.md
+++ b/release-team/role-handbooks/docs/README.md
@@ -89,7 +89,7 @@ These steps take approximately one hour to complete, and should be completed imm
     - [kubernetes-sig-docs](https://groups.google.com/forum/#!forum/kubernetes-sig-docs)
     - [kubernetes-milestone-burndown](https://groups.google.com/forum/#!forum/kubernetes-milestone-burndown)
     - [kubernetes-dev](https://groups.google.com/forum/#!forum/kubernetes-dev)
-    - [kubernetes-release-team](https://groups.google.com/forum/#!forum/kubernetes-release-team) # for enhancement google sheets access!
+    - [kubernetes-release-team](https://groups.google.com/a/kubernetes.io/g/release-team) # for enhancement google sheets access!
 
 - Make sure you're included in the "official" release team file, e.g: [release 1.14](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.14/release_team.md). If not submit a PR and add yourself.
 

--- a/release-team/role-handbooks/emeritus-adviser/README.md
+++ b/release-team/role-handbooks/emeritus-adviser/README.md
@@ -62,7 +62,7 @@ Occasionally, a role may not get enough qualified candidates, in which case it's
 
 Weeks: 1 to 12
 
-Remove prior release shadows from the [kubernetes-release-team-shadows](https://groups.google.com/forum/#!forum/kubernetes-release-team-shadows) Google Group and add the current release shadows.  This list can facilitate easier communication between what at times is 2-3 dozen shadows.
+Remove prior release shadows from the [kubernetes-release-team-shadows](https://groups.google.com/a/kubernetes.io/g/release-team-shadows) Google Group and add the current release shadows.  This list can facilitate easier communication between what at times is 2-3 dozen shadows.
 
 Poll the new shadows (eg: [Doodle](Doodle.com)) for their availability to have a "shadow orientation" meeting sometime in week 2 or week 3, after all shadows are selected.  This meeting will likely have to be split for time zone reasons and held twice.  In this meeting, go over the information in the main Shadow docs, give information about the release team and SIG Release, and then open things for questions or discussion. Make sure that Shadows know they can come to you if they have problems during their apprenticeship.
 

--- a/release-team/role-handbooks/enhancements/README.md
+++ b/release-team/role-handbooks/enhancements/README.md
@@ -236,7 +236,7 @@ https://groups.google.com/forum/#!topic/kubernetes-dev/5qU8irU7_tE
 
 
 [k/enhancements]: https://github.com/kubernetes/enhancements
-[rt-group]: https://groups.google.com/forum/#!forum/kubernetes-release-team
+[rt-group]: https://groups.google.com/a/kubernetes.io/g/release-team
 [rt-selection]: /README.md#release-team-selection
 [rt-requirements]: /release-team/release-team-onboarding.md
 [sig-docs-group]: https://groups.google.com/forum/#!forum/kubernetes-sig-docs

--- a/release-team/role-handbooks/release-team-lead/README.md
+++ b/release-team/role-handbooks/release-team-lead/README.md
@@ -178,7 +178,7 @@ Coordinate with SIG-Release Chairs (who have access to the CNCF Service Desk as 
   [kubernetes-release-team].
 - Ensure SIG Release co-chairs replace the outgoing Emeritus Advisor with
   the new Emeritus Advisor as an owner of the
-  [kubernetes-release-team-shadows](https://groups.google.com/forum/#!forum/kubernetes-release-team-shadows)
+  [kubernetes-release-team-shadows](https://groups.google.com/a/kubernetes.io/g/release-team-shadows)
   Google Group.
 - Ensure top-level OWNERS_ALIASES only includes Release Team personnel from four (4) releases, including the current one.
 - Create and finalize the release schedule, blocking test gates, and role assignments as a pull request in: kubernetes/sig-release/releases/release-x.y/README.md **Note: Do not ship the release on a Monday, to avoid preparing for the release on a weekend. Aim for Tuesday.**
@@ -343,7 +343,7 @@ Code Freeze will typically fall around Weeks 8 or 9 depending on the length or r
 [discourse]: https://discuss.kubernetes.io/
 [k/enhancements]: https://git.k8s.io/enhancements
 [kubernetes-release-calendar]: https://bit.ly/k8s-release-cal
-[kubernetes-release-team]: https://groups.google.com/forum/#!forum/kubernetes-release-team
+[kubernetes-release-team]: https://groups.google.com/a/kubernetes.io/g/release-team
 [kubernetes-sig-release]: https://groups.google.com/forum/#!forum/kubernetes-sig-release
 [kubernetes-sig-leads]: https://groups.google.com/forum/#!forum/kubernetes-sig-leads
 [kubernetes-dev]: https://groups.google.com/forum/#!forum/kubernetes-dev

--- a/release-team/role-handbooks/release-team-lead/README.md
+++ b/release-team/role-handbooks/release-team-lead/README.md
@@ -326,7 +326,7 @@ Code Freeze will typically fall around Weeks 8 or 9 depending on the length or r
   - Make sure that the Release Retrospective invite shows up in the
     [Kubernetes community calendar](https://calendar.google.com/calendar/embed?src=cgnt364vd8s86hr2phapfjc6uk%40group.calendar.google.com)
     and invite the following teams as attendees
-    - kubernetes-release-team@googlegroups.com
+    - release-team@kubernetes.io
     - release-managers@kubernetes.io
     - kubernetes-sig-release@googlegroups.com
 - Follow-up interviews with the media, the media roundtable

--- a/release-team/shadows.md
+++ b/release-team/shadows.md
@@ -24,10 +24,10 @@ The first week should be used to get Shadows set up with all of the "paperwork" 
 * Apply to be an Org Member if they are not already (see below).
 * Join the [#sig-release slack channel](https://slack.k8s.io/).
 * Get added to the `kubernetes-release-team` group by the Release Lead.
-* Join the [sig-release](https://groups.google.com/forum/#!forum/kubernetes-sig-release) and [release-team](https://groups.google.com/forum/#!forum/kubernetes-release-team) Google Groups and calendars.
+* Join the [sig-release](https://groups.google.com/forum/#!forum/kubernetes-sig-release) and [release-team](https://groups.google.com/a/kubernetes.io/g/release-team) Google Groups and calendars.
 * Add all contact information to their Release Team's contact sheet.
 * Get invited to the weekly Release Team Meeting and add the [sig-release calendar](https://calendar.google.com/calendar/embed?src=kipmnllvl17vl9m98jen6ujcrs%40group.calendar.google.com) to their calendar
-* Get added to the [kubernetes-release-team-shadows](https://groups.google.com/forum/#!forum/kubernetes-release-team-shadows) Google Group by the Emeritus Advisor.
+* Get added to the [kubernetes-release-team-shadows](https://groups.google.com/a/kubernetes.io/g/release-team-shadows) Google Group by the Emeritus Advisor.
 
 Becoming a Release Team Shadow is considered sufficient contribution to become a Kubernetes Org Member, and membership is needed for several tasks, especially having the Github bots obey the Shadow's commands. As such, each Shadow who is not already an org member should [apply to become one](https://github.com/kubernetes/community/blob/master/community-membership.md#member) with their mentoring role lead, the Release Lead, and/or the Emeritus Advisor as their sponsors.
 

--- a/releases/EXCEPTIONS.md
+++ b/releases/EXCEPTIONS.md
@@ -33,7 +33,7 @@ To file for an exception, please fill out the questions below:
 Email them to:
 
 - Your SIG's mailing list
-- kubernetes-release-team@googlegroups.com
+- release-team@kubernetes.io
 - kubernetes-sig-release@googlegroups.com
 
 [You should have *very high confidence* on the “additional time needed” number - we will not grant multiple exceptions for a enhancement.]

--- a/releases/release-1.14/README.md
+++ b/releases/release-1.14/README.md
@@ -207,7 +207,7 @@ than basing from master. **Be sure to open your PR against the release branch**.
 [Code Thaw]: #code-thaw
 [Exception]: #exceptions
 
-[kubernetes-release-team@]: https://groups.google.com/forum/#!forum/kubernetes-release-team
+[kubernetes-release-team@]: https://groups.google.com/a/kubernetes.io/g/release-team
 [kubernetes-sig-release@]: https://groups.google.com/forum/#!forum/kubernetes-sig-release
 [#sig-release]: https://kubernetes.slack.com/messages/sig-release/
 [contact-info]: https://bit.ly/k8s114-contacts

--- a/releases/release-1.15/README.md
+++ b/releases/release-1.15/README.md
@@ -180,7 +180,7 @@ than basing from master. **Be sure to open your PR against the release branch**.
 [Code Thaw]: #code-thaw
 [Exception]: #exceptions
 
-[kubernetes-release-team@]: https://groups.google.com/forum/#!forum/kubernetes-release-team
+[kubernetes-release-team@]: https://groups.google.com/a/kubernetes.io/g/release-team
 [kubernetes-sig-release@]: https://groups.google.com/forum/#!forum/kubernetes-sig-release
 [#sig-release]: https://kubernetes.slack.com/messages/sig-release/
 [k8s115-calendar]: http://bit.ly/k8s115cal 

--- a/releases/release-1.16/README.md
+++ b/releases/release-1.16/README.md
@@ -184,7 +184,7 @@ than basing from master. **Be sure to open your PR against the release branch**.
 [Code Thaw]: #code-thaw
 [Exception]: #exceptions
 
-[kubernetes-release-team@]: https://groups.google.com/forum/#!forum/kubernetes-release-team
+[kubernetes-release-team@]: https://groups.google.com/a/kubernetes.io/g/release-team
 [kubernetes-sig-release@]: https://groups.google.com/forum/#!forum/kubernetes-sig-release
 [#sig-release]: https://kubernetes.slack.com/messages/sig-release/
 [kubernetes-release-calendar]: https://bit.ly/k8s-release-cal

--- a/releases/release-1.17/README.md
+++ b/releases/release-1.17/README.md
@@ -84,7 +84,7 @@ Please refer to the [release phases document](../release_phases.md).
 [Exception]: ../release_phases.md#exceptions
 [Code Thaw]: ../release_phases.md#code-thaw
 
-[kubernetes-release-team@]: https://groups.google.com/forum/#!forum/kubernetes-release-team
+[kubernetes-release-team@]: https://groups.google.com/a/kubernetes.io/g/release-team
 [kubernetes-sig-release@]: https://groups.google.com/forum/#!forum/kubernetes-sig-release
 [#sig-release]: https://kubernetes.slack.com/messages/sig-release/
 [kubernetes-release-calendar]: https://bit.ly/k8s-release-cal

--- a/releases/release-1.18/README.md
+++ b/releases/release-1.18/README.md
@@ -106,6 +106,6 @@ Please refer to the [release phases document](../release_phases.md).
 [master-informing]: https://testgrid.k8s.io/sig-release-master-informing#Summary
 [1.18-blocking]: https://testgrid.k8s.io/sig-release-1.18-blocking#Summary
 
-[kubernetes-release-team@]: https://groups.google.com/forum/#!forum/kubernetes-release-team
+[kubernetes-release-team@]: https://groups.google.com/a/kubernetes.io/g/release-team
 [kubernetes-sig-release@]: https://groups.google.com/forum/#!forum/kubernetes-sig-release
 [#sig-release]: https://kubernetes.slack.com/messages/sig-release/

--- a/releases/release-1.19/README.md
+++ b/releases/release-1.19/README.md
@@ -110,6 +110,6 @@ Please refer to the [release phases document](../release_phases.md).
 [master-informing]: https://testgrid.k8s.io/sig-release-master-informing#Summary
 [1.19-blocking]: https://testgrid.k8s.io/sig-release-1.19-blocking#Summary
 
-[kubernetes-release-team@]: https://groups.google.com/forum/#!forum/kubernetes-release-team
+[kubernetes-release-team@]: https://groups.google.com/a/kubernetes.io/g/release-team
 [kubernetes-sig-release@]: https://groups.google.com/forum/#!forum/kubernetes-sig-release
 [#sig-release]: https://kubernetes.slack.com/messages/sig-release/

--- a/releases/release-1.20/README.md
+++ b/releases/release-1.20/README.md
@@ -91,7 +91,7 @@ Please refer to the [release phases document](../release_phases.md).
 [Exception]: ../release_phases.md#exceptions
 [Code Thaw]: ../release_phases.md#code-thaw
 
-[kubernetes-release-team@]: https://groups.google.com/forum/#!forum/kubernetes-release-team
+[kubernetes-release-team@]: https://groups.google.com/a/kubernetes.io/g/release-team
 [kubernetes-sig-release@]: https://groups.google.com/forum/#!forum/kubernetes-sig-release
 [#sig-release]: https://kubernetes.slack.com/messages/sig-release/
 [kubernetes-release-calendar]: https://bit.ly/k8s-release-cal


### PR DESCRIPTION
- Replace occurences of kuberentes-release-team@googlegroups.com with 
  release-team@kubernetes.io
- Replace https://groups.google.com/forum/#!forum/kubernetes-sig-release with 
  https://groups.google.com/a/kubernetes.io/g/release-team and 
  https://groups.google.com/forum/#!forum/kubernetes-sig-release-shadows with 
  https://groups.google.com/a/kubernetes.io/g/release-team-shadows 


/kind cleanup
/kind documentation

/cc @jeremyrickard @justaugustus @saschagrunert @alejandrox1