### PR TITLE
Release 1.23: add RT Lead Shadows to 1.23 team

### DIFF
--- a/releases/release-1.23/release-team.md
+++ b/releases/release-1.23/release-team.md
@@ -2,7 +2,7 @@
 
 | **Role** | **Name** (**GitHub / Slack ID**) | **Shadow Name(s) (GitHub / Slack ID)** |
 |----------|----------------------------------|----------------------------------------|
-| Lead | Rey Lejano ([@reylejano](https://github.com/reylejano)) / Slack: `@rlejano` |  |
+| Lead | Rey Lejano ([@reylejano](https://github.com/reylejano)) / Slack: `@rlejano` | James Laverack ([@JamesLaverack](https://github.com/JamesLaverack) / Slack: `@james.laverack`), Joseph Sandoval ([@jrsapi](https://github.com/jrsapi) / Slack: `@Joseph`), Max Körbächer ([@mkorbi](https://github.com/mkorbi) / Slack: `@mkorbi`), Menna Elmasry ([@MonzElmasry](https://github.com/MonzElmasry) / Slack: `@Menna`) |
 | Enhancements | Xander Grzywinski ([@salaxander](https://github.com/salaxander)) / Slack: `@Xander` | |
 | CI Signal | Hossein Salahi ([@encodeflush](https://github.com/encodeflush)) / Slack: `@hsalahi` | |
 | Bug Triage | Christoph Voigt ([@voigt](https://github.com/voigt)) / Slack: `@Christoph Voigt` | |


### PR DESCRIPTION
#### What type of PR is this:
/kind cleanup
/kind documentation

#### What this PR does / why we need it:
This PR updates the 1.23 Release Team with the RT Lead Shadows

#### Which issue(s) this PR fixes:
Ref: #1652

#### Special notes for your reviewer:
None

/sig release
/area release-team
/priority critical-urgent
/assign @justaugustus @saschagrunert @jeremyrickard @cpanato @puerco @hasheddan
/cc @JamesLaverack @jrsapi @mkorbi @MonzElmasry