### PR TITLE
Update onboarding issue and RT Lead Handbook for Inclusive Speaker Orientation

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-team-lead.md
+++ b/.github/ISSUE_TEMPLATE/release-team-lead.md
@@ -31,6 +31,7 @@ e.g., Kubernetes 1.18
     - [#sig-release](https://kubernetes.slack.com/messages/C2C40FMNF)
     - [#release-management](https://kubernetes.slack.com/messages/CJH2GBF7Y)
   - [ ] Is a [Kubernetes GitHub org member](https://github.com/kubernetes/community/blob/master/community-membership.md#member)
+  - [ ] Has completed the [CNCF Inclusive Speaker Orientation](https://training.linuxfoundation.org/training/inclusive-speaker-orientation/)
 
 ### Onboarding
 

--- a/release-team/role-handbooks/release-team-lead/README.md
+++ b/release-team/role-handbooks/release-team-lead/README.md
@@ -160,6 +160,7 @@ Coordinate with SIG-Release Chairs (who have access to the CNCF Service Desk as 
 - Plan release schedule and milestones. Gather feedback as needed.
 - Make sure you have your shadows confirmed and schedule an initial group meeting to onboard and establish timeline and responsibilities.
 - Make sure everyone joining the team reads the [release team onboarding document][release-team-onboarding].
+- Complete the [CNCF Inclusive Speaker Orientation](https://training.linuxfoundation.org/training/inclusive-speaker-orientation/).
 - Complete a [Release Team Lead onboarding issue][rtl-onboarding] for the Lead and RT Lead Shadows
 
 ### Week 1


### PR DESCRIPTION
#### What type of PR is this:

/kind documentation feature
/area release-team
/priority important-soon
/milestone v1.20

#### What this PR does / why we need it:

This PR adds a checklist item for RT Lead (and shadows) to complete the CNCF Inclusive Speaker Training to mirror the unconscious bias training requirement for SIG Chairs and Tech Leads to help ensure the Release Team promotes inclusivity in meetings and other communications. 

#### Which issue(s) this PR fixes:

Fixes #1251 

#### Special notes for your reviewer:

- [x] Jeremy Rickard
- [x] Dan Mangum
- [x] Nabarun Pal
- [x] Savitha Raghunathan

Signed-off-by: Jeremy Rickard <rickardj@vmware.com>