### PR TITLE
Add team meeting with shadows to RT Lead handbook

### DIFF
--- a/release-team/role-handbooks/release-team-lead/README.md
+++ b/release-team/role-handbooks/release-team-lead/README.md
@@ -158,7 +158,7 @@ Coordinate with SIG-Release Chairs (who have access to the CNCF Service Desk as 
 
 - Attend previous release retro to capture feedback and incorporate it into next release cycle
 - Plan release schedule and milestones. Gather feedback as needed.
-- Make sure you have your shadows confirmed
+- Make sure you have your shadows confirmed and schedule an initial group meeting to onboard and establish timeline and responsibilities.
 - Make sure everyone joining the team reads the [release team onboarding document][release-team-onboarding].
 - Complete a [Release Team Lead onboarding issue][rtl-onboarding] for the Lead and RT Lead Shadows
 


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this:

/kind documentation


#### What this PR does / why we need it:

Adds a pre-release cycle activity to RT Lead handbook to schedule a
group meeting with shadows to establish responsibilities and timeline so
that they can assist in onboarding activities for other RT members.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #
or
None
-->

Partially addresses #912 

#### Special notes for your reviewer:

/cc @jeremyrickard @palnabarun @savitharaghunathan 