### PR TITLE
OWNERS: SIG Release leadership transition and Release Manager updates

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,9 +1,10 @@
 aliases:
   sig-release-leads:
-    - alejandrox1
-    - justaugustus
-    - saschagrunert
-    - tpepper
+    - alejandrox1 # SIG Technical Lead
+    - hasheddan # SIG Technical Lead
+    - justaugustus # SIG Chair
+    - LappleApple # SIG Program Manager
+    - saschagrunert # SIG Chair
   licensing:
     - dims # subproject owner
     - justaugustus # subproject owner
@@ -11,27 +12,27 @@ aliases:
     - swinslow # subproject owner
   release-engineering-approvers:
     - cpanato # Release Manager
-    - dougm # Release Manager
     - feiskyer # Release Manager
-    - hasheddan # Release Manager
-    - hoegaarden # Release Manager
+    - hasheddan # subproject owner / Release Manager
     - idealhack # Release Manager
+    - puerco # Release Manager
     - saschagrunert # subproject owner / Release Manager
     - justaugustus # subproject owner / Release Manager
-    - tpepper # subproject owner / Release Manager
+    - tpepper # subproject owner
     - xmudrii # Release Manager
   release-engineering-reviewers:
+    - ameukam # Release Manager Associate
     - gianarb # Release Manager Associate
     - jimangel # Release Manager Associate
     - markyjackson-taulia # Release Manager Associate
     - mkorbi # Release Manager Associate
     - onlydole # Release Manager Associate
-    - puerco # Release Manager Associate
     - sethmccombs # Release Manager Associate
     - verolop # Release Manager Associate
   release-team:
     - alejandrox1 # subproject owner / 1.18 RT Lead
     - guineveresaenger # subproject owner / 1.17 RT Lead
+    - hasheddan # subproject owner
     - jeremyrickard # subproject owner / 1.20 RT Lead
     - justaugustus # subproject owner
     - onlydole # subproject owner / 1.19 RT Lead


### PR DESCRIPTION
#### What type of PR is this:

/kind cleanup

#### What this PR does / why we need it:

- Promote @puerco to full-fledged Release Manager
- Add @ameukam as Release Manager Associate
- @tpepper, @hoegaarden, and @dougm retire as Release Managers
- Tim is now Emeritus Chair
  ...but remains as subproject owner for a few things!
- @hasheddan joins as SIG TL (and by extension subproject owner)
- @saschagrunert moves from TL to Chair
- Grant @LappleApple approval powers as SIG Program Manager

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/assign @hasheddan @saschagrunert 
cc: @kubernetes/sig-release-leads @kubernetes/release-engineering 

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #
or
None
-->

#### Special notes for your reviewer:
