### PR TITLE
Fix missing release managers link

### DIFF
--- a/release-engineering/role-handbooks/patch-release-team.md
+++ b/release-engineering/role-handbooks/patch-release-team.md
@@ -618,3 +618,5 @@ For more information in how to run `krel gcbmgr` please check the [command docum
 | Official email notify | ```krel announce --tag v1.13.3 --nomock``` |
 | Check mail arrives | manual/visual check that [k-announce](https://groups.google.com/forum/#!forum/kubernetes-announce) and [k-dev](https://groups.google.com/forum/#!forum/kubernetes-dev) got mail OK |
 | Completion | n/a |
+
+[release-managers]: /release-managers.md#release-managers


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this:

/kind documentation


#### What this PR does / why we need it:

Fixes a broken link in patch release team doc to point at relevant
release managers doc.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #
or
None
-->

#### Special notes for your reviewer:

Matches same link in [Branch Manager Handbook](https://github.com/kubernetes/sig-release/blob/master/release-engineering/role-handbooks/branch-manager.md).

/cc @kubernetes/release-managers 