### PR TITLE
Add OWNERS for release-notes 1.24

### DIFF
--- a/releases/release-1.24/release-notes/OWNERS
+++ b/releases/release-1.24/release-notes/OWNERS
@@ -1,0 +1,7 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - release-notes-role
+
+reviewers:
+  - release-notes-role


### PR DESCRIPTION
similar to #1691 

**What type of PR is this:**

/kind cleanup
/kind documentation

**What this PR does / why we need it:**

Add OWNERS to 1.24 release notes dir.