### PR TITLE
Add OWNERS file for release-1.23

### DIFF
--- a/releases/release-1.23/OWNERS
+++ b/releases/release-1.23/OWNERS
@@ -1,0 +1,17 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - jeremyrickard           # Emeritus Adviser
+  - reylejano               # Release Team Lead
+  - JamesLaverack           # Release Team Lead Shadow
+  - jrsapi                  # Release Team Lead Shadow
+  - mkorbi                  # Release Team Lead Shadow
+  - MonzElmasry             # Release Team Lead Shadow
+
+reviewers:
+  - salaxander            # Enhancements
+  - encodeflush           # CI Signal
+  - voigt                 # Bug Triage
+  - karenhchu             # Communications
+  - jlbutler              # Docs
+  - cici37                # Release Notes


### PR DESCRIPTION
#### What type of PR is this:
/kind documentation

#### What this PR does / why we need it:
This PR adds an OWNERS file for release-1.23 with entries for `approvers` and `reviewers`

#### Which issue(s) this PR fixes:
Ref: https://github.com/kubernetes/sig-release/issues/1652

#### Special notes for your reviewer:
None

/sig release
/area release-team
/priority critical-urgent
/assign @justaugustus @saschagrunert @jeremyrickard @cpanato @puerco @hasheddan
/cc @JamesLaverack @jrsapi @mkorbi @MonzElmasry
/cc @salaxander @encodeflush @voigt @karenhchu @jlbutler @cici37
