### PR TITLE
fix yaml errors in mapping files for 1.24

### DIFF
--- a/releases/release-1.24/release-notes/maps/pr-105964-map.yaml
+++ b/releases/release-1.24/release-notes/maps/pr-105964-map.yaml
@@ -1,4 +1,4 @@
 pr: 105964
 releasenote:
-  text: `kubectl logs` will now warn and default to the first container in a pod. This
+  text: The `kubectl logs` will now warn and default to the first container in a pod. This
     new behavior brings it in line with `kubectl exec`.

--- a/releases/release-1.24/release-notes/maps/pr-107295-map.yaml
+++ b/releases/release-1.24/release-notes/maps/pr-107295-map.yaml
@@ -1,6 +1,6 @@
 pr: 107295
 releasenote:
-  text: 'kubeadm: make sure that `kubeadm init/join` always use a URL scheme (unix://
+  text: "kubeadm: make sure that `kubeadm init/join` always use a URL scheme (unix://
     on Linux and npipe:// on Windows) when passing a value to the `--container-runtime-endpoint`
     kubelet flag. This flag's value is taken from the kubeadm configuration `criSocket`
     field or the `--cri-socket` CLI flag. Automatically add a missing URL scheme to
@@ -9,4 +9,4 @@ releasenote:
     `/var/lib/kubelet/kubeadm-flags.env` file on disk and the `kubeadm.alpha.kubernetes.io/cri-socket`
     annotation Node object if needed. These automatic actions are temporary and will
     be removed in a future release. In the future the kubelet may not support CRI
-    endpoints without an URL scheme.'
+    endpoints without an URL scheme."


### PR DESCRIPTION
While running `krel release-notes` having yaml files in mappings will cause the tool to fail

The error would like this
```
FATA creating website PR: generating release notes in JSON format: gathering release notes: listing release notes: checking if a map exists for PR 108093: while reading release notes maps: while parsing note map in /var/folders/gl/l4j1f7bj0hlb83kk3_9wx4jm0000gn/T/k8s-2399869277/releases/release-1.24/release-notes/maps/pr-105964-map.yaml: decoding note map: yaml: line 3: found character that cannot start any token
```