### PR TITLE
releases/1.25: Add Jeremy and Joseph as Branch Manager shadows

### DIFF
--- a/releases/release-1.25/release-team.md
+++ b/releases/release-1.25/release-team.md
@@ -10,7 +10,7 @@
 | Release Notes | Carlos Santana ([@csantanapr](https://github.com/csantanapr) / Slack: `@csantanapr`) | Senthil Kumaran ([@orsenthil](https://github.com/orsenthil) / Slack: `Senthil Kumaran`), Divya Rani ([@Divya063](https://github.com/Divya063) / Slack: `Divya`), Rodolfo Martínez Vega ([@ramrodo](https://github.com/ramrodo) / Slack: `ramrodo`), Dipto Chakrabarty ([@DiptoChakrabarty](https://github.com/DiptoChakrabarty) / Slack: `Dipto`)|
 | Communications | Kat Cosgrove ([@katcosgrove](https://github.com/katcosgrove) / Slack: `@katcosgrove`) | Debabrata Panigrahi ([@Debanitrkl](https://github.com/Debanitrkl) / Slack: `@deba`), Ana Margarita Medina ([@AnaMMedina21](https://github.com/AnaMMedina21) / Slack: `@Ana Margarita Medina`), Garima Negi ([@Garima-Negi](https://github.com/Garima-Negi) / Slack: `@garima negi`), Frederico Serrano Muñoz ([@fsmunoz](https://github.com/fsmunoz) / Slack: `@fsm` ) |
 | Emeritus Adviser | Rey Lejano ([@reylejano](https://github.com/reylejano)) / Slack: `@rlejano` | |
-| Branch Manager | Verónica López ([@Verolop](https://github.com/Verolop)) / Slack: `@veronica` | |
+| Branch Manager | Verónica López ([@Verolop](https://github.com/Verolop)) / Slack: `@veronica` | Jeremy Rickard ([@jeremyrickard](https://github.com/jeremyrickard)) / Slack: `@jerickar`, Joseph Sandoval ([@jrsapi](https://github.com/jrsapi) / Slack: `@Joseph`) |
 
 Review the [Release Managers page](https://github.com/kubernetes/website/blob/main/content/en/releases/release-managers.md) for up-to-date contact information on Release Engineering personnel.
 


### PR DESCRIPTION
#### What type of PR is this:

/kind documentation

#### What this PR does / why we need it:

In discussion with the other @kubernetes/sig-release-leads, I'd like to propose @jeremyrickard and @jrsapi as 1.25 Branch Manager shadows.

They have worked in/around the Release Team for several cycles, are highly trusted members of SIG Release (both having served in the Emeritus Adviser role for the Release Team), and have the technical background to thrive in this role.

This roster addition would implicitly make them Release Manager Associates, which implied by the action of opening this PR, I am in favor of. :)

We'd like to workshop ideas for release manager selection, but let's treat that as a trailing item, to be discussed as part of https://github.com/kubernetes/sig-release/pull/1958.

Signed-off-by: Stephen Augustus <foo@auggie.dev>

Assigning a few people for approval...
SIG Release leads:
/assign @saschagrunert @cpanato @puerco

1.25 Branch Manager:
/assign @Verolop

1.25 Release Team lead:
/assign @cici37

cc: @kubernetes/release-engineering @kubernetes/release-team-leads

/hold
the cycle is well underway, so I will consider this mergeable with an `/lgtm` from:
- branch manager
- RT lead
- one of other SIG Release leads

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #
or
None
-->

#### Special notes for your reviewer:
