### PR TITLE
OWNERS_ALIASES: update release-engineering-approvers with new release managers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -8,20 +8,20 @@ aliases:
     - saschagrunert # SIG Chair
   release-engineering-approvers:
     - cpanato # Release Manager
+    - justaugustus # subproject owner / Release Manager
+    - palnabarun # Release Manager
     - puerco # Release Manager
     - saschagrunert # subproject owner / Release Manager
-    - justaugustus # subproject owner / Release Manager
     - xmudrii # Release Manager
+    - verolop # Release Manager
   release-engineering-reviewers:
     - ameukam # Release Manager Associate
     - jimangel # Release Manager Associate
     - markyjackson-taulia # Release Manager Associate
     - mkorbi # Release Manager Associate
-    - palnabarun # Release Manager Associate
     - onlydole # Release Manager Associate
     - sethmccombs # Release Manager Associate
     - thejoycekung # Release Manager Associate
-    - verolop # Release Manager Associate
     - wilsonehusin # Release Manager Associate
   release-team:
     - jeremyrickard # subproject owner / 1.20 RT Lead


### PR DESCRIPTION
Part of kubernetes/sig-release#1713 and kubernetes/sig-release#1789