### PR TITLE
Add start of Friday APAC-friendly meetings to schedule

### DIFF
--- a/releases/release-1.24/README.md
+++ b/releases/release-1.24/README.md
@@ -61,6 +61,7 @@ The 1.24 release cycle is as follows:
 | 1.24.0-alpha.2 released | Branch Manager | Tuesday 1st February 2022 | Week 4 | |
 | **Begin [Enhancements Freeze]** | Enhancements Lead | 02:00 UTC Friday 4th February 2022 / 18:00 PST Thursday 3rd February 2022 | week 4 | [master-blocking], [master-informing] |
 | 1.24.0-alpha.3 released | Branch Manager | Tuesday 15th February 2022 | Week 6 | |
+| Begin Friday APAC-friendly meetings | Lead | Friday 25th February 2022 | Week 7 | |
 | (most of) North America enters Daylight Savings Time | | Sunday 13th March 2022 | | |
 | **Begin [Burndown]** (Monday, Wednesday, and Friday meetings) | Lead | Monday 21st March 2022 | week 11 | [1.24-blocking], [master-blocking], [master-informing] |
 | **Call for [Exceptions][Exception]** | Lead | Monday 21st March 2022 | week 11 | |


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this:

<!--
Add one of the following kinds:
/kind cleanup
/kind documentation
/kind feature
/kind design
-->

/kind documentation

#### What this PR does / why we need it:

This adds the start of Friday meetings in an APAC timezone to the schedule. My hope is this will be carried forward to future release cycles formally, instead of as an informal convention.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #
or
None
-->

#### Special notes for your reviewer:
