### PR TITLE
Add image promotion step to release cut issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/cut-release.md
+++ b/.github/ISSUE_TEMPLATE/cut-release.md
@@ -44,6 +44,7 @@ Platform:      linux/amd64
 | Mock stage | `krel gcbmgr --stage [arguments]` | <!-- link-to-MOCK-gcb-stage-run --> |  |  |  |
 | Mock release | `krel gcbmgr --release [arguments]` | <!-- link-to-MOCK-gcb-release-run --> |  |  |  |
 | Stage | `krel gcbmgr --stage [arguments]` | <!-- link-to-REAL-gcb-stage-run --> |  |  |  |
+| Image Promotion | `krel promote-images -i --fork=[your-github-user] --tag=[version]` | <!-- link-to-k8s.io-PR --> |  |  |  |
 | Release | `krel gcbmgr --release [arguments]` | <!-- link-to-REAL-gcb-release-run --> |  |  |  |
 | Cut packages <!-- not required for pre-releases (alpha, beta, rc) --> | -- | -- |  |  |  |
 | Notify | -- | <!-- link-to-kubernetes-announce-list-thread --> |  | -- |  |


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this:

/kind documentation

#### What this PR does / why we need it:

Adds image promotion step and krel command for opening PR against k8s.io
with images for release version. This step is required for all releases
since VDF.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #
or
None
-->

#### Special notes for your reviewer:

/cc @puerco @saschagrunert 