### PR TITLE
Add v1.22-alpha.1 date

### DIFF
--- a/releases/release-1.22/README.md
+++ b/releases/release-1.22/README.md
@@ -50,7 +50,7 @@ The 1.22 release cycle is proposed as follows:
 |---|---|-------|---|---|
 | Start of Release Cycle | Lead | Mon April 26 | week 1 | [master-blocking] |
 | Start Enhancements Tracking | Enhancements Lead | Mon April 26 | week 1 | |
-| 1.22.0-alpha.1 released | Branch Manager (TBD) | TBD  | TBD | |
+| 1.22.0-alpha.1 released | Branch Manager (@puerco) | Wed April 28  | week 1 | |
 | Schedule finalized | Lead | Thur April 29 | week 1 | |
 | Team finalized | Lead | Fri April 30 | week 1 | |
 | 1.22.0-alpha.2 released | Branch Manager (TBD) | TBD | TBD | |


### PR DESCRIPTION
#### What type of PR is this:
/kind documentation

#### What this PR does / why we need it:

This PR adds the release cut date for `v1.22-alpha.1` (Wed 28 Apr)

Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>

#### Which issue(s) this PR fixes:

None
#### Special notes for your reviewer:
/cc @savitharaghunathan @kubernetes/release-team-leads 