### PR TITLE
Update links to release manages and patch release pages in 1.24 release team file

### DIFF
--- a/releases/release-1.24/release-team.md
+++ b/releases/release-1.24/release-team.md
@@ -12,6 +12,6 @@
 | Emeritus Adviser | Joseph Sandoval ([@jrsapi](https://github.com/jrsapi) / Slack: `@Joseph`) | |
 | Branch Manager | Nabarun Pal ([@palnabarun](https://github.com/palnabarun) / Slack: `@palnabarun`) | |
 
-Review the [Release Managers page](/release-managers.md) for up-to-date contact information on Release Engineering personnel.
+Review the [Release Managers page](https://github.com/kubernetes/website/blob/main/content/en/releases/release-managers.md) for up-to-date contact information on Release Engineering personnel.
 
-The schedule for all patch releases can be found at [Patch Releases page](/releases/patch-releases.md). It will be updated to include 1.24, once the 1.24 release cycle concludes.
+The schedule for all patch releases can be found at [Patch Releases page](https://github.com/kubernetes/website/blob/main/content/en/releases/patch-releases.md). It will be updated to include 1.24, once the 1.24 release cycle concludes.


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR updates the current placeholder links pointing to the [`Release Managers`](/release-managers.md) & [`Patch Releases`](/releases/patch-releases.md) pages in the [1.24 release team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.24/release-team.md) markdown file.

The current content from both these pages has been moved from the sig-release repository to under [kubernetes/website](https://github.com/kubernetes/website/blob/main/content/en/releases/release-managers.md). And these current placeholder files are scheduled to be removed anytime after **2021-12-31.**

#### What type of PR is this:

/kind cleanup


