### PR TITLE
Add 1.25 Bug Triage Shadows

### DIFF
--- a/releases/release-1.25/release-team.md
+++ b/releases/release-1.25/release-team.md
@@ -2,10 +2,10 @@
 
 | **Role** | **Name** (**GitHub / Slack ID**) | **Shadow Name(s) (GitHub / Slack ID)** |
 |----------|----------------------------------|----------------------------------------|
-| Lead | Cici Huang ([@cici37](https://github.com/cici37) / Slack: `@cici37`) | Jesse Butler ([@jlbutler](https://github.com/jlbutler) / Slack: `@Jesse Butler`), Xander Grzywinski ([@salaxander](https://github.com/salaxander) / Slack: `@Xander`), Grace Nguyen ([@gracenng](https://github.com/gracenng) / Slack: `@Grace Nguyen`), Leonard Vincent Simon Pahlke ([@leonardpahlke](https://github.com/leonardpahlke) / Slack: `@leonardpahlke`) | 
+| Lead | Cici Huang ([@cici37](https://github.com/cici37) / Slack: `@cici37`) | Jesse Butler ([@jlbutler](https://github.com/jlbutler) / Slack: `@Jesse Butler`), Xander Grzywinski ([@salaxander](https://github.com/salaxander) / Slack: `@Xander`), Grace Nguyen ([@gracenng](https://github.com/gracenng) / Slack: `@Grace Nguyen`), Leonard Vincent Simon Pahlke ([@leonardpahlke](https://github.com/leonardpahlke) / Slack: `@leonardpahlke`) |
 | Enhancements | Priyanka Saggu ([@Priyankasaggu11929](https://github.com/Priyankasaggu11929) / Slack: `@psaggu`) |
 | CI Signal | Arsh Sharma ([@RinkiyaKeDad](https://github.com/RinkiyaKeDad) / Slack: `@arsh`) |
-| Bug Triage | Heba Elayoty ([@helayoty](https://github.com/helayoty) / Slack: `@helayoty`) |
+| Bug Triage | Heba Elayoty ([@helayoty](https://github.com/helayoty) / Slack: `@helayoty`) |Harshita Sao ([@harshitasao](https://github.com/harshitasao) / Slack: `@harshitasao`), Hosam Kamel ([@hkamel](https://github.com/hkamel) / Slack: `@hkamel`), Marky Jckson ([@markyjackson-taulia](https://github.com/markyjackson-taulia) / Slack: `@markyjackson`), Justin Chizer ([@Justin-chizer](https://github.com/justin-chizer) / Slack: `@justin chizer`) |
 | Docs | Kristin Martin ([@kcmartin](https://github.com/kcmartin) / Slack: `@kcmartin`) |
 | Release Notes | Carlos Santana ([@csantanapr](https://github.com/csantanapr) / Slack: `@csantanapr`) |
 | Communications | Kat Cosgrove ([@katcosgrove](https://github.com/katcosgrove) / Slack: `@katcosgrove`) | Debabrata Panigrahi ([@Debanitrkl](https://github.com/Debanitrkl) / Slack: `@deba`), Ana Margarita Medina ([@AnaMMedina21](https://github.com/AnaMMedina21) / Slack: `@Ana Margarita Medina`), Garima Negi ([@Garima-Negi](https://github.com/Garima-Negi) / Slack: `@garima negi`), Frederico Serrano Muñoz ([@fsmunoz](https://github.com/fsmunoz) / Slack: `@fsm` ) |


### PR DESCRIPTION
#### What type of PR is this:

/kind documentation

#### What this PR does / why we need it:

The PR adds the 1.25 Bug Triage Shadows to the [1.25 release-team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.25/release-team.md) document:

- @harshitasao 
- @hkamel 
- @markyjackson-taulia 
- @justin-chizer

// @cici37 @reylejano 