### PR TITLE
Fix links to "Test Freeze"

### DIFF
--- a/releases/release_phases.md
+++ b/releases/release_phases.md
@@ -57,7 +57,7 @@ it is expected that all outstanding PRs for the release of Kubernetes have been
 merged into the release branch. Assuming the release team agrees,
 [Code Freeze], will be lifted, and we enter Code Thaw. This means from a 
 technical perspective, that now the `master` and `release-1.x` branch diverge,
-whereas both kept in sync during [Code Freeze] and [Test Freze]. After Code 
+whereas both kept in sync during [Code Freeze] and [Test Freeze]. After Code 
 Thaw the `master` branch develops toward the next minor release and the release
 branch goes into maintenance mode. From this point forward, any PRs intended
 for the current release must be cherry-picked into the appropriate branch.
@@ -117,4 +117,5 @@ than basing from master. **Be sure to open your PR against the release branch**.
 [Kubernetes Release Calendar]: https://bit.ly/k8s-release-cal
 [Exception]: ./EXCEPTIONS.md
 [Code Freeze]: #code-freeze
+[Test Freeze]: #test-freeze
 [Enhancements Freeze]: #enhancements-freeze


### PR DESCRIPTION
#### What type of PR is this:

/kind documentation

#### What this PR does / why we need it:

Fixes broken links inside [releases/release_phases.md](https://github.com/kubernetes/sig-release/blob/ef8985c02b93d68b183f24312d0d1ed8cfc5a7cf/releases/release_phases.md#release-phases)
Caused by two problems:

1. Typo
2. Missing "link reference definition" https://github.github.com/gfm/#link-reference-definition

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #
or
None
-->

#### Special notes for your reviewer:
