### PR TITLE
Fix release 1.20 README self link

### DIFF
--- a/releases/release-1.20/README.md
+++ b/releases/release-1.20/README.md
@@ -13,7 +13,7 @@ description: |
 
 #### Links
 
-* [This document](https://git.k8s.io/sig-release/blob/master/releases/release-1.20/README.md)
+* [This document](https://git.k8s.io/sig-release/releases/release-1.20/README.md)
 * [Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.20/release-team.md)
 * [Meeting Minutes](http://bit.ly/k8s120-releasemtg) (join [kubernetes-sig-release@] to receive meeting invites)
 * [v1.20 Release Calendar][k8s120-calendar]


### PR DESCRIPTION
Hello 👋 

Just a small PR to fix release 1.20 README self link 😄 

<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this:

<!--
Add one of the following kinds:
/kind cleanup
/kind documentation
/kind feature
/kind design
-->

/kind documentation

#### What this PR does / why we need it:
Fix release 2.20 README.md self link

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #
or
None
-->

#### Special notes for your reviewer:
