### PR TITLE
kube-controller-manager is already distroless

### DIFF
--- a/release-engineering/baseimage-exception-list.md
+++ b/release-engineering/baseimage-exception-list.md
@@ -18,7 +18,6 @@ Please feel free to edit this file when you find any updates. Links to detailed 
 | Image Name | Reasons for exception |
 |---|---|
 | [debian-iptables] | Needed to supported images that require `iptables` |
-| [kube-controller-manager][core-images] | [Flexvolume master driver is blocking controller-manager from moving to distroless](https://github.com/kubernetes/kubernetes/issues/78737) |
 
 ### Release: `debian-iptables`
 


### PR DESCRIPTION
https://github.com/kubernetes/kubernetes/issues/78737 is closed. fixed in https://github.com/kubernetes/kubernetes/pull/91329

<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this:

<!--
Add one of the following kinds:
/kind cleanup
/kind documentation
/kind feature
/kind design
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #
or
None
-->

#### Special notes for your reviewer:
