### PR TITLE
Update priority link in Bug-Triage Handbook

### DIFF
--- a/release-team/role-handbooks/bug-triage/README.md
+++ b/release-team/role-handbooks/bug-triage/README.md
@@ -94,7 +94,7 @@ The Bug Triage role relates to both the Enhancements and CI Signal roles. Unders
 
 Before starting, the Bug Triage members should refer to the following guides to get familiar with used labels:
 - [the documentation for issue `kind` labels](https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label)
-- [the documentation for defining priority and `priority` labels](https://github.com/kubernetes/community/blob/master/contributors/guide/issue-triage.md#define-priority).
+- [the documentation for defining priority and `priority` labels](https://github.com/kubernetes/community/blob/master/contributors/guide/issue-triage.md#step-three-define-priority).
 
 ### How to Escalate
 


### PR DESCRIPTION
This change updates the link of "the documentation for defining priority and `priority` labels" to the right one.

related to #1324

Signed-off-by: Rodolfo Martínez Vega <rodomar@outlook.com>

#### What type of PR is this:

/kind documentation

#### What this PR does / why we need it:

Since the 1.21 Release Team Shadow Application is started, some Shadow candidates are reading these docs and should be referenced to the right information.  

#### Which issue(s) this PR fixes:

Relevant to #1324
