### PR TITLE
update access reqs for enhancements handbook

### DIFF
--- a/release-team/role-handbooks/enhancements/README.md
+++ b/release-team/role-handbooks/enhancements/README.md
@@ -61,9 +61,8 @@ The shadows should be selected keeping in mind that one of them may eventually b
 
 Ensure that the previous Enhancements Lead has given (or facilitated getting) you access to:
 - GitHub teams
-  - enhancements (This group should be used for Enhancement Subproject related pinging only and not for Release Team Enhancements Group)
-  - milestone-maintainers
-- OWNERS_ALIASES (as `enhancements` in [kubernetes/enhancements][k/enhancements] repo)
+  - [enhancements](https://git.k8s.io/org/config/kubernetes/sig-architecture/teams.yaml) (This group should be used for Enhancement Subproject related pinging only and not for Release Team Enhancements Group)
+  - [milestone-maintainers](https://git.k8s.io/org/config/kubernetes/sig-release/teams.yaml)
 - Access to the previous Kubernetes Release Enhancements Tracking Sheet.
 
 ## Process


### PR DESCRIPTION
Update enhancements handbook to remove Owners_aliases requirement (which is stale and milestone maintainer gives all needed permissions) and to add links to appropriate github teams for clarity.