### PR TITLE
releng: add new GCP project for RelEng

### DIFF
--- a/release-engineering/gcp.md
+++ b/release-engineering/gcp.md
@@ -38,6 +38,7 @@ Mail to the groups below will be ignored. Please instead use the [contact groups
 | `k8s-staging-release-test` | Deprecated | Kubernetes | Release Engineering | Test staging project for Release Engineering (K8s Infra) |
 | `k8s-staging-releng` | Active | Kubernetes | Release Engineering | Staging project for Release Engineering tooling (K8s Infra) |
 | `k8s-releng-prod` | Active | Kubernetes | Release Engineering | Production project for Release Engineering (K8s Infra) |
+| `k8s-staging-releng-test` | Active | Kubernetes | Release Engineering | Staging project for Release Engineering build images (K8s Infra) |
 
 ## KMS
 


### PR DESCRIPTION
#### What type of PR is this:

/kind documentation


#### What this PR does / why we need it:

Document the new GCP project created https://github.com/kubernetes/k8s.io/pull/1592 as part of https://github.com/kubernetes/release/issues/1850

#### Which issue(s) this PR fixes:

None


#### Special notes for your reviewer:

/assign @justaugustus @hasheddan @saschagrunert 
cc @kubernetes/release-engineering 
