### PR TITLE
Add Release Managers roster to 1.22 schedule

### DIFF
--- a/releases/release-1.22/README.md
+++ b/releases/release-1.22/README.md
@@ -50,26 +50,26 @@ The 1.22 release cycle is proposed as follows:
 |---|---|-------|---|---|
 | Start of Release Cycle | Lead | Mon April 26 | week 1 | [master-blocking] |
 | Start Enhancements Tracking | Enhancements Lead | Mon April 26 | week 1 | |
-| 1.22.0-alpha.1 released | Branch Manager (@puerco) | Wed April 28  | week 1 | |
+| 1.22.0-alpha.1 released | Branch Manager ([@puerco](https://github.com/puerco)) | Wed April 28  | week 1 | |
 | Schedule finalized | Lead | Thur April 29 | week 1 | |
 | Team finalized | Lead | Fri April 30 | week 1 | |
 | KubeCon EU + Co-located events | | May 3-7 | | |
 | **Begin [Enhancements Freeze]** (23:59 PDT) | Enhancements Lead | Thur May 13 | week 3 | [master-blocking], [master-informing] |
-| 1.22.0-alpha.2 released | Branch Manager (TBD) | Tue May 18 | week 4 | |
-| 1.22.0-alpha.3 released | Branch Manager (TBD) | Tue June 7 | week 7 | |
-| 1.22.0-beta.0 released | Branch Manager (TBD) | Tue June 21 | week 9 | |
+| 1.22.0-alpha.2 released | Branch Manager ([@Verolop](https://github.com/Verolop)) | Tue May 18 | week 4 | |
+| 1.22.0-alpha.3 released | Branch Manager ([@wilsonehusin](https://github.com/wilsonehusin)) | Tue June 7 | week 7 | |
+| 1.22.0-beta.0 released | Branch Manager ([@onlydole](https://github.com/onlydole)) | Tue June 21 | week 9 | |
 | **Begin [Burndown]** (MWF meetings) | Lead | Mon June 28 | week 10 | [1.22-blocking], [master-blocking], [master-informing] |
 | **Call for [Exceptions][Exception]** | Lead | Mon June 28 | week 10 | |
 | Brace Yourself, Code Freeze is Coming | Comms / Bug Triage | Mon June 28 | week 10 | |
 | **Begin Feature blog freeze** (23:59 PDT) | Comms Lead | Mon June 28 | week 10 | |
-| 1.22.0-beta.1 released | Branch Manager (TBD) | Thu July 8 | week 11 | |
+| 1.22.0-beta.1 released | Branch Manager ([@ameukam](https://github.com/ameukam)) | Thu July 8 | week 11 | |
 | **Begin [Code Freeze]** (18:00 PDT) | Branch Manager | Thur July 8 | week 11 | |
 | Docs deadline - Open placeholder PRs | Docs Lead | Fri July 9 | week 11 | |
 | Burndown Meetings daily| Lead | Mon July 12 | week 12 | |
-| 1.22.0-beta.2 released | Branch Manager (TBD) | Tue Jul 13 | week 12 | |
+| 1.22.0-beta.2 released | Branch Manager ([@jimangel](https://github.com/jimangel)) | Tue Jul 13 | week 12 | |
 | **[Test Freeze]** (18:00 PDT) | Branch Manager | Thur July 15 | week 12 | |
 | Docs deadline - PRs ready for review | Docs Lead | Tue July 20 | week 13 | |
-| 1.22.0-rc.0 released | Branch Manager (@puerco) | Tue July 20 | week 13 | |
+| 1.22.0-rc.0 released | Branch Manager ([@puerco](https://github.com/puerco)) | Tue July 20 | week 13 | |
 | release-1.22 branch created | Branch Manager | Tue July 20 | week 13 | |
 | release-1.22 jobs created | Branch Manager | Tue July 20 | week 13 | |
 | Start final draft of Release Notes | Release Notes Lead | Tue July 20 | week 13 | |
@@ -77,7 +77,7 @@ The 1.22 release cycle is proposed as follows:
 | Docs complete - All PRs reviewed and ready to merge | Docs Lead | Tue July 27 | week 14 | |
 | Feature blogs ready to review (23:59 PDT)| Enhancement Owner / SIG Leads | Tue July 27 | week 14 | |
 | Release Notes complete - reviewed & merged to `k/sig-release` (23:59 PDT) | Release Notes Lead | Thur July 29 | week 14 | |
-| **v1.22.0 released** | Branch Manager (@puerco) | Wed August 4 | week 15 | |
+| **v1.22.0 released** | Branch Manager ([@puerco](https://github.com/puerco)) | Wed August 4 | week 15 | |
 | Release blog published | Comms | Wed August 4 | week 15 | |
 | **[Thaw]** | Branch Manager | Wed August 4 | week 15 | |
 | Release retrospective | Community | TBD | Week 16 | |


### PR DESCRIPTION
#### What type of PR is this:
/kind documentation

#### What this PR does / why we need it:

This PR modifies the 1.22 schedule to add the release managers who will take care of cutting each of the 1.22 prereleases.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:
