### PR TITLE
Update release-team-lead onboarding issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-team-lead.md
+++ b/.github/ISSUE_TEMPLATE/release-team-lead.md
@@ -60,8 +60,7 @@ As you work through the checklist, use the following PRs as guides:
 - [ ] Update Google Groups/GCP IAM membership [(`kubernetes/k8s.io`)](https://git.k8s.io/k8s.io/groups/groups.yaml)
   - `k8s-infra-release-viewers@`
   - `release-managers@`
-- [ ] Manually grant access on the following Google Groups:
-  - [kubernetes-release-team](https://groups.google.com/a/kubernetes.io/g/release-team) (Add as Manager)
+  - `release-team@`
 - [ ] Grant calendar access
 - [ ] Grant Zoom credentials (host key)
 - [ ] Add incoming leads to `release-team-leads` Slack Group [(`kubernetes/community`)](https://git.k8s.io/community/communication/slack-config/sig-release/usergroups.yaml)

--- a/.github/ISSUE_TEMPLATE/release-team-lead.md
+++ b/.github/ISSUE_TEMPLATE/release-team-lead.md
@@ -62,7 +62,6 @@ As you work through the checklist, use the following PRs as guides:
   - `release-managers@`
 - [ ] Manually grant access on the following Google Groups:
   - [kubernetes-release-team](https://groups.google.com/a/kubernetes.io/g/release-team) (Add as Manager)
-  - [kubernetes-sig-leads](https://groups.google.com/forum/#!forum/kubernetes-sig-leads) (Add as Member)
 - [ ] Grant calendar access
 - [ ] Grant Zoom credentials (host key)
 - [ ] Add incoming leads to `release-team-leads` Slack Group [(`kubernetes/community`)](https://git.k8s.io/community/communication/slack-config/sig-release/usergroups.yaml)


### PR DESCRIPTION
#### What type of PR is this:
/kind cleanup

#### What this PR does / why we need it:
This PR updates the release-team-lead.md issue template and removes the task to add RT Leads to the `kubernetes-sig-leads` Google Group

#### Which issue(s) this PR fixes:
None


#### Special notes for your reviewer:
Ref: https://github.com/kubernetes/k8s.io/pull/2541#pullrequestreview-731037513

/assign
/sig release
/priority critical-urgent
/assign @justaugustus @saschagrunert @jeremyrickard @cpanato @puerco @hasheddan
/cc @JamesLaverack @jrsapi @mkorbi @MonzElmasry