### PR TITLE
Updating RT & RT shadows google group references

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-team-lead.md
+++ b/.github/ISSUE_TEMPLATE/release-team-lead.md
@@ -60,7 +60,7 @@ As you work through the checklist, use the following PRs as guides:
   - `k8s-infra-release-viewers@`
   - `release-managers@`
 - [ ] Manually grant access on the following Google Groups:
-  - [kubernetes-release-team](https://groups.google.com/forum/#!forum/kubernetes-release-team) (Add as Manager)
+  - [kubernetes-release-team](https://groups.google.com/a/kubernetes.io/g/release-team) (Add as Manager)
   - [kubernetes-sig-leads](https://groups.google.com/forum/#!forum/kubernetes-sig-leads) (Add as Member)
 - [ ] Grant calendar access
 - [ ] Grant Zoom credentials (host key)

--- a/release-team/role-handbooks/emeritus-adviser/README.md
+++ b/release-team/role-handbooks/emeritus-adviser/README.md
@@ -52,7 +52,7 @@ Once most of the Role Leads are selected, the EA should solicit candidates for S
 4. Close the Shadow Application around 7-10 days after the initial announcement.
 5. Chat with each of the incoming Role Leads about selecting their shadows, and make sure that they stay on schedule for it.
 6. Once all role leads select their shadows the EA will send out a notification to all applicants not selected for this release cycle 
-7. Ensure the outgoing EA or one of the SIG Release co-chairs has added you in as an owner of the [kubernetes-release-team-shadows](https://groups.google.com/forum/#!forum/kubernetes-release-team-shadows) Google Group.
+7. Ensure the outgoing EA or one of the SIG Release co-chairs has added you in as an owner of the [kubernetes-release-team-shadows](https://groups.google.com/a/kubernetes.io/g/release-team-shadows) Google Group.
 
 The most time-consuming part of this is helping the Role Leads select shadows.  In addition to the usual dilemmas of too many good candidates, the EA needs to give advice that makes sure that a diverse pool of shadows is selected, and that the Role Lead doesn't take on more shadows than they can effectively mentor.
 


### PR DESCRIPTION
Updating google group references for RT and RT shadows:
 
Replace https://groups.google.com/forum/#!forum/kubernetes-sig-release with https://groups.google.com/a/kubernetes.io/g/release-team and
 
Replace https://groups.google.com/forum/#!forum/kubernetes-sig-release-shadows with https://groups.google.com/a/kubernetes.io/g/release-team-shadows

/kind cleanup
/kind documentation

/cc @jeremyrickard @justaugustus @saschagrunert @alejandrox1