### PR TITLE
Add Branch Managers to the v1.23 release team

### DIFF
--- a/releases/release-1.23/release-team.md
+++ b/releases/release-1.23/release-team.md
@@ -10,6 +10,7 @@
 | Release Notes | Cici Huang ([@cici37](https://github.com/cici37)) / Slack: `@cici37` | Daman Arora ([@Damans227](https://github.com/Damans227) / Slack: `@Daman`), Lucas Dwyer ([@AuraSinis](https://github.com/AuraSinis) / Slack: `@Lucas Dwyer`), Parul Sahoo ([@parul5sahoo](https://github.com/parul5sahoo) / Slack: `@parul_sahoo`), Sam Cogan ([@sam-cogan](https://github.com/sam-cogan) / Slack: `@samcogan`) |
 | Communications | Karen Chu ([@karenhchu](https://github.com/karenhchu)) / Slack: `@karenhchu` | |
 | Emeritus Adviser | Jeremy Rickard ([@jeremyrickard](https://github.com/jeremyrickard)) / Slack: `@jerickar` | |
+| Branch Manager | Verónica López ([@Verolop](https://github.com/Verolop)) /  Slack: `@veronica` | Nabarun Pal ([@palnabarun](https://github.com/palnabarun)) / Slack: `@palnabarun`  |
 
 Review the [Release Managers page](/release-managers.md) for up-to-date contact information on Release Engineering personnel.
 


### PR DESCRIPTION
#### What type of PR is this:
/kind documentation

#### What this PR does / why we need it:

This PR adds @Verolop as Branch Manager for Kubernetes 1.23 and @palnabarun as BM shadow to the v1.23 release team page.

Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:
