### PR TITLE
Add initial 1.23 release team (leads)

### DIFF
--- a/releases/release-1.23/release-team.md
+++ b/releases/release-1.23/release-team.md
@@ -2,14 +2,14 @@
 
 | **Role** | **Name** (**GitHub / Slack ID**) | **Shadow Name(s) (GitHub / Slack ID)** |
 |----------|----------------------------------|----------------------------------------|
-| Lead |  |  |
-| Enhancements | | |
-| CI Signal | | |
-| Bug Triage | | |
-| Docs | | |
-| Release Notes | | |
-| Communications | | |
-| Emeritus Adviser | | |
+| Lead | Rey Lejano ([@reylejano](https://github.com/reylejano) / Slack: `@rlejano`) |  |
+| Enhancements | Xander Grzywinski ([@salaxander](https://github.com/salaxander) / Slack: `@Xander`) ) |
+| CI Signal | Hossein Salahi ([@encodedflush](https://github.com/encodedflush) / Slack: `@hsalahi`) | |
+| Bug Triage | Christoph Voigt ([@voigt](https://github.com/voigt) / Slack: `@Christoph Voigt`) | |
+| Docs | Jesse Butler ([@jlbutler](https://github.com/jlbutler) / Slack: `@Jesse Butler`) | |
+| Release Notes | Cici Huang ([@cici37](https://github.com/cici37) / Slack: `@cici37`) | |
+| Communications | Karen Chu ([@karenhchu](https://github.com/karenhchu) / Slack: `@karenhchu`) | |
+| Emeritus Adviser | Jeremy Rickard ([@jeremyrickard](https://github.com/jeremyrickard) / Slack: `@jerickar`) | |
 
 Review the [Release Managers page](/release-managers.md) for up-to-date contact information on Release Engineering personnel.
 


### PR DESCRIPTION
Signed-off-by: Jeremy <jeremyrrickard@gmail.com>

#### What type of PR is this:

/kind documentation
/area release-team
/priority important-soon
/milestone v1.23
/sig release

#### What this PR does / why we need it:

This PR adds the leads to the 1.23 Release Team file. 🥳 🎆 

#### Which issue(s) this PR fixes:

Ref: #1623 


#### Special notes for your reviewer:
