### PR TITLE
Update release branch management handbook

### DIFF
--- a/release-engineering/role-handbooks/branch-manager.md
+++ b/release-engineering/role-handbooks/branch-manager.md
@@ -212,15 +212,18 @@ At the end of a release, Release Managers will need to announce the new release 
 This can be done in one of two ways:
 
 - The `krel announce` sub command -- A [`SENDGRID_API_KEY`](https://sendgrid.com/docs/ui/account-and-settings/api-keys) will need to be configured correctly on your environment for this to work
-- Manually -- Send the email notification manually to [kubernetes-announce][k-announce-list] by taking the contents from the Google Cloud Bucket: `gs://kubernetes-release/archive/anago-vX.Y.0-{alpha,beta,rc}.z`:
+  - If you haven't used SendGrid before, SendGrid might require you to go through the [Sender Identity Verification process][sendgrid-identity-verification] before you can send emails/announcements
+- Manually -- Send the email notification manually to [kubernetes-announce][k-announce-list] and [kubernetes-dev][k-dev-list]. You can take contents of the announcement in one of the following ways:
+  - By taking the contents from the Google Cloud Bucket: `gs://kubernetes-release/archive/anago-vX.Y.0-{alpha,beta,rc}.z`:
+  - By using `krel announce` command with the `--print-only` flag
   - [Example subject](https://gcsweb.k8s.io/gcs/kubernetes-release/archive/anago-v1.17.0-rc.2/announcement-subject.txt)
   - [Example body](https://gcsweb.k8s.io/gcs/kubernetes-release/archive/anago-v1.17.0-rc.2/announcement.html)
 
 [k-announce-list]: https://groups.google.com/forum/#!forum/kubernetes-announce
-[k-announce-request]: https://groups.google.com/forum/#!contactowner/kubernetes-announce
+[k-dev-list]: https://groups.google.com/forum/#!forum/kubernetes-dev
 [release tools]: https://github.com/kubernetes/release#tools
 [kubernetes/release]: https://github.com/kubernetes/release
-[kubernetes-sigs/k8s-container-image-promoter]: https://github.com/kubernetes-sigs/k8s-container-image-promoter/tree/master/cmd/cip-mm
+[sendgrid-identity-verification]: https://sendgrid.com/docs/for-developers/sending-email/sender-identity/
 
 ## Releases Management
 

--- a/release-engineering/role-handbooks/branch-manager.md
+++ b/release-engineering/role-handbooks/branch-manager.md
@@ -283,6 +283,8 @@ After the release process has been completed, you can use the `krel gcbmgr histo
 krel gcbmgr history --branch release-1.xy --date-from <date-of-release>
 ```
 
+_note:_ `krel gcbmgr history` command might require additional `gcloud` authentication. If you see an error, follow the steps mentioned in the error message to authenticate, and then re-run the command.
+
 The generated table is copied to the created issue, as it can be seen in the [following issue for the v1.20.0-alpha.1 release](https://github.com/kubernetes/sig-release/issues/1249#issue-705792603).
 
 After having thoroughly read the section on cutting a release version of the handbook, and that all items on the checklist have completed (you may include notes on events that was unique to cutting that release version as comments), close the issue with `/close` as a comment the issue thread.

--- a/release-engineering/role-handbooks/branch-manager.md
+++ b/release-engineering/role-handbooks/branch-manager.md
@@ -13,6 +13,7 @@
     - [Release tooling](#release-tooling)
     - [Google Cloud SDK](#google-cloud-sdk)
     - [Sending mail](#sending-mail)
+    - [Skopeo](#skopeo)
 - [Releases Management](#releases-management)
   - [Alpha Releases](#alpha-releases)
     - [Alpha Stage](#alpha-stage)
@@ -224,6 +225,13 @@ This can be done in one of two ways:
 [release tools]: https://github.com/kubernetes/release#tools
 [kubernetes/release]: https://github.com/kubernetes/release
 [sendgrid-identity-verification]: https://sendgrid.com/docs/for-developers/sending-email/sender-identity/
+
+#### Skopeo
+
+[Skopeo][skopeo] is a command line utility that performs various operations on container images and image repositories. Skopeo is not required for performing branch management tasks (if needed, Docker and other relevant tools can be used instead), however, it might be referred to by other guides. If you want to install Skopeo, you can follow the [official installation guide][skopeo-install].
+
+[skopeo]: https://github.com/containers/skopeo
+[skopeo-install]: https://github.com/containers/skopeo/blob/master/install.md
 
 ## Releases Management
 


### PR DESCRIPTION
#### What type of PR is this:

/kind documentation

#### What this PR does / why we need it:

This PR proposes some improvements to the branch management handbook:

- Add additional information about sending the announcement
  - Add information about `krel announce --print-only`
  - Add information about needed SendGrid Sender Identity Verification
  - Recommend sending the announcement to both k-announce and k-dev
- Add a note about additional `gcloud` authentication for `krel gcbmgr history`
- Add information about Skopeo
  - I wasn't sure about this because it's not mandatory (I have mentioned this in the handbook), but I thought it might be useful and referred to in other guides

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

/hold
for discussion

/assign @justaugustus @saschagrunert @cpanato @hasheddan 