### PR TITLE
docs: add a place where retro link should be shared

### DIFF
--- a/release-team/role-handbooks/release-team-lead/README.md
+++ b/release-team/role-handbooks/release-team-lead/README.md
@@ -184,7 +184,8 @@ Coordinate with SIG-Release Chairs (who have access to the CNCF Service Desk as 
 - Ensure top-level OWNERS_ALIASES only includes Release Team personnel from four (4) releases, including the current one.
 - Create and finalize the release schedule, blocking test gates, and role assignments as a pull request in: kubernetes/sig-release/releases/release-x.y/README.md **Note: Do not ship the release on a Monday, to avoid preparing for the release on a weekend. Aim for Tuesday.**
 - Send an update to [kubernetes-dev] and [kubernetes-sig-leads] mailing list to announce the start of the release cycle, including any notable changes in the release process, key dates, and links to important documents
-- Create the retrospective document and corresponding bit.ly link
+- Create the retrospective document and corresponding bit.ly link.  Insert this link in the list of retrospectives in the header of the
+  [kubernetes-community-meeting](Kubernetes Community Meeting Topics) document.
 - Begin meeting with SIGs to introduce yourself
 - Begin paying attention to [CI signal][ci-signal], as it may begin degrading soon after the prior release is cut and any slips must be caught and rectified promptly.
 - Request, in coordination with CI Signal Lead, a representative from SIG-Scalability to give a weekly update on the release meeting notes. Prepare to have a release team representative attend SIG-scalability's meeting two or three times throughout the release.
@@ -343,6 +344,7 @@ Code Freeze will typically fall around Weeks 8 or 9 depending on the length or r
 [ci-signal]: /release-team/role-handbooks/ci-signal/README.md
 [discourse]: https://discuss.kubernetes.io/
 [k/enhancements]: https://git.k8s.io/enhancements
+[kubernetes-community-meeting]: https://bit.ly/k8scommunity
 [kubernetes-release-calendar]: https://bit.ly/k8s-release-cal
 [kubernetes-release-team]: https://groups.google.com/a/kubernetes.io/g/release-team
 [kubernetes-sig-release]: https://groups.google.com/forum/#!forum/kubernetes-sig-release


### PR DESCRIPTION
The release retrospectives are linked from the header of the
Kubernetes Community Meeting Topics (who knew?!).  These hadn't
been updated since the 1.18 release, which is a sign there isn't a
clear owner for doing that updating.  It's really useful to have
early and broad visibility for retrospectives in order to capture
folks input during the cycle, so I'm proposing a specific owner on
it.

Signed-off-by: Tim Pepper <tpepper@vmware.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this:

<!--
Add one of the following kinds:
/kind cleanup
/kind documentation
/kind feature
/kind design
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #
or
None
-->

#### Special notes for your reviewer:
