### PR TITLE
Remove SIG PM from README files

### DIFF
--- a/release-team/README.md
+++ b/release-team/README.md
@@ -29,8 +29,8 @@ which shall be the discharged by the Release Team.
 
 ## Specific responsibilities
 
-- Support SIG PM by providing tooling and processes for the generation of release notes
-- Coordinate with SIG PM to communicate enhancement burndown progress during a release cycle
+- Generation of release notes
+- Communicate enhancement burndown progress during a release cycle
 - Manage repositories and tooling dedicated to releasing Kubernetes which at time of chartering these include:
   - kubernetes/release
   - deb/rpm packaging and hosting
@@ -56,7 +56,7 @@ which shall be the discharged by the Release Team.
 - Identifying owning individuals and SIGs for blocking issues
 - Working with SIGs and individuals to drive resolution of open issues
 - Building summary of release criteria and status and publish to the community on a regular basis throughout the release cycle
-- Manage the contents of `kubernetes/enhancements` along with SIG PM
+- Manage the contents of `kubernetes/enhancements`
 - Define burndown process
   - use of GitHub labels to signal release blocking status
   - use of GitHub milestones to communicate release blocking issues
@@ -127,8 +127,8 @@ During the code freeze period, fix any bugs discovered with your enhancement, an
 ## Other activities of the Release Team
 
 ### During "Major" releases
-To date no major release has been scheduled, however, SIG Release would be responsible for working closely with SIG PM
-and SIG Testing to coordinate this effort across SIGs. The precise work required to produce a major release (e.g. 2.0, 3.0)
+To date no major release has been scheduled, however, SIG Release would be responsible for working closely with SIG Testing
+to coordinate this effort across SIGs. The precise work required to produce a major release (e.g. 2.0, 3.0)
 is undefined.
 
 ### During "Security" releases

--- a/release-team/role-handbooks/release-team-lead/README.md
+++ b/release-team/role-handbooks/release-team-lead/README.md
@@ -289,7 +289,7 @@ Code Freeze will typically fall around Weeks 8 or 9 depending on the length or r
 - The task is now to ensure the release branch is ready to go. This means there are zero pending PRs, no failing x.y-blocking tests, no open issues in the milestone. This will continue until release day.
 - Final documentation PRs are reviewed and ready to be merged. Likely, this is not true and some are outstanding, so you need to help convince SIG doc writers to get these in with urgency.
 - The release notes draft needs to be completely done and ready to consume by anago. Have SIG volunteers do a final proofread of their sections. Make sure people actually do this. You need to avoid having the release notes volunteers pull “all nighters” before the release.
-- Work with the CNCF, SIG PM, SIG Docs, and Communications Lead to start the Release Blog post pulling from SIG Themes, the enhancements repo, SIG members, and possibly release notes in specific PRs.
+- Work with the CNCF, SIG Docs, and Communications Lead to start the Release Blog post pulling from SIG Themes, the enhancements repo, SIG members, and possibly release notes in specific PRs.
 - Work with the incoming Release Team Lead to establish incoming Release Team.
 - Release Day is coming up! Make the day as fun as you can for the team. Plan ahead for this and do something nice.
 
@@ -302,7 +302,7 @@ Code Freeze will typically fall around Weeks 8 or 9 depending on the length or r
 - Note that release day can and should be postponed if any of the conditions outlined in week 11 are not satisfied.
 - Every issue in the milestone is considered release blocking.
 - If you have to push the release date back, try to avoid Friday since it makes release publicity extremely difficult. Also, people seem to have patience with delay as long as the reasons are clear and openly communicated. This is your duty. You must over-communicate and ensure the team is also talking to their stakeholders (CNCF, community, press, etc.)
-- Confirm a facilitator for the Release Retrospective with SIG PM
+- Confirm a facilitator for the Release Retrospective
 - The following final actions **must occur in order**, with successful completion of each being the entry criteria to the next.
   - Release day morning:
     - Go / No-Go: should generally be clear a day or three ahead of release, but the day's burndown provides a final opportunity for the team to affirm things are ready.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

Removes SIG PM references from the various README.md files as SIG PM has been retired

/kind documentation
/kind cleanup

/hold
(for reviews)

<!--
Add one of the following kinds:
/kind cleanup
/kind documentation
/kind feature
/kind design
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #
or
None
-->
