### PR TITLE
Release Engineering artifacts: Rename Docker to Container Images

### DIFF
--- a/release-engineering/artifacts.md
+++ b/release-engineering/artifacts.md
@@ -1,4 +1,4 @@
-## Docker Images
+## Container Images
 
 |                          	| 386 	| amd64 	| arm 	| arm64 	| ppc64le 	| s390x 	|
 |--------------------------	|:---:	|:-----:	|:---:	|:-----:	|:-------:	|:-----:	|
@@ -9,9 +9,6 @@
 | kube-controller-manager  	|  ✅  	|   ✅   	|  ✅  	|   ✅   	|    ✅    	|   ✅   	|
 | kube-proxy               	|  ✅  	|   ✅   	|  ✅  	|   ✅   	|    ✅    	|   ✅   	|
 | kube-scheduler           	|  ✅  	|   ✅   	|  ✅  	|   ✅   	|    ✅    	|   ✅   	|
-
-Note: starting at 1.16 container images archives for 'amd64' will contain the arch in the name, like 'kube-apiserver-amd64'.
-These can be found inside the binaries tar files, in the manifest.json file under "RepoTags".
 
 ## Storage
 


### PR DESCRIPTION

#### What type of PR is this:

/kind documentation

#### What this PR does / why we need it:
Beside renaming "Docker Images" to "Container Images" we also remove the
note that we changed the file naming convention in 1.16, because we do
not support previous releases any more.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #
or
None
-->
Refers to #1337 
#### Special notes for your reviewer:
None