### PR TITLE
releases/* move AishSundar to emeritus

### DIFF
--- a/releases/release-1.11/OWNERS
+++ b/releases/release-1.11/OWNERS
@@ -8,5 +8,4 @@ reviewers:
   - calebamiles
   - jdumars
   - tpepper
-  - AishSundar
   # - nickchase (release notes lead)

--- a/releases/release-1.12/OWNERS
+++ b/releases/release-1.12/OWNERS
@@ -2,8 +2,9 @@
 
 approvers:
   - tpepper # RT Lead
-  - AishSundar # RT Lead Shadow
 reviewers:
   - justaugustus
   - marpaia
   # - nickchase (release notes lead)
+emeritus_approvers:
+  - AishSundar # RT Lead Shadow

--- a/releases/release-1.13/OWNERS
+++ b/releases/release-1.13/OWNERS
@@ -1,7 +1,6 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-  - AishSundar # RT Lead
   - spiffxp # RT Lead Shadow
 reviewers:
   - kacole2
@@ -10,3 +9,5 @@ reviewers:
   - tfogo
   - marpaia
   - nikopen
+emeritus_approvers:
+  - AishSundar # RT Lead


### PR DESCRIPTION
ref: https://github.com/kubernetes/org/issues/2456

As a part of cleaning up inactive members (those with no activity within
the past 18 months, this commit removes AishSundar as a reviewer and
where appropriate moves them to emeritus_approvers.

/kind cleanup

