### PR TITLE
patch release schedule: add expected EOL for 1.18, 1.17

### DIFF
--- a/releases/patch-releases.md
+++ b/releases/patch-releases.md
@@ -72,7 +72,7 @@ End of Life for **1.19** is **2021-09-30**
 
 Next patch release is **1.18.11**
 
-End of Life for **1.18** is **TBD**
+End of Life for **1.18** is **2021-04-30**
 
 | PATCH RELEASE | CHERRY PICK DEADLINE | TARGET DATE |
 |--- |--- |--- |
@@ -92,7 +92,7 @@ End of Life for **1.18** is **TBD**
 
 Next patch release is **1.17.14**
 
-End of Life for **1.17** is **TBD**
+End of Life for **1.17** is **2021-01-30**
 
 | PATCH RELEASE | CHERRY PICK DEADLINE | TARGET DATE |
 |--- |--- |--- |

--- a/releases/schedule.yaml
+++ b/releases/schedule.yaml
@@ -18,7 +18,7 @@ schedules:
   next: 1.18.11
   cherryPickDeadline: 2020-11-06
   targetDate: 2020-11-11
-  endOfLifeDate: TBD
+  endOfLifeDate: 2021-04-30
   previousPatches:
     - release: 1.18.10
       cherryPickDeadline: 2020-10-09
@@ -54,7 +54,7 @@ schedules:
   next: 1.17.14
   cherryPickDeadline: 2020-11-06
   targetDate: 2020-11-11
-  endOfLifeDate: TBD
+  endOfLifeDate: 2021-01-30
   previousPatches:
     - release: 1.17.13
       cherryPickDeadline: 2020-10-09


### PR DESCRIPTION
As a part of WG LTS's wind down, we've discussed that given expected
release cadences that 1.18 and 1.17 are going to get a year of patch
support.  It's been noted though that the schedule remained ambiguous
for these two.  This commit adds an EOL target date in the month
of their release one year anniversary.

Signed-off-by: Tim Pepper <tpepper@vmware.com>


/kind documentation

#### Special notes for your reviewer:

Note that this will conflict with https://github.com/kubernetes/sig-release/pull/1294 and I will rebase after that merges.