### PR TITLE
Bump 1.20 Docs Merge Ready Date

### DIFF
--- a/releases/release-1.20/README.md
+++ b/releases/release-1.20/README.md
@@ -41,7 +41,7 @@ The 1.20 release cycle is proposed as follows:
 - **Tuesday, Oct 6th**: Week 4 - [Enhancements Freeze](../release_phases.md#enhancements-freeze)
 - **Thursday, Nov 12th**: Week 9 - [Code Freeze](../release_phases.md#code-freeze)
 - **Monday, Nov 23rd**: Week 11 - [Test Freeze](../release_phases.md#test-freeze)
-- **Monday, Nov 30th**: Week 12 - Docs must be completed and reviewed
+- **Wednesday, Dec 2nd**: Week 12 - Docs must be completed and reviewed
 - **Tuesday, Dec 8th**: Week 13 - Kubernetes v1.20.0 released
 - **Thursday, Dec 17th**: Week 14 - Release Retrospective
 
@@ -71,7 +71,7 @@ The 1.20 release cycle is proposed as follows:
 | **KubeCon CloudNativeCon North America Ends** | Community | Friday, November 20 |  | |
 | Docs deadline - PRs ready for review | Docs Lead | Mon November 23 | week 11 | |
 | **[Test Freeze]** (EOD PST) | Branch Manager | Mon November 23 | |
-| Docs complete - All PRs reviewed and ready to merge | Docs Lead | Mon November 30 | week 12 | |
+| Docs complete - All PRs reviewed and ready to merge | Docs Lead | Wed December 2 | week 12 | |
 | release-1.20 branch created | Branch Manager | Tue December 1 | | |
 | release-1.20 jobs created | Branch Manager | Tue December 1 | | |
 | 1.20.0-rc.0 released | Branch Manager | Tue December 1 | | |


### PR DESCRIPTION
Signed-off-by: Jeremy Rickard <rickardj@vmware.com>

#### What type of PR is this:

<!--
Add one of the following kinds:
/kind cleanup
/kind documentation
/kind feature
/kind design
-->
/kind cleanup
/area release-team

#### What this PR does / why we need it:

This PR bumps out the docs ready for merge date by 2 days to account for the large number of items in the release needing docs, as well as the holiday and KubeCon overlaps. New date becomes Wed, Dec 2nd. 


/hold for review from docs team
/cc @annajung @hasheddan @savitharaghunathan @palnabarun 