### PR TITLE
Update Release Managers (promotions, new members, retirement, and inactivity updates)

### DIFF
--- a/release-managers.md
+++ b/release-managers.md
@@ -60,13 +60,10 @@ GitHub Mentions: [@kubernetes/release-engineering](https://github.com/orgs/kuber
 - Adolfo García Veytia ([@puerco](https://github.com/puerco))
 - Carlos Panato ([@cpanato](https://github.com/cpanato))
 - Daniel Mangum ([@hasheddan](https://github.com/hasheddan))
-- Doug MacEachern ([@dougm](https://github.com/dougm))
-- Hannes Hörl ([@hoegaarden](https://github.com/hoegaarden))
 - Marko Mudrinić ([@xmudrii](https://github.com/xmudrii))
 - Pengfei Ni ([@feiskyer](https://github.com/feiskyer))
 - Sascha Grunert ([@saschagrunert](https://github.com/saschagrunert))
 - Stephen Augustus ([@justaugustus](https://github.com/justaugustus))
-- Tim Pepper ([@tpepper](https://github.com/tpepper))
 - Yang Li ([@idealhack](https://github.com/idealhack))
 
 ### Becoming a Release Manager

--- a/release-managers.md
+++ b/release-managers.md
@@ -57,6 +57,7 @@ GitHub Access Controls: [@kubernetes/release-managers](https://github.com/orgs/k
 
 GitHub Mentions: [@kubernetes/release-engineering](https://github.com/orgs/kubernetes/teams/release-engineering)
 
+- Adolfo García Veytia ([@puerco](https://github.com/puerco))
 - Carlos Panato ([@cpanato](https://github.com/cpanato))
 - Daniel Mangum ([@hasheddan](https://github.com/hasheddan))
 - Doug MacEachern ([@dougm](https://github.com/dougm))
@@ -104,7 +105,6 @@ referred to as Release Manager shadows. They are responsible for:
 
 GitHub Mentions: @kubernetes/release-engineering
 
-- Adolfo García Veytia ([@puerco](https://github.com/puerco))
 - Gianluca Arbezzano ([@gianarb](https://github.com/gianarb))
 - Jim Angel ([@jimangel](https://github.com/jimangel))
 - Marky Jackson ([@markyjackson-taulia](https://github.com/markyjackson-taulia))

--- a/release-managers.md
+++ b/release-managers.md
@@ -105,6 +105,7 @@ referred to as Release Manager shadows. They are responsible for:
 
 GitHub Mentions: @kubernetes/release-engineering
 
+- Arnaud Meukam ([@ameukam](https://github.com/ameukam))
 - Gianluca Arbezzano ([@gianarb](https://github.com/gianarb))
 - Jim Angel ([@jimangel](https://github.com/jimangel))
 - Marky Jackson ([@markyjackson-taulia](https://github.com/markyjackson-taulia))

--- a/release-managers.md
+++ b/release-managers.md
@@ -15,7 +15,7 @@ The responsibilities of each role are described below.
 - [Build Admins](#build-admins)
 - [SIG Release Leads](#sig-release-leads)
   - [Chairs](#chairs)
-  - [Technical Leads](#technical-leads) 
+  - [Technical Leads](#technical-leads)
 
 ## Contact
 
@@ -145,13 +145,13 @@ GitHub team: [@kubernetes/sig-release-leads](https://github.com/orgs/kubernetes/
 
 ### Chairs
 
+- Sascha Grunert ([@saschagrunert](https://github.com/saschagrunert))
 - Stephen Augustus ([@justaugustus](https://github.com/justaugustus))
-- Tim Pepper ([@tpepper](https://github.com/tpepper))
 
 ### Technical Leads
 
+- Daniel Mangum ([@hasheddan](https://github.com/hasheddan))
 - Jorge Alarcon ([@alejandrox1](https://github.com/alejandrox1))
-- Sascha Grunert ([@saschagrunert](https://github.com/saschagrunert))
 
 ---
 

--- a/release-managers.md
+++ b/release-managers.md
@@ -22,7 +22,7 @@ The responsibilities of each role are described below.
 | Mailing List | Slack | Visibility | Usage | Membership |
 | --- | --- | --- | --- | --- |
 | [release-managers@kubernetes.io](mailto:release-managers@kubernetes.io) | [#release-management](https://kubernetes.slack.com/messages/CJH2GBF7Y) (channel) / @release-managers (user group) | Public | Public discussion for Release Managers | All Release Managers (including Associates, Build Admins, and SIG Chairs) |
-| [release-managers-private@kubernetes.io](mailto:release-managers-private@kubernetes.io) | [#release-private](https://kubernetes.slack.com/messages/GKEA5EL67) | Private | Private discussion for privileged Release Managers | Patch Release Team, Branch Managers, SIG Chairs |
+| [release-managers-private@kubernetes.io](mailto:release-managers-private@kubernetes.io) | [#release-private](https://kubernetes.slack.com/messages/GKEA5EL67) | Private | Private discussion for privileged Release Managers | Release Managers, SIG Release leadership |
 | [security-release-team@kubernetes.io](mailto:security-release-team@kubernetes.io) | N/A | Private | Security release coordination with the Product Security Committee | [security-discuss-private@kubernetes.io](mailto:security-discuss-private@kubernetes.io), [release-managers-private@kubernetes.io](mailto:release-managers-private@kubernetes.io) |
 
 ## Handbooks
@@ -42,9 +42,12 @@ Release Managers are responsible for:
   [Release Team](/release-team/README.md) through each release cycle
 - Mentoring the [Release Manager Associates](#associates) group
 - Actively developing features and maintaining the code in k/release
-- Supporting Release Manager Associates and contributors through actively participating in the Buddy program
-  - Check in monthly with Associates and delegate tasks, empower them to cut releases, and mentor
-  - Being available to support Associates in onboarding new contributors—answering questions and suggesting appropriate work for them to do
+- Supporting Release Manager Associates and contributors through actively
+  participating in the Buddy program
+  - Check in monthly with Associates and delegate tasks, empower them to cut
+    releases, and mentor
+  - Being available to support Associates in onboarding new contributors e.g.,
+    answering questions and suggesting appropriate work for them to do
 
 This team at times works in close conjunction with the
 [Product Security Committee][psc] and therefore should abide by the guidelines
@@ -67,14 +70,20 @@ GitHub Mentions: [@kubernetes/release-engineering](https://github.com/orgs/kuber
 
 ### Becoming a Release Manager
 
-To become a Release Manager, one must first serve as a Release Manager Associate. Associates graduate to Release Manager by actively working on releases over several cycles and:
+To become a Release Manager, one must first serve as a Release Manager
+Associate. Associates graduate to Release Manager by actively working on
+releases over several cycles and:
 
 - demonstrating the willingness to lead
-- tag-teaming with Release Managers on patches, to eventually cut a release independently
-  - because releases have a limiting function, we also consider substantial contributions to image promotion and other core Release Engineering tasks
-- questioning how Associates work, suggesting improvements, gathering feedback, and driving change
+- tag-teaming with Release Managers on patches, to eventually cut a release
+  independently
+  - because releases have a limiting function, we also consider substantial
+    contributions to image promotion and other core Release Engineering tasks
+- questioning how Associates work, suggesting improvements, gathering feedback,
+  and driving change
 - being reliable and responsive
-- leaning into advanced work that requires Release Manager-level access and privileges to complete
+- leaning into advanced work that requires Release Manager-level access and
+  privileges to complete
 
 ## Release Manager Associates
 
@@ -82,13 +91,16 @@ Release Manager Associates are apprentices to the Release Managers, formerly
 referred to as Release Manager shadows. They are responsible for:
 
 - Patch release work, cherry pick review
-- Contributing to k/release: updating dependencies and getting used to the source codebase
-- Working on minor releases (x.y.z, where z = 0) 
-- With help from a release manager, working with the Release Team during the release cycle
+- Contributing to k/release: updating dependencies and getting used to the
+  source codebase
+- Working on minor releases (x.y.z, where z = 0)
+- With help from a release manager, working with the Release Team during the
+  release cycle
 - Seeking opportunities to help with prioritization and communication
-    - Sending out pre-announcements and updates about patch releases
-    - Updating the calendar
-- Through the Buddy program, onboarding new contributors and pairing up with them on tasks
+  - Sending out pre-announcements and updates about patch releases
+  - Updating the calendar
+- Through the Buddy program, onboarding new contributors and pairing up with
+  them on tasks
 
 GitHub Mentions: @kubernetes/release-engineering
 
@@ -105,11 +117,17 @@ GitHub Mentions: @kubernetes/release-engineering
 
 Contributors can become Associates by demonstrating the following:
 
-- consistent participation, including 6-12 months of active release engineering-related work
-- experience fulfilling a technical lead role on the Release Team during a release cycle
-    - this experience provides a solid baseline for understanding how SIG Release works overall—including our expectations regarding technical skills, communications/responsiveness, and reliability
-- working on k/release items that improve our interactions with Testgrid, cleaning up libraries, etc.
-    - these efforts require interacting and pairing with Release Managers and Associates
+- consistent participation, including 6-12 months of active release
+  engineering-related work
+- experience fulfilling a technical lead role on the Release Team during a
+  release cycle
+  - this experience provides a solid baseline for understanding how SIG Release
+    works overall—including our expectations regarding technical skills,
+    communications/responsiveness, and reliability
+- working on k/release items that improve our interactions with Testgrid,
+  cleaning up libraries, etc.
+  - these efforts require interacting and pairing with Release Managers and
+    Associates
 
 ## Build Admins
 
@@ -118,7 +136,7 @@ Google build systems/tooling to publish deb/rpm packages on behalf of the
 Kubernetes project. They are responsible for:
 
 - Building, signing, and publishing the deb/rpm packages
-- Being the interlock with Release Managers (and Associates) on the final steps 
+- Being the interlock with Release Managers (and Associates) on the final steps
 of each minor (1.Y) and patch (1.Y.Z) release
 
 GitHub team: [@kubernetes/build-admins](https://github.com/orgs/kubernetes/teams/build-admins)
@@ -136,10 +154,11 @@ SIG Release Chairs and Technical Leads are responsible for:
 - Leading knowledge exchange sessions for Release Managers and Associates
 - Coaching on leadership and prioritization
 
-They are mentioned explicitly here as they are owners of the various communications 
-channels and permissions groups (GitHub teams, GCP access) for each role. As such, they 
-are highly privileged community members and privy to some private communications, which 
-can at times relate to Kubernetes security disclosures.
+They are mentioned explicitly here as they are owners of the various
+communications channels and permissions groups (GitHub teams, GCP access) for
+each role. As such, they are highly privileged community members and privy to
+some private communications, which can at times relate to Kubernetes security
+disclosures.
 
 GitHub team: [@kubernetes/sig-release-leads](https://github.com/orgs/kubernetes/teams/sig-release-leads)
 
@@ -155,7 +174,8 @@ GitHub team: [@kubernetes/sig-release-leads](https://github.com/orgs/kubernetes/
 
 ---
 
-Past Branch Managers, can be found in the [releases directory](/releases) within `release-x.y/release_team.md`.
+Past Branch Managers, can be found in the [releases directory](/releases)
+within `release-x.y/release_team.md`.
 Example: [1.15 Release Team](/releases/release-1.15/release_team.md)
 
 [psc]: https://git.k8s.io/community/committee-product-security/README.md


### PR DESCRIPTION
#### What type of PR is this:

/kind cleanup documentation

#### What this PR does / why we need it:

We've got a set of team changes in flight, which are captured here.
This PR will only contain changes to the Release Managers page; I'll follow-up with OWNERS updates in future PRs.

- Rotate leadership team listed on Release Managers page (https://github.com/kubernetes/community/pull/5286)
  - @tpepper steps down as SIG Chair (https://github.com/kubernetes/sig-release/issues/1321)
  - @saschagrunert steps up as SIG Chair (https://github.com/kubernetes/sig-release/issues/1322)
  - @hasheddan steps up as SIG Technical Lead (https://github.com/kubernetes/sig-release/issues/1322)

- Promote @puerco to full-fledged Release Manager (ref: https://groups.google.com/a/kubernetes.io/g/release-managers-private/c/TeZm5Zxxwz4)

  Adolfo has been doing excellent work with the Release Engineering tooling, consistently exercises good judgement, and ability to execute.

- Add @ameukam as a Release Manager Associate (discussed w/ @kubernetes/sig-release-leads)
  
  Arnaud continues to be involved in WG K8s Infra, has assisted with standing up our instance of Triage Party, and is working on migrating our CI build jobs to community infrastructure.
  As we prepare to take on more responsibilities around GCS/GCR artifact administration and K8s Infra, his participation in the Release Managers groups will be strategic.

- @tpepper, @hoegaarden, and @dougm stepping down as Release Managers (results of the Release Managers check-in survey)

---

The final commit for this PR will be the removal of inactive Release Managers and Associates, which is gated on responses to the Release Managers check-in survey (which closes this Friday, November 13, EOD US Eastern).
/hold

The following notices were sent about the survey:
- 11/4: https://groups.google.com/a/kubernetes.io/g/release-managers/c/-0THUc578s8/m/WjFcf7h3BwAJ
- 11/4: https://kubernetes.slack.com/archives/C2C40FMNF/p1604504049103400
- 11/10: https://kubernetes.slack.com/archives/C2C40FMNF/p1605018614180000

~At present, 5 of our 18 current Release Managers and Associates have not completed the survey.
Individual pings have been sent to each of these group members.~

All Release Managers and Associates have checked in.

/assign @saschagrunert @hasheddan 
cc: @kubernetes/release-engineering 

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #
or
None
-->

#### Special notes for your reviewer:
