### PR TITLE
Cut 1.20.0-alpha.1 release in 1.20 cycle

### DIFF
--- a/releases/release-1.20/README.md
+++ b/releases/release-1.20/README.md
@@ -52,11 +52,11 @@ The 1.20 release cycle is proposed as follows:
 | Start Enhancements Tracking | Enhancements Lead | Tue September 15 | | |
 | Schedule finalized | Lead | Wed September 16 | | |
 | Team finalized | Lead | Friday September 18 |  | |
-| 1.20.0-alpha.2 released | Branch Manager | Tue September 22 | week 2 | |
+| 1.20.0-alpha.1 released | Branch Manager | Tue September 22 | week 2 | |
 | Start Release Notes Draft | Release Notes Lead | Tue September 29 | week 3 | |
 | **Begin [Enhancements Freeze]** (EOD PST) | Enhancements Lead | Tue October 6 | week 4 | [master-blocking], [master-informing] |
-| 1.20.0-alpha.3 released | Branch Manager | Tue October 13 | week 5 | |
-| 1.20.0-alpha.4 released | Branch Manager | Tue October 20 | week 6 | |
+| 1.20.0-alpha.2 released | Branch Manager | Tue October 13 | week 5 | |
+| 1.20.0-alpha.3 released | Branch Manager | Tue October 20 | week 6 | |
 | release-1.20 branch created | Branch Manager | Tue October 27 | week 7 | |
 | release-1.20 jobs created | Branch Manager | Tue October 27| | |
 | 1.20.0-beta.0 released | Branch Manager | Tue October 27 | | |


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this:

/kind documentation

#### What this PR does / why we need it:

This modifies the 1.20 release schedule to start with 1.20.0-alpha.1
release instead of 1.20.0-alpha.2, and adjusts the following releases
accordingly.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #
or
None
-->

ref #1229 

#### Special notes for your reviewer:

This does not fully address #1229, but updates the 1.20 schedule in the mean time to reflect the planned alpha releases.

/cc @tpepper @jeremyrickard @justaugustus 
