### PR TITLE
Update milestone maintainers section to reflect change in access

### DIFF
--- a/release-team/README.md
+++ b/release-team/README.md
@@ -143,27 +143,27 @@ If you're interested in learning more about how the Release Team is selected, as
 
 Across release cycles, one of the best signals for [issue triage](https://github.com/kubernetes/community/blob/master/contributors/guide/issue-triage.md#milestones) is whether or not an issue or PR is actually targeted for the current milestone.
 
-To maintain up-to-date status on milestone inclusion, we rely on a set of Milestone Maintainers (members of the `kubernetes-milestone-maintainers` GitHub team) to apply the appropriate labels to issues / PRs. This is facilitated by `/milestone` commands and bot automation.
+To maintain up-to-date status on milestone inclusion, we rely on a set of Milestone Maintainers (members of the `milestone-maintainers` GitHub team) to apply the appropriate labels to issues / PRs. This is facilitated by `/milestone` commands and bot automation.
 
 Each release cycle, the current Release Team Lead must update membership to the aforementioned GitHub team.
 
-Maintainers of the `kubernetes-milestone-maintainers` GitHub team are defined as follows:
+Maintainers of the `milestone-maintainers` GitHub team are defined as follows:
 - SIG Release Chairs
 - Current Release Team Lead
 
-Members of the `kubernetes-milestone-maintainers` GitHub team can include:
+Members of the `milestone-maintainers` GitHub team can include:
 - SIG leadership (SIG Chairs / Technical Leads) from all SIGs
 - SIG milestone maintainers from all SIGs (in addition to SIG leadership)
 - Special code reviewers, as selected by SIG Release
 
 Maintainers of the GitHub team can, with justification, add or remove members at any time during release cycles.
 
-Members are expected to actively triage issues and PRs to retain membership in `kubernetes-milestone maintainers`. Members not fulfilling the duties of this role should be removed.
+Members are expected to actively triage issues and PRs to retain membership in `milestone maintainers`. Members not fulfilling the duties of this role should be removed.
 
-Milestone maintainers also have write access to [kubernetes/enhancements][k/enhancements], which allows them to keep enhancement tracking issue descriptions up-to-date.
+Milestone maintainers also have triage access to [kubernetes/enhancements][k/enhancements].
 
-To request membership to `kubernetes-milestone-maintainers` or update the team:
-- File a PR to [kubernetes/org][k/org] making changes to the `kubernetes-milestone-maintainers` team config [here](https://git.k8s.io/org/config/kubernetes/sig-release/teams.yaml). In your PR, include the reason you're requesting access in the description, as well as a comment next to your username in the team config
+To request membership to `milestone-maintainers` or update the team:
+- File a PR to [kubernetes/org][k/org] making changes to the `milestone-maintainers` team config [here](https://git.k8s.io/org/config/kubernetes/sig-release/teams.yaml). In your PR, include the reason you're requesting access in the description, as well as a comment next to your username in the team config
   e.g.,
   ```
   - justaugustus # Azure / PM / Release


### PR DESCRIPTION
Signed-off-by: Anna Jung (VMware) <antheaj@vmware.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this:

<!--
Add one of the following kinds:
/kind cleanup
/kind documentation
/kind feature
/kind design
-->
/kind cleanup
/kind documentation

#### What this PR does / why we need it:
- Update milestone maintainers section to reflect a change in access from write to triage
- Update github team name from `kubernetes-milestone-maintainers` to `milestone-maintainers`

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #
or
None
-->
None

#### Special notes for your reviewer:
