### PR TITLE
Add Roadmap and Vision

### DIFF
--- a/north-star-vision.md
+++ b/north-star-vision.md
@@ -47,6 +47,8 @@ the following listing, all deliverables are sorted by their priority.
 
 1. **Enhance Kubernetes binary artifact management (Consumable)**
 
+   https://github.com/kubernetes/sig-release/issues/1372
+
    Outcome: Being able to promote files as artifacts and using this mechanism
    for Kubernetes releases.
 
@@ -74,7 +76,7 @@ the following listing, all deliverables are sorted by their priority.
    Kubernetes releases.
 
 1. **Establish Cluster API as first-class signal for upstream releases
-   (Secure)**
+   (Consumable)**
 
    Outcome: Cluster API provides a CI signal for blocking release test jobs.
 
@@ -83,27 +85,25 @@ the following listing, all deliverables are sorted by their priority.
    Outcome: Clear documentation about available version markers as well as their
    simplified automation.
 
-### Out of Scope
+1. **Moving deb/rpm package builds to community infrastructure (Consumable)**
 
-Topic size estimates are roughly: small (1 week or less), medium (2-3 weeks),
-large (4-5 weeks).
+   Outcome: Automated builds of `deb` and `rpm` Kubernetes packages within
+   community infrastructure.
 
-1. **Moving deb/rpm package builds to community infrastructure (large)**
-   - _What:_ The reb/rpm packages are built by the Google build admin, we should
-     move that to community infrastructure and build them automatically.
-   - _Why:_ It’s easier for us to fix issues independently that way and we have
-     more control about how the packages are being built.
-1. **Create a releases landing page (medium)**
-   - _What:_ Creating a releases website as a centralized and canonical place
-     for release related information.
-   - _Why:_ Finding consolidation options where information is right now spread
-     across different places. Helping people to find the latest patch release
-     and where to obtain its artifacts.
-1. **Signing of release artifacts (large)**
-   - _What:_ Being able to GPG sign release artifacts, which also includes
-     container images.
-   - _Why:_ This allows us to enhance the chain of trust between users of
-     Kubernetes artifacts.
+1. **Create releases landing page (Consumable)**
+
+   https://github.com/kubernetes/website/issues/20293
+
+   Outcome: A releases page that is up to date and acts as canonical place for
+   release related information, for example links to release notes and support
+   timelines.
+
+1. **Signing of release artifacts (Secure)**
+
+   https://github.com/kubernetes/release/issues/914
+
+   Outcome: Being able to GPG sign release artifacts, which also includes
+   container images.
 
 ### Known Risks
 

--- a/north-star-vision.md
+++ b/north-star-vision.md
@@ -87,6 +87,8 @@ the following listing, all deliverables are sorted by their priority.
 
 1. **Moving deb/rpm package builds to community infrastructure (Consumable)**
 
+   https://github.com/kubernetes/release/issues/281
+
    Outcome: Automated builds of `deb` and `rpm` Kubernetes packages within
    community infrastructure.
 

--- a/north-star-vision.md
+++ b/north-star-vision.md
@@ -20,7 +20,9 @@ publishing of Kubernetes related artifacts.
    companies like Google.
 1. **Introspectable**: It is clear for users at which point and how Kubernetes
    artifacts are being built. This includes the documentation of all
-   deliverables as well as clarifying what we do not support.
+   deliverables as well as clarifying what we do not support. All official
+   release artifacts will be built by a hermetic process that is impervious to
+   human interference.
 1. **Secure**: The artifacts we produce are verified for their integrity. This
    applies to their functionality (we know what we deliver) as well as their
    software security (we know when CVEs occur).

--- a/north-star-vision.md
+++ b/north-star-vision.md
@@ -1,0 +1,137 @@
+# North Star Vision
+
+## SIG Release Roadmap for 2021 and beyond
+
+This document contains the SIG Release Roadmap for 2021. The status tracking can
+be found at the bottom. More detailed information can be found on the [SIG
+Release][0] and [Release Engineering][1] project boards.
+
+[0]: https://github.com/orgs/kubernetes/projects/23
+[1]: https://github.com/orgs/kubernetes/projects/30
+
+### Primary Focus
+
+Establish a **consumable**, **introspectable**, and **secure** supply chain for
+Kubernetes. As a supply chain we understand the defining, building and
+publishing of Kubernetes related artifacts.
+
+1. **Consumable**: Improving the usability of artifacts by making their
+   consumption easier. This includes being process independent from external
+   companies like Google.
+1. **Introspectable**: It is clear for users at which point and how Kubernetes
+   artifacts are being built. This includes the documentation of all
+   deliverables as well as clarifying what we do not support.
+1. **Secure**: The artifacts we produce are verified for their integrity. This
+   applies to their functionality (we know what we deliver) as well as their
+   software security (we know when CVEs occur).
+
+### Deliverables
+
+The following deliverables are necessary to achieve the overall goal. Within
+the following listing, all deliverables are sorted by their priority.
+
+1. **Formalize supported release platforms (Introspectable)**
+
+   https://github.com/kubernetes/sig-release/issues/1337
+
+   Outcome: Definition of the life cycle for currently supported Kubernetes
+   artifacts and a guideline for the community about how to add new platforms.
+
+1. **Implement a Bill of Materials (BOM) for release artifacts (Introspectable /
+   Secure)**
+
+   https://github.com/kubernetes/release/issues/1837
+
+   Outcome: An automated formal verification of produced release artifacts for
+   every future release.
+
+1. **Enhance Kubernetes binary artifact management (Consumable)**
+
+   Outcome: Being able to promote files as artifacts and using this mechanism
+   for Kubernetes releases.
+
+1. **Define and collect metrics about Kubernetes releases (Introspectable)**
+
+   https://github.com/kubernetes/sig-release/issues/1527
+
+   Outcome: Being able to measure and interpret a set of defined metrics about
+   Kubernetes releases to associate actions with those.
+
+1. **Define and implement the release cadence survey (Introspectable)**
+
+   https://github.com/kubernetes/sig-release/issues/1526
+
+   Outcome: A regular survey evaluating the user experience of the current
+   release cadence.
+
+1. **Simplify CVE process for release management (Secure)**
+
+   https://github.com/kubernetes/sig-release/issues/896
+
+   https://github.com/kubernetes/release/issues/1354
+
+   Outcome: A documented and simple process for handling CVE information within
+   Kubernetes releases.
+
+1. **Establish Cluster API as first-class signal for upstream releases
+   (Secure)**
+
+   Outcome: Cluster API provides a CI signal for blocking release test jobs.
+
+1. **Enhance and simplify Kubernetes version markers (Consumable)**
+
+   Outcome: Clear documentation about available version markers as well as their
+   simplified automation.
+
+### Out of Scope
+
+Topic size estimates are roughly: small (1 week or less), medium (2-3 weeks),
+large (4-5 weeks).
+
+1. **Moving deb/rpm package builds to community infrastructure (large)**
+   - _What:_ The reb/rpm packages are built by the Google build admin, we should
+     move that to community infrastructure and build them automatically.
+   - _Why:_ It’s easier for us to fix issues independently that way and we have
+     more control about how the packages are being built.
+1. **Create a releases landing page (medium)**
+   - _What:_ Creating a releases website as a centralized and canonical place
+     for release related information.
+   - _Why:_ Finding consolidation options where information is right now spread
+     across different places. Helping people to find the latest patch release
+     and where to obtain its artifacts.
+1. **Signing of release artifacts (large)**
+   - _What:_ Being able to GPG sign release artifacts, which also includes
+     container images.
+   - _Why:_ This allows us to enhance the chain of trust between users of
+     Kubernetes artifacts.
+
+### Known Risks
+
+1. **We rely on different SIGs for our work**
+
+   We have a need to discuss our enhancements with different SIGs to get all
+   required information and drive the change. This can lead into helpful, but
+   maybe not expected input and delay the deliverable.
+
+1. **Some topics require initial research**
+
+   We're not completely aware of all technical aspects for the changes. This
+   means that there is a risk of delaying because of investing more time in
+   pre-research.
+
+### Requests to Other Teams
+
+1. **SIG Architecture**
+
+   For the formalization of the released platforms and input about the overall
+   supply chain.
+
+1. **SIG Cluster Lifecycle**
+
+   To get input for making Cluster API a first-class signal for upstream releases.
+
+### Current Status
+
+| Topic | Lead | Status | Target Date | Links |
+| ----- | ---- | ------ | ----------- | ----- |
+|       |      |        |             |       |

--- a/roadmap.md
+++ b/roadmap.md
@@ -1,4 +1,4 @@
-# North Star Vision
+# Roadmap and Vision
 
 ## SIG Release Roadmap for 2021 and beyond
 

--- a/roadmap.md
+++ b/roadmap.md
@@ -16,8 +16,8 @@ Kubernetes. As a supply chain we understand the defining, building and
 publishing of Kubernetes related artifacts.
 
 1. **Consumable**: Improving the usability of artifacts by making their
-   consumption easier. This includes being process independent from external
-   companies like Google.
+   consumption easier. This includes being process independent of vendor,
+   employer and individuals.
 1. **Introspectable**: It is clear for users at which point and how Kubernetes
    artifacts are being built. This includes the documentation of all
    deliverables as well as clarifying what we do not support. All official


### PR DESCRIPTION
#### What type of PR is this:

/kind documentation

#### What this PR does / why we need it:

This PR adds the SIG Release Roadmap and Vision for 2021 and beyond.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

/priority important-soon
/cc @kubernetes/sig-release-leads 
/hold for discussion and review

Referring mailing list discussion: https://groups.google.com/g/kubernetes-sig-release/c/YTessa2-Kow/m/bFy_9bEMAQAJ
Should merge after the cadence KEP: https://github.com/kubernetes/enhancements/pull/2567