### PR TITLE
Add checkbox for slack group user mgmt

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-team-lead.md
+++ b/.github/ISSUE_TEMPLATE/release-team-lead.md
@@ -64,6 +64,9 @@ As you work through the checklist, use the following PRs as guides:
   - [kubernetes-sig-leads](https://groups.google.com/forum/#!forum/kubernetes-sig-leads) (Add as Member)
 - [ ] Grant calendar access
 - [ ] Grant Zoom credentials (host key)
+- [ ] Add incoming leads to `release-team-leads` Slack Group [(`kubernetes/community`)](https://git.k8s.io/community/communication/slack-config/sig-release/usergroups.yaml)
+  - Add slack ID(s) to [`users.yaml`](https://git.k8s.io/community/communication/slack-config/users.yaml), if they are not yet in the file
+  - Add username(s) to [`usergroups.yaml`](https://git.k8s.io/community/communication/slack-config/sig-release/usergroups.yaml)
 
 ### Offboarding
 
@@ -77,5 +80,8 @@ As you work through the checklist, use the following PRs as guides:
 - [ ] Manually remove from the following Google Groups:
   - [kubernetes-release-team](https://groups.google.com/a/kubernetes.io/g/release-team) (Add as Manager)
   - [kubernetes-sig-leads](https://groups.google.com/forum/#!forum/kubernetes-sig-leads) (Add as Member)
+- [ ] Remove from `release-team-leads` Slack Group [(`kubernetes/community`)](https://git.k8s.io/community/communication/slack-config/sig-release/usergroups.yaml)
+  - Remove slack ID(s) from [`users.yaml`](https://git.k8s.io/community/communication/slack-config/users.yaml), if no longer in a group
+  - Remove username(s) from [`usergroups.yaml`](https://git.k8s.io/community/communication/slack-config/sig-release/usergroups.yaml)
 
 cc: @kubernetes/release-engineering @kubernetes/release-team


### PR DESCRIPTION
#### What type of PR is this:

/kind cleanup documentation


#### What this PR does / why we need it:

This PR adds a checkbox/reminder to onboard incoming release team leads to the [release-team-leads](https://github.com/kubernetes/community/blob/master/communication/slack-config/sig-release/usergroups.yaml) Slack Group at the start of the release. It also includes a checkbox/reminder for the offboarding at the end of the release. 

Signed-off-by: Jeremy Rickard <rickardj@vmware.com>