### PR TITLE
Update role lead handbooks

### DIFF
--- a/release-team/role-handbooks/bug-triage/README.md
+++ b/release-team/role-handbooks/bug-triage/README.md
@@ -83,6 +83,7 @@ In addition to the above requirements for Shadows, most of which become prerequi
 - Have the ability to add a milestone to issues/PRs, so must be a member of the [milestone maintainers team](/release-team/README.md#milestone-maintainers)
 - Have a working knowledge of GitHub labeling and labels used by the project. Bug Triage leads must be able to identify relevant issues and PRs for a given milestone.
 - Have an understanding of what defines a Release Blocking issue or PR, or know who to contact to determine that information.
+- The bug triage lead should take the [Inclusive Speaker Orientation (LFC101)](https://training.linuxfoundation.org/training/inclusive-speaker-orientation/) training course
 
 ## Getting Started
 

--- a/release-team/role-handbooks/ci-signal/README.md
+++ b/release-team/role-handbooks/ci-signal/README.md
@@ -101,6 +101,7 @@ In addition to the above requirements for Shadows, most of which become prerequi
 -   Signal lead needs to understand what tests matter and generally how our testing infra is wired together.
     -   They can ask previous CI Signal leads for advice
     -   They can ask SIG-Testing for guidance
+- The CI Signal lead should take the [Inclusive Speaker Orientation (LFC101)](https://training.linuxfoundation.org/training/inclusive-speaker-orientation/) training course
 
 ## Overview of tasks across release timeline
 

--- a/release-team/role-handbooks/communications/README.md
+++ b/release-team/role-handbooks/communications/README.md
@@ -18,6 +18,7 @@ Communications deliverables that come from the release process include a release
 - Experience with the Kubernetes release process enough to understand how communications milestones fit into the overall release
 - Project management experience is helpful
 - Existing relationships with the CNCF, relevant media personnel and outlets, Kubernetes project managers, and vendor stakeholders is helpful
+- The communications lead should take the [Inclusive Speaker Orientation (LFC101)](https://training.linuxfoundation.org/training/inclusive-speaker-orientation/) training course
 
 ### Expected Time Investment
 

--- a/release-team/role-handbooks/docs/README.md
+++ b/release-team/role-handbooks/docs/README.md
@@ -66,6 +66,7 @@ In addition to the time requirements above, a Docs Lead must:
 - Have the ability to add a milestone to issues, so must be a member of the [website milestone maintainers](https://github.com/orgs/kubernetes/teams/website-milestone-maintainers/). Access can be requested by creating a [PR](https://github.com/kubernetes/org/pull/2235) against `kubernetes/org` repo.
 > Note: access to see [website milestone maintainers](https://github.com/orgs/kubernetes/teams/website-milestone-maintainers/) is restricted to Kubernetes GitHub org members
 - Have the ability to `/approve` PRs. Access can be requested by creating a [PR](https://github.com/kubernetes/website/pull/20351) against `main` branch.
+- Take the [Inclusive Speaker Orientation (LFC101)](https://training.linuxfoundation.org/training/inclusive-speaker-orientation/) training course
 
 ### Prerequisites for Shadows
 

--- a/release-team/role-handbooks/enhancements/README.md
+++ b/release-team/role-handbooks/enhancements/README.md
@@ -37,6 +37,7 @@ An Enhancements Lead holds the following responsibilities:
 - MUST be a member of the [SIG Release Google Group][sig-release-group]
 - MUST be a member of the [SIG Architecture Google Group][sig-arch-group]
 - MUST be a member of the [Kubernetes Enhancements Google Group][enhancements-group]
+- The enhancements lead should take the [Inclusive Speaker Orientation (LFC101)](https://training.linuxfoundation.org/training/inclusive-speaker-orientation/) training course
 
 Helpful characteristics of an Enhancements Lead include:
 - experience with the Kubernetes community, code layout, ecosystem projects, organizational norms, governance, SIG structure, architecture, and release process

--- a/release-team/role-handbooks/release-notes/README.md
+++ b/release-team/role-handbooks/release-notes/README.md
@@ -52,6 +52,7 @@ If there are potential fixes to the issues indicated and team members are keen, 
 - Strong written and verbal communications skills
 - A working knowledge of Kubernetes concepts
 - Project management experience is helpful but not required
+- The release notes lead should take the [Inclusive Speaker Orientation (LFC101)](https://training.linuxfoundation.org/training/inclusive-speaker-orientation/) training course
 
 ### Time Requirements
 


### PR DESCRIPTION
Signed-off-by: leonardpahlke <leonard.pahlke@googlemail.com>

#### What type of PR is this:

/kind documentation

#### What this PR does / why we need it:

In a 1.24 retro session, it was discussed whether the I[nclusive Speaker Orientation (LFC101)](https://training.linuxfoundation.org/training/inclusive-speaker-orientation/) should also be set as a requirement for Release Team Role Leads.

In today's sig-release session (2022/05/31) this idea was positively received and therefore now updated.

#### Which issue(s) this PR fixes:

`None`

#### Special notes for your reviewer:

`NONE`