### PR TITLE
Clarify instructions to fetch all upstream branches

### DIFF
--- a/release-team/role-handbooks/docs/README.md
+++ b/release-team/role-handbooks/docs/README.md
@@ -352,7 +352,7 @@ To merge `master` into `dev-[future release]` on your local fork:
 # Step 0 (if you don't already have a remote called "upstream")
 git remote add upstream https://github.com/kubernetes/website.git
 # Step 1
-git fetch upstream master
+git fetch upstream #grab all branches from upstream repo
 # Step 2
 git checkout --track upstream/dev-[future release]
 # Step 3

--- a/release-team/role-handbooks/docs/README.md
+++ b/release-team/role-handbooks/docs/README.md
@@ -352,21 +352,23 @@ To merge `master` into `dev-[future release]` on your local fork:
 # Step 0 (if you don't already have a remote called "upstream")
 git remote add upstream https://github.com/kubernetes/website.git
 # Step 1
-git fetch upstream #grab all branches from upstream repo
+git fetch upstream master
 # Step 2
-git checkout --track upstream/dev-[future release]
+git fetch upstream dev-[future release]
 # Step 3
+git checkout --track upstream/dev-[future release]
+# Step 4
 git pull --ff-only # make sure you're up to date
-# Step 4. You might see merge conflicts at this point.
+# Step 5 You might see merge conflicts at this point.
 git merge upstream/master
 ## if needed: https://help.github.com/articles/resolving-a-merge-conflict-using-the-command-line/
 ## git add ...
 ## git merge --continue
-# Step 5
+# Step 6
 git checkout -b merged-master-dev-[future release]
-# Step 6
+# Step 7
 git commit -m "Merge master into dev-[future release] to keep in sync"
-# Step 6
+# Step 8
 git push origin merged-master-dev-[future release]
 ```
 


### PR DESCRIPTION
Clarify instructions to state fetch all branches from upstream website repo, not just master branch

<!--  Thanks for sending a pull request!  Here are some tips for you:



#### What type of PR is this:

/kind documentation


#### What this PR does / why we need it:

Clarify instructions to fetch all branches from upstream website repo, not just master branch

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:
