### PR TITLE
Release 1.23: update OWNER_ALIASES with 1.23 team

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -27,13 +27,13 @@ aliases:
     - wilsonehusin # Release Manager Associate
   release-team:
     - alejandrox1 # subproject owner / 1.18 RT Lead
-    - guineveresaenger # subproject owner / 1.17 RT Lead
     - hasheddan # subproject owner
     - jeremyrickard # subproject owner / 1.20 RT Lead
     - justaugustus # subproject owner
     - onlydole # subproject owner / 1.19 RT Lead
     - palnabarun # subproject owner / 1.21 RT Lead
-    - savitharaghunathan # 1.22 RT Lead
+    - reylejano # 1.23 RT Lead
+    - savitharaghunathan # subproject owner / 1.22 RT Lead
     - tpepper # subproject owner
   build-admins:
     - amwat
@@ -41,44 +41,44 @@ aliases:
     - MushuEE
     - spiffxp
   release-team-lead-role:
-    - alejandrox1 # 1.18 RT Lead
     - onlydole # 1.19 RT Lead / 1.21 Emeritus Advisor
     - jeremyrickard # 1.20 RT Lead
     - palnabarun # 1.21 RT Lead
     - savitharaghunathan # 1.22 RT Lead
+    - reylejano # 1.23 RT Lead
   ci-signal-role:
-    - droslean # 1.18
     - hasheddan # 1.19
     - RobertKielty # 1.20
     - thejoycekung # 1.21
     - mkorbi # 1.22
+    - encodeflush # 1.23
   enhancements-role:
-    - jeremyrickard # 1.18
     - palnabarun # 1.19
     - kikisdeliveryservice # 1.20
     - annajung # 1.21
     - jameslaverack # 1.22
+    - salaxander # 1.23
   bug-triage-role:
-    - smourapina # 1.18
     - markyjackson-taulia # 1.19
     - bai # 1.20
     - erismaster # 1.21
     - monzelmasry # 1.22
+    - voigt # 1.23
   docs-role:
-    - VineethReddy02 # 1.18
     - savitharaghunathan # 1.19
     - annajung # 1.20
     - reylejano # 1.21
     - pi-victor # 1.22
+    - jlbutler # 1.23
   release-notes-role:
-    - Evillgenius75 # 1.18
     - puerco # 1.19
     - JamesLaverack # 1.20
     - wilsonehusin # 1.21
     - pmmalinov01 # 1.22
+    - cici37 # 1.23
   communications-role:
-    - karenhchu # 1.18
     - mkorbi # 1.19
     - jrsapi # 1.20
     - divya-mohan0209 # 1.21
     - pensu # 1.22
+    - karenhchu # 1.23


### PR DESCRIPTION
#### What type of PR is this:
/kind cleanup
/kind documentation

#### What this PR does / why we need it:
Updates the following OWNER_ALIASES with the 1.23 team:

-  release-team
-  release-team-lead-role
-  ci-signal-role
-  enhancements-role
-  bug-triage-role
-  docs-role
-  release-notes-role
-  communications-role

#### Which issue(s) this PR fixes:
Ref #1652 

#### Special notes for your reviewer:
Cleaned up 1.18 team as the branch is not currently active

/assign
/sig release
/area release-team
/priority critical-urgent
/assign @justaugustus @saschagrunert @jeremyrickard @cpanato @puerco @hasheddan
/cc @JamesLaverack @jrsapi @mkorbi @MonzElmasry