### PR TITLE
Hyperlink from v1.21 major themes to to docs about structured logging

### DIFF
--- a/releases/release-1.21/release-notes/major-themes.md
+++ b/releases/release-1.21/release-notes/major-themes.md
@@ -22,7 +22,7 @@ Immutable Secrets and ConfigMaps graduates to GA. This feature allows users to s
 
 ## Structured Logging in Kubelet
 
-Kubelet has adopted structured logging, thanks to community effort in accomplishing this within the release timeline. Structured logging in the project remains an ongoing effort -- for folks interested in participating, [keep an eye / chime in to the mailing list discussion](https://groups.google.com/g/kubernetes-dev/c/y4WIw-ntUR8).
+Kubelet has adopted [structured logging](https://kubernetes.io/docs/concepts/cluster-administration/system-logs/#structured-logging), thanks to community effort in accomplishing this within the release timeline. Structured logging in the project remains an ongoing effort -- for folks interested in participating, [keep an eye / chime in to the mailing list discussion](https://groups.google.com/g/kubernetes-dev/c/y4WIw-ntUR8).
 
 ## Storage Capacity Tracking
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this:

<!--
/kind cleanup
-->

#### What this PR does / why we need it:
In “Kubelet has adopted structured logging”, make _structured logging_ a hyperlink, ie “Kubelet has adopted [structured logging](https://kubernetes.io/docs/concepts/cluster-administration/system-logs/#structured-logging)”
This is for the v1.21 release notes; I think it's useful to add that link. https://kubernetes.io/docs/concepts/cluster-administration/system-logs/#structured-logging is not super clear, but linking _somewhere_ does feel more informative than not linking anywhere.

#### Which issue(s) this PR fixes:

<!--
None
-->

#### Special notes for your reviewer:
/sig docs
/sig node
(I think)