### PR TITLE
Release-1.22: update OWNER_ALIASES

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -33,6 +33,7 @@ aliases:
     - justaugustus # subproject owner
     - onlydole # subproject owner / 1.19 RT Lead
     - palnabarun # subproject owner / 1.21 RT Lead
+    - savitharaghunathan # 1.22 RT Lead 
     - tpepper # subproject owner
   build-admins:
     - amwat
@@ -40,44 +41,44 @@ aliases:
     - MushuEE
     - spiffxp
   release-team-lead-role:
-    - guineveresaenger # 1.17 RT Lead
     - alejandrox1 # 1.18 RT Lead
     - onlydole # 1.19 RT Lead / 1.21 Emeritus Advisor
     - jeremyrickard # 1.20 RT Lead
     - palnabarun # 1.21 RT Lead
+    - savitharaghunathan # 1.22 RT Lead
   ci-signal-role:
-    - alenkacz # 1.17
     - droslean # 1.18
     - hasheddan # 1.19
     - RobertKielty # 1.20
     - thejoycekung # 1.21
+    - mkorbi # 1.22
   enhancements-role:
-    - mrbobbytables # 1.17
     - jeremyrickard # 1.18
     - palnabarun # 1.19
     - kikisdeliveryservice # 1.20
     - annajung # 1.21
+    - jameslaverack # 1.22
   bug-triage-role:
-    - josiahbjorgaard # 1.17
     - smourapina # 1.18
     - markyjackson-taulia # 1.19
     - bai # 1.20
     - erismaster # 1.21
+    - monzelmasry # 1.22
   docs-role:
-    - daminisatya # 1.17
     - VineethReddy02 # 1.18
     - savitharaghunathan # 1.19
     - annajung # 1.20
     - reylejano # 1.21
+    - pi-victor # 1.22
   release-notes-role:
-    - cartyc # 1.17
     - Evillgenius75 # 1.18
     - puerco # 1.19
     - JamesLaverack # 1.20
     - wilsonehusin # 1.21
+    - pmmalinov01 # 1.22
   communications-role:
-    - rawkode # 1.17
     - karenhchu # 1.18
     - mkorbi # 1.19
     - jrsapi # 1.20
     - divya-mohan0209 # 1.21
+    - pensu # 1.22


### PR DESCRIPTION

#### What type of PR is this:

/kind cleanup
/kind documentation


#### What this PR does / why we need it:
Updates the following OWNER_ALIASES with the 1.22 team:

-   release-team-lead-role
-   ci-signal-role
-   enhancements-role
-   bug-triage-role
-   docs-role
-   release-notes-role
-   communications-role

#### Which issue(s) this PR fixes:
 Ref: #1522

#### Special notes for your reviewer:
Cleaned up 1.17 team as the branch is not currently active 

/assign
/sig release
/area release-team
/priority critical-urgent
/assign @justaugustus @saschagrunert @jeremyrickard @hasheddan
/cc @annajung @divya-mohan0209 @erismaster @kikisdeliveryservice 
