### PR TITLE
Add a step about modifying prow config file to automatically apply milestones

### DIFF
--- a/release-team/role-handbooks/docs/Release-Timeline.md
+++ b/release-team/role-handbooks/docs/Release-Timeline.md
@@ -661,6 +661,18 @@ Enable branch protection on the new `dev-` branch, and deprecate the older one; 
 
 Create a milestone for NEW upcoming release. Depending on your permissions, you might need to contact a SIG Docs maintainer. Move anything missed for the current release to the new milestone.
 
+### Modify prow config file
+
+Create a [pull request](https://github.com/kubernetes/test-infra/pull/19877) against [k/test-infra](https://github.com/kubernetes/test-infra)
+ to configure [prow](https://github.com/kubernetes/test-infra/tree/master/prow#) to automatically apply milestones to future release branch
+ and to remove the configuration for the last release.
+
+```diff
+kubernetes/website:
+-   dev-1.19: 1.19
++   dev-1.20: 1.20
+```
+
 ### Update Netlify
 
 Update Netlify (contact a [SIG Docs Chair or Technical Lead](https://git.k8s.io/community/sig-docs#leadership) if you do not have access and they can assist with this):


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this:

<!--
Add one of the following kinds:
/kind cleanup
/kind documentation
/kind feature
/kind design
-->
/kind documentation

#### What this PR does / why we need it:
By modifying the prow config, this allows prow to automatically apply the milestone to future branches when a PR is created against it. Therefore, adding a step in the docs role handbook to make sure prow is set up for the next release

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #
or
None
-->
None

#### Special notes for your reviewer:
Relates to https://github.com/kubernetes/website/pull/24835 and https://github.com/kubernetes/test-infra/pull/19877
/hold for feedback from @kubernetes/sig-docs-leads 