### PR TITLE
Clean up docs role handbook

### DIFF
--- a/release-team/role-handbooks/docs/Release-Timeline.md
+++ b/release-team/role-handbooks/docs/Release-Timeline.md
@@ -31,6 +31,7 @@ For each release, the schedule with deliverables is added to the release directo
     - [Generate the reference documentation](#generate-the-reference-documentation)
     - [Update minor version on API index page](#update-minor-version-on-api-index-page)
     - [Touch base with SIG Cluster Lifecycle (kubeadm)](#touch-base-with-sig-cluster-lifecycle-kubeadm)
+    - [Touch base with the release communications team](#touch-base-with-the-release-communications-team)
 - [Release Week (Week 12)](#release-week-week-12)
     - [Create the release branch](#create-the-release-branch)
     - [Update Netlify](#update-netlify)
@@ -52,6 +53,7 @@ For each release, the schedule with deliverables is added to the release directo
     - [Hold a docs-only retro with Sig Docs](#hold-a-docs-only-retro-with-sig-docs)
 - [Prepare the Next Docs Lead for Success](#prepare-the-next-docs-lead-for-success)
     - [Create branches](#create-branches)
+    - [Enable branch protection](#enable-branch-protection)
     - [Create milestone](#create-milestone)
     - [Update Netlify](#update-netlify)
     - [Update Slack](#update-slack)
@@ -745,8 +747,10 @@ git commit --allow-empty -m "Tracking commit for v1.15 docs"
 git push -u origin dev-1.15
 ```
 
-Enable branch protection on the new `dev-` branch, and deprecate the older one,
-e.g. [Add branch protection and milestone applier for k/website 1.21](https://github.com/kubernetes/test-infra/pull/20182/files)
+### Enable branch protection
+
+Enable branch protection on the new release branch, e.g.
+[Add branch protection and milestone applier for k/website 1.21](https://github.com/kubernetes/test-infra/pull/20182/files)
 
 > Note: You can avoid creating two PRs against the `test-infra` repo by completing the
 > [Modify prow config file](#modify-prow-config-file) at the same time.


### PR DESCRIPTION
Signed-off-by: Anna Jung (VMware) <antheaj@vmware.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this:

<!--
Add one of the following kinds:
/kind cleanup
/kind documentation
/kind feature
/kind design
-->
/kind cleanup

#### What this PR does / why we need it:
- Remove step to create branch protection against the new `dev` branch
- Branch protection is only enabled for the release branches
- Add in the missing header into the toc

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #
or
None
-->
None

#### Special notes for your reviewer:
After speaking with @jimangel on https://github.com/kubernetes/test-infra/pull/20182, we decided that branch protection against the new dev branch is not required. This PR cleans up that requirement in the docs role handbook and focus enabling the protection against the release branches

/assign @savitharaghunathan @jimangel @reylejano 