### PR TITLE
.github/ISSUE_TEMPLATE/cut-release.md: Use k8s.io links

### DIFF
--- a/.github/ISSUE_TEMPLATE/cut-release.md
+++ b/.github/ISSUE_TEMPLATE/cut-release.md
@@ -43,7 +43,7 @@ http://bit.ly/relmanagers-handbook#releases-management
 
 Image promotion:
 Use `krel promote images` to create a pull request
-https://github.com/kubernetes-sigs/promo-tools/blob/main/docs/promotion-pull-requests.md
+https://sigs.k8s.io/promo-tools/docs/promotion-pull-requests.md
 
 Notify #release-management on Slack:
 Announce the release in a message in the Channel and paste the link

--- a/.github/ISSUE_TEMPLATE/cut-release.md
+++ b/.github/ISSUE_TEMPLATE/cut-release.md
@@ -43,7 +43,7 @@ http://bit.ly/relmanagers-handbook#releases-management
 
 Image promotion:
 Use `krel promote images` to create a pull request
-http://bit.ly/k8s-image-promotion
+https://github.com/kubernetes-sigs/promo-tools/blob/main/docs/promotion-pull-requests.md
 
 Notify #release-management on Slack:
 Announce the release in a message in the Channel and paste the link


### PR DESCRIPTION
#### What type of PR is this:

/kind cleanup
/kind documentation

#### What this PR does / why we need it:

Some general improvements to the release cut issue template. If we don't want to link to the file, we could update the bit.ly link. I'm not sure who owns those.

#### Which issue(s) this PR fixes:

Partial fix on: https://github.com/kubernetes/sig-release/issues/1778

/cc @kubernetes/release-managers
/priority important-soon
/area release-eng