### PR TITLE
release-1.21: update OWNER_ALIASES

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -36,6 +36,7 @@ aliases:
     - jeremyrickard # subproject owner / 1.20 RT Lead
     - justaugustus # subproject owner
     - onlydole # subproject owner / 1.19 RT Lead
+    - palnabarun # subproject owner / 1.21 RT Lead
     - tpepper # subproject owner
   build-admins:
     - amwat
@@ -45,36 +46,42 @@ aliases:
   release-team-lead-role:
     - guineveresaenger # 1.17 RT Lead
     - alejandrox1 # 1.18 RT Lead
-    - onlydole # 1.19 RT Lead
-    - lachie83 # 1.20 Emeritus Adviser
+    - onlydole # 1.19 RT Lead / 1.21 Emeritus Advisor
     - jeremyrickard # 1.20 RT Lead
+    - palnabarun # 1.21 RT Lead
   ci-signal-role:
     - alenkacz # 1.17
     - droslean # 1.18
     - hasheddan # 1.19
     - RobertKielty # 1.20
+    - thejoycekung # 1.21
   enhancements-role:
     - mrbobbytables # 1.17
     - jeremyrickard # 1.18
     - palnabarun # 1.19
     - kikisdeliveryservice # 1.20
+    - annajung # 1.21
   bug-triage-role:
     - josiahbjorgaard # 1.17
     - smourapina # 1.18
     - markyjackson-taulia # 1.19
     - bai # 1.20
+    - erismaster # 1.21
   docs-role:
     - daminisatya # 1.17
     - VineethReddy02 # 1.18
     - savitharaghunathan # 1.19
     - annajung # 1.20
+    - reylejano # 1.21
   release-notes-role:
     - cartyc # 1.17
     - Evillgenius75 # 1.18
     - puerco # 1.19
     - JamesLaverack # 1.20
+    - wilsonehusin # 1.21
   communications-role:
     - rawkode # 1.17
     - karenhchu # 1.18
     - mkorbi # 1.19
     - jrsapi # 1.20
+    - divya-mohan0209 # 1.21


### PR DESCRIPTION
#### What type of PR is this:

/kind cleanup
/kind feature

#### What this PR does / why we need it:

Updates the following OWNER_ALIASES with the 1.21 team:
- release-team-lead-role
- ci-signal-role
- enhancements-role
- bug-triage-role
- docs-role
- release-notes-role
- communications-role

Thank you @lachie83 for being the Emeritus Advisor for 1.20 Release Team. ❤️ 

#### Which issue(s) this PR fixes:

ref: https://github.com/kubernetes/sig-release/issues/1404

#### Special notes for your reviewer:

I noticed that 1.17 is yet to be EOL. So, kept the role lead entries for 1.17.

/assign
/sig release
/area release-team
/priority critical-urgent
/assign @justaugustus @saschagrunert @jeremyrickard @hasheddan @alejandrox1
/cc @kikisdeliveryservice @savitharaghunathan @bai