### PR TITLE
ci-signal: use k8s-release-dev for CI builds

### DIFF
--- a/release-team/role-handbooks/ci-signal/upgrade-job-versions.md
+++ b/release-team/role-handbooks/ci-signal/upgrade-job-versions.md
@@ -36,10 +36,10 @@ aka trust the CI
 - look for the `--extract=` flags
 - the version there corresponds to files in GCS buckets
 
-ci/foo versions live in kubernetes-release-dev:
+ci/foo versions live in k8s-release-dev:
 ```shell
 $ for suffix in beta stable1 stable2 stable3; do
-  echo ci/k8s-$suffix: $(gsutil cat gs://kubernetes-release-dev/ci/k8s-$suffix.txt);
+  echo ci/k8s-$suffix: $(gsutil cat gs://k8s-release-dev/ci/k8s-$suffix.txt);
 done
 
 ci/k8s-beta: v1.12.0-beta.1.129+1d58f1aebfe1e3


### PR DESCRIPTION
#### What type of PR is this:

/kind cleanup
/kind documentation

#### What this PR does / why we need it:

kubernetes-release-dev is deprecated and has no new builds as of v1.23

#### Which issue(s) this PR fixes:

n/a

#### Special notes for your reviewer:

Related:
- Part of: https://github.com/kubernetes/k8s.io/issues/2318
- Migration of similar content in kubernetes/community: https://github.com/kubernetes/community/pull/5893