### PR TITLE
updating docs

### DIFF
--- a/release-engineering/role-handbooks/branch-manager.md
+++ b/release-engineering/role-handbooks/branch-manager.md
@@ -163,6 +163,8 @@ In addition to `gcloud,` `gsutil` is required as well. By default, it comes with
 
 At the end of a release, Release Managers will need to announce the new release to the community.
 
+> NOTE: ALL OF THE FOLLOWING `krel` COMMANDS RUN AS MOCK (NO CHANGES) BY DEFAULT. No mock (`--nomock`) must be specified for command to execute / take action. This is clear in the output based on the targeted email test groups, but not obvious before running the command.
+
 This can be done in one of two ways:
 
 - The `krel announce` sub command -- A [`SENDGRID_API_KEY`](https://sendgrid.com/docs/ui/account-and-settings/api-keys) will need to be configured correctly on your environment for this to work
@@ -176,7 +178,7 @@ This can be done in one of two ways:
 ```shell
 # Only for the official release: Inform the Google team to complete the corresponding Deb and RPM builds and confirm with them whether Debian and RPM repositories have the packages before sending the email
 export SENDGRID_API_KEY=<API_KEY>
-krel announce send --tag vX.Y.0-{alpha,beta,rc}.Z --name "<Your Name>" --name <Your Email ID>
+krel announce send --tag vX.Y.0-{alpha,beta,rc}.Z --name "<Your Name>" --name <Your Email Address>
 ```
 
 See the [Release Commands Cheat Sheet](https://github.com/kubernetes/sig-release/blob/master/release-engineering/role-handbooks/patch-release-team.md#release-commands-cheat-sheet) for example commands.


### PR DESCRIPTION
#### What type of PR is this:

/kind cleanup
/kind documentation

#### What this PR does / why we need it:

Attempting to add clarity to the `krel announce` command and identify when things execute vs. `nomock`.

#### Which issue(s) this PR fixes:

Partial fix on: https://github.com/kubernetes/sig-release/issues/1778

/cc @kubernetes/release-managers
/priority important-soon
/area release-eng