### PR TITLE
releng: Update active Release Managers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -8,22 +8,22 @@ aliases:
     - saschagrunert # SIG Chair
   release-engineering-approvers:
     - cpanato # Release Manager
-    - feiskyer # Release Manager
     - hasheddan # subproject owner / Release Manager
-    - idealhack # Release Manager
     - puerco # Release Manager
     - saschagrunert # subproject owner / Release Manager
     - justaugustus # subproject owner / Release Manager
-    - tpepper # subproject owner
     - xmudrii # Release Manager
   release-engineering-reviewers:
     - ameukam # Release Manager Associate
     - jimangel # Release Manager Associate
     - markyjackson-taulia # Release Manager Associate
     - mkorbi # Release Manager Associate
+    - palnabarun # Release Manager Associate
     - onlydole # Release Manager Associate
     - sethmccombs # Release Manager Associate
+    - thejoycekung # Release Manager Associate
     - verolop # Release Manager Associate
+    - wilsonehusin # Release Manager Associate
   release-team:
     - alejandrox1 # subproject owner / 1.18 RT Lead
     - guineveresaenger # subproject owner / 1.17 RT Lead

--- a/release-managers.md
+++ b/release-managers.md
@@ -82,10 +82,8 @@ GitHub Mentions: [@kubernetes/release-engineering](https://github.com/orgs/kuber
 - Carlos Panato ([@cpanato](https://github.com/cpanato))
 - Daniel Mangum ([@hasheddan](https://github.com/hasheddan))
 - Marko Mudrinić ([@xmudrii](https://github.com/xmudrii))
-- Pengfei Ni ([@feiskyer](https://github.com/feiskyer))
 - Sascha Grunert ([@saschagrunert](https://github.com/saschagrunert))
 - Stephen Augustus ([@justaugustus](https://github.com/justaugustus))
-- Yang Li ([@idealhack](https://github.com/idealhack))
 
 ### Becoming a Release Manager
 

--- a/release-managers.md
+++ b/release-managers.md
@@ -125,8 +125,10 @@ GitHub Mentions: @kubernetes/release-engineering
 
 - Arnaud Meukam ([@ameukam](https://github.com/ameukam))
 - Jim Angel ([@jimangel](https://github.com/jimangel))
+- Joyce Kung ([@thejoycekung](https://github.com/thejoycekung))
 - Marky Jackson ([@markyjackson-taulia](https://github.com/markyjackson-taulia))
 - Max Körbächer ([@mkorbi](https://github.com/mkorbi))
+- Nabarun Pal ([@palnabarun](https://github.com/palnabarun))
 - Seth McCombs ([@sethmccombs](https://github.com/sethmccombs))
 - Taylor Dolezal ([@onlydole](https://github.com/onlydole))
 - Verónica López ([@verolop](https://github.com/verolop))


### PR DESCRIPTION
#### What type of PR is this:

/kind cleanup documentation feature

#### What this PR does / why we need it:

- Update active Release Managers
  - Thanks for all of your work here, @idealhack + @feiskyer!
- Add @thejoycekung and @palnabarun as Release Manager Associates

/assign @hasheddan @saschagrunert
cc: @kubernetes/sig-release-leads @kubernetes/release-engineering 

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #
or
None
-->

#### Special notes for your reviewer:

~Gimme a sec to update OWNERS as well.~