### PR TITLE
Fix typo in 1.20 maintenance mode date

### DIFF
--- a/releases/patch-releases.md
+++ b/releases/patch-releases.md
@@ -93,7 +93,7 @@ End of Life for **1.21** is **2022-06-28**
 
 ### 1.20
 
-**1.20** enters maintenance mode on **2022-12-28**
+**1.20** enters maintenance mode on **2021-12-28**
 
 End of Life for **1.20** is **2022-02-28**
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this:

/kind documentation

#### What this PR does / why we need it:

This fixes the Kubernetes 1.20 maintenance mode date that seems to be off by 1 year

It seems that 1.20 has a typo (12 months after release is Dec 2021)
Also EOL is Feb 2022, so it cannot be earlier than maintenance deadline.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #
or
None
-->

#### Special notes for your reviewer:
