### PR TITLE
Update roadmap

### DIFF
--- a/roadmap.md
+++ b/roadmap.md
@@ -30,11 +30,12 @@ publishing of Kubernetes related artifacts.
 ### Deliverables
 
 The following deliverables are necessary to achieve the overall goal. Within
-the following listing, all deliverables are sorted by their priority.
+the following listing, all deliverables are sorted by their priority and their
+state.
 
-1. **SLSA compliance in the Kubernetes Release Process**
+### Work in progress (WIP)
 
-   https://github.com/kubernetes/release/issues/2267
+1. **SLSA compliance in the Kubernetes Release Process (Secure)**
 
    Outcome: Ensure that our release process is [SLSA](https://slsa.dev)
    compliant. We also intend to participate actively in the development of the
@@ -50,42 +51,36 @@ the following listing, all deliverables are sorted by their priority.
 
    Enhancement: https://github.com/kubernetes/enhancements/issues/3031
 
+### To be done (TODO)
+
 1. **Enhance Kubernetes binary artifact management (Consumable)**
 
    https://github.com/kubernetes/sig-release/issues/1372
 
+   Enhancement: _none_
+
    Outcome: Being able to promote files as artifacts and using this mechanism
    for Kubernetes releases.
-
-1. **Distribute the load of Kubernetes artifacts between vendors (Consumable)**
-
-   Outcome: A policy and procedure for use by SIG Release to promote container
-   images and release binaries to multiple registries and mirrors.
-
-   Enhancements: https://github.com/kubernetes/enhancements/issues/3055
 
 1. **Define and collect metrics about Kubernetes releases (Introspectable)**
 
    https://github.com/kubernetes/sig-release/issues/1527
 
+   Enhancement: _none_
+
    Outcome: Being able to measure and interpret a set of defined metrics about
    Kubernetes releases to associate actions with those.
-
-1. **Simplify CVE process for release management (Secure)**
-
-   https://github.com/kubernetes/sig-release/issues/896
-
-   https://github.com/kubernetes/release/issues/1354
-
-   Outcome: A documented and simple process for handling CVE information within
-   Kubernetes releases.
 
 1. **Establish Cluster API as first-class signal for upstream releases
    (Consumable)**
 
+   Enhancement: _none_
+
    Outcome: Cluster API provides a CI signal for blocking release test jobs.
 
 1. **Enhance and simplify Kubernetes version markers (Consumable)**
+
+   Enhancement: _none_
 
    Outcome: Clear documentation about available version markers as well as their
    simplified automation.
@@ -93,6 +88,8 @@ the following listing, all deliverables are sorted by their priority.
 1. **Moving deb/rpm package builds to community infrastructure (Consumable)**
 
    https://github.com/kubernetes/release/issues/913
+
+   Enhancement: _none_
 
    Outcome: Automated builds of `deb` and `rpm` Kubernetes packages within
    community infrastructure.
@@ -160,3 +157,18 @@ the following listing, all deliverables are sorted by their priority.
 
    Outcome: A regular survey evaluating the user experience of the current
    release cadence.
+
+1. **Distribute the load of Kubernetes artifacts between vendors (Consumable)**
+
+   Outcome: A policy and procedure for use by SIG Release to promote container
+   images and release binaries to multiple registries and mirrors.
+
+   Enhancement: https://github.com/kubernetes/enhancements/issues/3055
+
+1. **Simplify CVE process for release management (Secure)**
+
+   https://github.com/kubernetes/sig-release/issues/896,
+   https://github.com/kubernetes/release/issues/1354
+
+   Outcome: A documented and simple process for handling CVE information within
+   Kubernetes releases.


### PR DESCRIPTION


#### What type of PR is this:


/kind documentation


#### What this PR does / why we need it:

We now split-up the deliverables to reflect the state better (WIP vs TODO). This also means that we outline if no enhancement is available for a certain item.

We also move "Distribute the load of Kubernetes artifacts between vendors (Consumable)" to done since this is mostly in the scope of K8S infra now and we supported the initial phase.

We also move "Simplify CVE process for release management (Secure)" to done because there is just a single PR in the scope of Security Response Committee which has to be merged: https://github.com/kubernetes/committee-security-response/issues/63

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #
or
None
-->
None
#### Special notes for your reviewer:
Kudos to @LappleApple for the help on the new outline. :heart: 