### PR TITLE
Add 1.21 to the patch releases schedule

### DIFF
--- a/releases/patch-releases.md
+++ b/releases/patch-releases.md
@@ -54,6 +54,14 @@ releases may also occur in between these.
 
 ## Detailed Release History for Active Branches
 
+### 1.21
+
+End of Life for **1.21** is **2022-04-30**
+
+| PATCH RELEASE | CHERRY PICK DEADLINE | TARGET DATE |
+|--- |--- |--- |
+| 1.21.1        | 2021-05-07           | 2021-05-12  |
+
 ### 1.20
 
 End of Life for **1.20** is **2021-12-30**

--- a/releases/schedule.yaml
+++ b/releases/schedule.yaml
@@ -1,4 +1,10 @@
 schedules:
+- release: 1.21
+  next: 1.21.1
+  cherryPickDeadline: 2021-05-07
+  targetDate: 2021-05-12
+  endOfLifeDate: 2022-04-30
+  previousPatches:
 - release: 1.20
   next: 1.20.6
   cherryPickDeadline: 2021-04-09


### PR DESCRIPTION
#### What type of PR is this:

/kind documentation

#### What this PR does / why we need it:

The Kubernetes 1.21 release went out yesterday, so this PR adds 1.21 to the patch releases schedule.

#### Which issue(s) this PR fixes:

Ref: https://kubernetes.slack.com/archives/C2C40FMNF/p1617961638360800

#### Special notes for your reviewer:

None

cc @kubernetes/release-engineering @kubernetes/release-team-leads 