### PR TITLE
Move Release Manager responsibilities to release-managers doc

### DIFF
--- a/release-engineering/role-handbooks/branch-manager.md
+++ b/release-engineering/role-handbooks/branch-manager.md
@@ -3,9 +3,6 @@
 - [Content Notice](#content-notice)
 - [Overview](#overview)
   - [Conventions](#conventions)
-  - [Minimum Requirements](#minimum-requirements)
-  - [Responsibilities](#responsibilities)
-  - [Associates Expectations](#associates-expectations)
 - [Prerequisites](#prerequisites)
   - [Branch Management Onboarding](#branch-management-onboarding)
   - [Machine setup](#machine-setup)
@@ -90,50 +87,6 @@ To simplify certain instructions, we will make the following connections:
 | "release no longer in support" | `x.y-4` | Kubernetes 1.14 |
 
 **As an editor of this content, Branch Managers should periodically update these conventions and the examples contained within this handbook.**
-
-### Minimum Requirements
-
-- Familiarity with basic Unix commands and able to debug shell scripts.
-- Familiarity with branched source code workflows via `git` and associated `git` command line invocations.
-- General knowledge of Google Cloud (Cloud Build and Cloud Storage).
-- Open to seeking help and communicating clearly.
-- [Kubernetes Community Membership](https://github.com/kubernetes/community/blob/master/community-membership.md#member)
-
-### Responsibilities
-
-The release branch manager is responsible for cutting a version of [Kubernetes]. Each release is a three month cycle where as branch manager it's expected you:
-
-1. Cut releases for the next release cycle as specified on the timeline in `sig-release/releases/release-x.y/README.md`
-   - For example, during the v1.16 cycle you're expected to allocate time to cut releases on the dates detailed in [sig-release/releases/release-1.16/README.md][release-1.16]. The bulk of your time commitment is during release cut days.
-1. Allocate time to setup your system to run the release tools; eventually you'll become more familiar with the process.
-1. Participate in weekly one hour release team meetings.
-1. Run `krel ff` as soon as the release branch (`release-x.y`) [is created](#branch-creation) on a daily basis. (Takes less than 45 minutes)
-1. Dedicate additional time during [code freeze](#code-freeze) when approaching the official release (expect around three one hour meetings in a week).
-1. Select Associates and guide them in preparation to become the section lead for the next cycle.
-1. Delegate tasks to the Associates (where applicable), so they may participate during the release process.
-1. Update this handbook where appropriate for the next release cycle.
-1. Have willingness to accommodate with different time zones especially for the release team and Associates.
-1. Participate in conversations that happen on [#sig-release] and [#release-management]
-
-To get a better overview of the time it takes to run the release tools, you can take a look at the collected metrics from each of these [release cut issues][release-cut-issues].
-
-[Branch Management diagram](https://docs.google.com/presentation/d/1usEbwHMSC8vR7HvbxHJBOj2ISdTkw9rmufQUq7fkIl4/edit?ts=5cc0de62#slide=id.g577153f745_1_405) illustrating the process over a 3 month [release lifecycle](https://docs.google.com/presentation/d/1usEbwHMSC8vR7HvbxHJBOj2ISdTkw9rmufQUq7fkIl4/edit?ts=5cc0de62#slide=id.g577153f745_3_0).
-
-[Kubernetes]: https://github.com/kubernetes/kubernetes/releases
-[release-1.16]: https://github.com/kubernetes/sig-release/tree/master/releases/release-1.16
-[#sig-release]: https://kubernetes.slack.com/messages/C2C40FMNF
-[#release-management]: https://kubernetes.slack.com/messages/CJH2GBF7Y
-[release-cut-issues]: https://github.com/kubernetes/sig-release/issues?utf8=%E2%9C%93&q=is%3Aissue+1.18.0+is%3Aclosed+
-
-### Associates Expectations
-
-Release Manager Associates are apprentices to the Branch Managers, it's expected you:
-
-1. Attend most of the release team meetings; you're highly encouraged to give suggestions, ask questions, voice thoughts, etc.
-1. Know, and help with, the release dates from the [release cycle Timeline](https://github.com/kubernetes/sig-release/tree/master/releases).
-1. Participate in discussion to improve the [release tools].
-1. Question the content of this handbook. *“The greatest enemy of knowledge is not ignorance, it is the illusion of knowledge.”*
-1. Be curious and make the most out of this opportunity.
 
 ## Prerequisites
 

--- a/release-engineering/role-handbooks/patch-release-team.md
+++ b/release-engineering/role-handbooks/patch-release-team.md
@@ -43,28 +43,6 @@ construction.**
 
 ---
 
-Specific duties of the Patch Release Team include:
-
-- Ensuring the release branch (e.g. `release-1.13`) remains in a
-  healthy state as measured by the branch version specific release-blocking
-  CI (e.g. for version 1.13 it is [testgrid sig-release-1.13-blocking
-  board](https://testgrid.k8s.io/sig-release-1.13-blocking). If the
-  build breaks or any CI for the release branch becomes unhealthy due
-  to a bad merge or infrastructure issue, ensure that actions are
-  taken ASAP to bring it back to a healthy state.
-- Reviewing and approving [cherry
-  picks](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) to
-  the release branch.
-  - Patch releases should not contain new features, so ensure that
-    cherry-picks are for bug/security fixes only.
-  - Cherry picks should not destabilize the branch, so ensure that
-    either the PR has had time to stabilize in master or will have
-    time to stabilize in the release branch before the next patch
-    release is cut.
-- Setting the [schedule and cadence for patch
-  releases](/releases/patch-releases.md) and cutting the
-  [releases](https://github.com/kubernetes/kubernetes/releases).
-
 While this playbook is intended to guide Patch Release Team members,
 it largely consists of opinions and recommendations from former
 patch release managers.  Each Patch Release Team member is ultimately

--- a/release-managers.md
+++ b/release-managers.md
@@ -35,11 +35,32 @@ The responsibilities of each role are described below.
 
 ## Release Managers
 
+**Note:** The documentation might refer to the Patch Release Team and the
+Branch Management role. Those two roles were consolidated into the
+Release Managers role.
+
+Minimum requirements for Release Managers and Release Manager Associates are:
+
+- Familiarity with basic Unix commands and able to debug shell scripts.
+- Familiarity with branched source code workflows via `git` and associated
+  `git` command line invocations.
+- General knowledge of Google Cloud (Cloud Build and Cloud Storage).
+- Open to seeking help and communicating clearly.
+- [Kubernetes Community Membership](https://github.com/kubernetes/community/blob/master/community-membership.md#member)
+
 Release Managers are responsible for:
 
-- Coordinating patch releases (`x.y.z`, where `z` > 0) of Kubernetes
-- Minor releases (`x.y.z`, where `z` = 0) of Kubernetes, working with the
-  [Release Team](/release-team/README.md) through each release cycle
+- Coordinating and cutting Kubernetes releases:
+  - Patch releases (`x.y.z`, where `z` > 0)
+  - Minor releases (`x.y.z`, where `z` = 0)
+  - Pre-releases (alpha, beta, and release candidates)
+  - Working with the [Release Team](/release-team/README.md) through each
+  release cycle
+  - Setting the [schedule and cadence for patch releases](/releases/patch-releases.md)
+- Maintaining the release branches:
+  - Reviewing cherry picks
+  - Ensuring the release branch stays healthy and that no unintended patch
+    gets merged
 - Mentoring the [Release Manager Associates](#associates) group
 - Actively developing features and maintaining the code in k/release
 - Supporting Release Manager Associates and contributors through actively
@@ -91,12 +112,14 @@ referred to as Release Manager shadows. They are responsible for:
 - Patch release work, cherry pick review
 - Contributing to k/release: updating dependencies and getting used to the
   source codebase
-- Working on minor releases (x.y.z, where z = 0)
-- With help from a release manager, working with the Release Team during the
-  release cycle
+- Contributing to the documentation: maintaining the handbooks, ensuring that
+  release processes are documented
+- With help from a release manager: working with the Release Team during the
+  release cycle and cutting Kubernetes releases
 - Seeking opportunities to help with prioritization and communication
   - Sending out pre-announcements and updates about patch releases
-  - Updating the calendar
+  - Updating the calendar, helping with the release dates and milestones from
+  the [release cycle Timeline](https://github.com/kubernetes/sig-release/tree/master/releases)
 - Through the Buddy program, onboarding new contributors and pairing up with
   them on tasks
 


### PR DESCRIPTION
#### What type of PR is this:

/kind cleanup

#### What this PR does / why we need it:

We have responsibilities and expectations for Release Managers and Release Manager Associates listed in three places:

- `release-managers.md` document
- Branch Management handbook
- Patch Release Team handbook

The purpose of this PR is to collect responsibilities and expectations and document them in a single place. I've chosen the `release-managers.md` document to be the place where we put that information, but if there's a better place for this, I'd be happy to update the PR.

#### Which issue(s) this PR fixes:

Relevant to #1324

#### Special notes for your reviewer:

I have two concerns regarding this PR for which I'm looking for feedback:

- Does this accurately reflect what was in the handbooks?
- Does this accurately reflect the work that Release Managers and Release Manager Associates are currently doing?

/assign @saschagrunert @justaugustus @cpanato @hasheddan @puerco 
cc: @kubernetes/release-engineering @kubernetes/sig-release-leads 