### PR TITLE
Add 1.21 prerelease dates to calendar

### DIFF
--- a/releases/release-1.21/README.md
+++ b/releases/release-1.21/README.md
@@ -51,31 +51,30 @@ The 1.21 release cycle is proposed as follows:
 | **What** | **Who** | **When** | **WEEK** | **CI SIGNAL** |
 |---|---|---|---|---|
 | Start of Release Cycle | Lead | Mon January 11 | week 1 | [master-blocking] |
-| Start Enhancements Tracking | Enhancements Lead | Tue January 12 | | |
-| Schedule finalized | Lead | Thurs January 14 | | |
-| Team finalized | Lead | Friday January 15 |  | |
-| 1.21.0-alpha.1 released | Branch Manager | TBC | TBC | |
-| Start Release Notes Draft | Release Notes Lead | TBC | TBC | |
+| Start Enhancements Tracking | Enhancements Lead | Tue January 12 | week 1 | |
+| 1.21.0-alpha.1 released | Branch Manager | Wed January 13  | week 1 | |
+| Start Release Notes Draft | Release Notes Lead | TBC | week 1 | |
+| Schedule finalized | Lead | Thurs January 14 | week 1 | |
+| Team finalized | Lead | Friday January 15 | week 1 | |
+| 1.21.0-alpha.2 released | Branch Manager | Tue January 26 | week 3 | |
 | **Begin [Enhancements Freeze]** (EOD PST) | Enhancements Lead | Tue February 9th | week 5 | [master-blocking], [master-informing] |
-| 1.21.0-alpha.2 released | Branch Manager | TBC | TBC | |
-| 1.21.0-alpha.3 released | Branch Manager | TBC | TBC | |
-| 1.21.0-beta.0 released | Branch Manager | TBC | TBC | |
+| 1.21.0-alpha.3 released | Branch Manager | Tue February 9 | week 5 | |
+| 1.21.0-beta.0 released | Branch Manager | Tue February 23 | week 7 | |
 | **Begin [Burndown]** (MWF meetings) | Lead | Mon March 1 | week 8 | [1.21-blocking], [master-blocking], [master-informing] |
-| **Call for [Exceptions][Exception]** | Lead | Mon March 1 | | |
-| Brace Yourself, Code Freeze is Coming | Comms / Bug Triage | Mon March 1 | | |
-| 1.21.0-beta.1 released | Branch Manager | TBC | | |
+| **Call for [Exceptions][Exception]** | Lead | Mon March 1 | week 8 | |
+| Brace Yourself, Code Freeze is Coming | Comms / Bug Triage | Mon March 1 | week 8 | |
+| 1.21.0-beta.1 released | Branch Manager | Tue March 9 | week 9 | |
 | **Begin [Code Freeze]** (EOD PST) | Branch Manager | Tue March 9 | week 9 | |
 | Burndown Meetings daily| Lead | Mon March 15 | week 10 | |
-| Docs deadline - Open placeholder PRs | Docs Lead | Tuesday March 16 | Week 10 | |
-| 1.21.0-beta.2 released | Branch Manager | TBC | | |
-| Docs deadline - PRs ready for review | Docs Lead | Wednesday March 24 | Week 11 | |
-| **[Test Freeze]** (EOD PST) | Branch Manager | TBC | |
-| Docs complete - All PRs reviewed and ready to merge | Docs Lead | Wednesday March 31 | Week 12 | |
-| release-1.21 branch created | Branch Manager | TBC | | |
-| release-1.21 jobs created | Branch Manager | TBC | | |
-| 1.21.0-rc.0 released | Branch Manager | TBC | | |
-| **v1.21.0 released** | Branch Manager | Thurs April 8 | week 13 | |
-| **[Thaw]** | Branch Manager | Thurs April 8 | | |
+| Docs deadline - Open placeholder PRs | Docs Lead | Tue March 16 | week 10 | |
+| Docs deadline - PRs ready for review | Docs Lead | Wed March 24 | week 11 | |
+| **[Test Freeze]** (EOD PST) | Branch Manager | Wed March 24 | week 11 | |
+| 1.21.0-rc.0 released | Branch Manager | Tue March 25 | week 11 | |
+| release-1.21 branch created | Branch Manager | Tue March 25 | week 11 | |
+| release-1.21 jobs created | Branch Manager | Tue March 25 | week 11 | |
+| Docs complete - All PRs reviewed and ready to merge | Docs Lead | Wed March 31 | week 12 | |
+| **v1.21.0 released** | Branch Manager | Thu April 8 | week 13 | |
+| **[Thaw]** | Branch Manager | Thu April 8 | week 13 | |
 | Release retrospective | Community | TBC | TBC | |
 
 ## Phases


### PR DESCRIPTION
#### What type of PR is this:

/kind documentation

#### What this PR does / why we need it:

This PR adds the prerelease cut dates to the 1.21 release calendar.  Dates are standardized to use the same format and weeks numbers are filled in.

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:

/assign @palnabarun 

Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>