### PR TITLE
Document timeliness of exception request as assessment criteria

### DIFF
--- a/releases/EXCEPTIONS.md
+++ b/releases/EXCEPTIONS.md
@@ -14,7 +14,7 @@ An issue must be opened for the enhancement in the [enhancements repo](https://g
 
 The length of exception needed should be on the order of days, not weeks. If there are 3 PRs in and 1 still waiting review, that's a much stronger case than a enhancement that doesn't have any PRs out yet.
 
-Exceptions should be filed at the earliest oppitunity, including before the deadline if it is likely to miss.
+Exceptions should be filed at the earliest opportunity i.e., as soon as it's clear an enhancement may miss the deadline
 
 ## Requesting an exception
 

--- a/releases/EXCEPTIONS.md
+++ b/releases/EXCEPTIONS.md
@@ -14,7 +14,7 @@ An issue must be opened for the enhancement in the [enhancements repo](https://g
 
 The length of exception needed should be on the order of days, not weeks. If there are 3 PRs in and 1 still waiting review, that's a much stronger case than a enhancement that doesn't have any PRs out yet.
 
-Exceptions should be filed at the earliest opportunity i.e., as soon as it's clear an enhancement may miss the deadline
+Exceptions should be filed at the earliest opportunity i.e., as soon as it's clear an enhancement may miss the deadline.
 
 ## Requesting an exception
 

--- a/releases/EXCEPTIONS.md
+++ b/releases/EXCEPTIONS.md
@@ -6,13 +6,15 @@ While the enhancement complete milestone dates are published well in advance, an
 
 ## Exception Criteria
 
-Exceptions will be granted on the basis of *risk* and *length of exception required*.
+Exceptions will be granted on the basis of *risk*, *length of exception required*, and *timeliness of exception request*.
 
 The enhancement coming in late should represent a **low risk to the Kubernetes system** - it should not risk other areas of the code, and it should itself be well contained and tested.
 
 An issue must be opened for the enhancement in the [enhancements repo](https://github.com/kubernetes/enhancements/issues).
 
 The length of exception needed should be on the order of days, not weeks. If there are 3 PRs in and 1 still waiting review, that's a much stronger case than a enhancement that doesn't have any PRs out yet.
+
+Exceptions should be filed at the earliest oppitunity, including before the deadline if it is likely to miss.
 
 ## Requesting an exception
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this:

<!--
Add one of the following kinds:
/kind cleanup
/kind documentation
/kind feature
/kind design
-->

/kind documentation

#### What this PR does / why we need it:

Following on from the discussion in the Kubernetes 1.22 release retrospective — this clarifies that release team may consider the timeliness of an exception request as part of the assessment criteria when deciding if to grant an exception.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #
or
None
-->

#### Special notes for your reviewer:
