### PR TITLE
Update a 1.23 Major Theme heading

### DIFF
--- a/releases/release-1.23/release-notes/release-notes-draft.md
+++ b/releases/release-1.23/release-notes/release-notes-draft.md
@@ -1,6 +1,6 @@
 ## What's New (Major Themes)
 
-### The HPA v2beta2 API is deprecated
+### The HPA v2beta2 API is deprecated. The HPA v2 API is GA.
 
 The HPA v2beta2 API is deprecated. The HPA v2 (stable) API is available.
 


### PR DESCRIPTION
#### What type of PR is this:
/kind cleanup

#### What this PR does / why we need it:
Clarify a major theme heading

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:
What was tracked for enhancements for 1.23 was https://github.com/kubernetes/enhancements/issues/2702 Graduate HPA API to GA. What was opted-in as a Major Theme was 
> The HPA v2beta2 API is deprecated

I propose to change the headline to:
> The HPA v2beta2 API is deprecated. The HPA v2 API is GA.


/assign @cici37 
/cc @salaxander @jrsapi @JamesLaverack @mkorbi @MonzElmasry  