### PR TITLE
Update 1.24 links for clarity

### DIFF
--- a/releases/release-1.24/README.md
+++ b/releases/release-1.24/README.md
@@ -14,9 +14,9 @@ description: |
 
 * [This document](https://git.k8s.io/sig-release/releases/release-1.24/README.md)
 * [Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.24/release-team.md)
-* [Meeting Minutes](http://bit.ly/k8s124-releasemtg) (join [release-team@] to receive meeting invites)
+* [Meeting Minutes](http://bit.ly/k8s124-releasemtg) (members of [release-team@] receive meeting invites)
 * [v1.24 Release Calendar][k8s124-calendar]
-* Contact: [#sig-release] on slack, [release-team@] on e-mail
+* Contact: [#sig-release] on slack, [release-team](mailto://release-team@kubernetes.io) on e-mail
 * [Internal Contact Info] (accessible only to members of [release-team@])
 
 #### Tracking docs


### PR DESCRIPTION
#### What type of PR is this:
/kind cleanup

#### What this PR does / why we need it:

The release page feeds https://www.kubernetes.dev/resources/release/#links
This PR adds clarity to the 1.24 release links in the following way:
- remove the implication that people can join the release-team group through the link
- For the Contact line, update the link to the release-team group to a mailto link as non-members can not see the link

This PR came about because of a [Slack message](https://kubernetes.slack.com/archives/C1J0BPD2M/p1643994883568779) stating that the links in  https://www.kubernetes.dev/resources/release/#links are incorrect but the person did not have permissions to go to the release-team group page

/assign @JamesLaverack 