### PR TITLE
Add updating publishing-bot rules to the Branch Management handbook and Release issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/cut-release.md
+++ b/.github/ISSUE_TEMPLATE/cut-release.md
@@ -62,6 +62,10 @@ Collect Metrics:
 Run krel history --branch release-1.mm --date-from 2021-mm-dd
 http://bit.ly/relmanagers-handbook#adding-data-about-the-cloud-build-jobs
 
+Finish post-release branch creation tasks:    ← Only for rc.0 release
+See the Branch Creation section of the handbook for more details:
+http://bit.ly/relmanagers-handbook#branch-creation
+
 Help? Ring @release-managers on slack!
 
 -->
@@ -81,7 +85,7 @@ Help? Ring @release-managers on slack!
 - [ ] Notify #release-management: <!-- Paste link to slack -->
 - [ ] Send notification: <!-- Paste link to kubernetes-dev email -->
 - [ ] Collect metrics and add them to the `Release steps` table below
-
+<!-- ONLY FOR RC.0 RELEASE - [ ] Finish post-release branch creation tasks -->
 
 ## Release Tools Version
 

--- a/release-engineering/role-handbooks/branch-manager.md
+++ b/release-engineering/role-handbooks/branch-manager.md
@@ -41,6 +41,7 @@
     - [Update milestone requirements](#update-milestone-requirements)
     - [Update e2e variants](#update-e2e-variants)
     - [Generate release branch jobs](#generate-release-branch-jobs)
+    - [Update publishing-bot rules](#update-publishing-bot-rules)
   - [Configure Merge Automation](#configure-merge-automation)
     - [Tide](#tide)
     - [Code Freeze](#code-freeze)
@@ -586,6 +587,17 @@ This task should be done after the release is complete and previous PRs are merg
     - [sig-release-1.17-informing](https://testgrid.k8s.io/sig-release-1.17-informing)
 
 1. [Announce in #sig-release and #release-management](https://kubernetes.slack.com/archives/C2C40FMNF/p1565746110248300?thread_ts=1565701466.241200&cid=C2C40FMNF) that this work has been completed
+
+#### Update publishing-bot rules
+
+The Kubernetes Publishing Bot is responsible for:
+
+* ensuring that the master and release branches in the staging repositories are in-sync with the appropriate branches in `kubernetes/kubernetes`
+* creating tags in the staging repositories for each Kubernetes release
+
+It's required to create the appropriate publishing-bot rules for the publishing-bot to work with the release branches. Once a new release branch is created in `kubernetes/kubernetes`, the Release Manager needs to update the publishing-bot rules as described in the [`k/publishing-bot` repository](https://git.k8s.io/publishing-bot#updating-rules).
+
+Here's an [example PR](https://github.com/kubernetes/kubernetes/pull/100616).
 
 [sig-release-x.y-blocking]: https://testgrid.k8s.io/sig-release-1.17-blocking
 [`krel ff`]: https://git.k8s.io/release


### PR DESCRIPTION
#### What type of PR is this:

/kind documentation

#### What this PR does / why we need it:

In the previous (1.20) and the current (1.21) release cycles, we encountered a problem that the publishing-bot rules were not updated when creating a new release branch. That caused a delay between the RC release and creating tags for the RC release in the staging repositories.

The current workflow is that Release Managers cut the RC (which creates a new branch) and then the publishing-bot folks are responsible to add rules for a newly-created branch.

To remind the publishing-bot folks, we create an issue in the `k8s-release-robot/sig-release` repository, such as this one: https://github.com/k8s-release-robot/sig-release/issues/30

However, due to timezones and availability of publishing-bot folks, there might be a delay between the branch cut and when they can update the publishing-bot rules. That delay might even be one day or more. Additionally, once the rules are updated, it might take up to 5 hours for the publishing-bot to publish branches and tags (the bot runs every 4 hours and each run is 1 hour long).

This RFC proposes that the publishing-bot folks handover the responsibility of adding publishing-rules for a new branch to the Release Managers.

I believe that this task is a low to medium effort for the Release Managers, but it can remove or significantly reduce the mentioned delay.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Additional discussion and feedback can be found in the following Slack thread: https://kubernetes.slack.com/archives/C2C40FMNF/p1617007926111900

/hold
for discussion

/cc @kubernetes/release-managers @kubernetes/sig-release-leads

/cc @nikhita @sttts @dims 
tagging folks responsible for the publishing-bot