### PR TITLE
release notes get final into k/k

### DIFF
--- a/releases/release-1.25/README.md
+++ b/releases/release-1.25/README.md
@@ -84,7 +84,7 @@ The 1.25 release cycle is as follows:
 | Docs complete — All PRs reviewed and ready to merge           | Docs Lead | Tuesday 16th August 2022                                                                                        | week 13  | |
 | Feature blogs ready to review                                 | Enhancement Owner / SIG Leads | Tuesday 16th August 2022                                                                                        | week 13  | |
 | 1.25.0-rc.1 released                                          | Branch Manager | Tuesday 16th August 2022                                                                                                      | week 13  | |
-| Release Notes complete — reviewed & merged to `k/sig-release` | Release Notes Lead | 01:00 UTC Friday 19th August 2022 / 02:00 BST Friday 19th August 2022 / 18:00 PDT Thursday 18th August 2022     | week 13  | |
+| Release Notes complete — reviewed & merged to `k/k` | Release Notes Lead | 01:00 UTC Friday 19th August 2022 / 02:00 BST Friday 19th August 2022 / 18:00 PDT Thursday 18th August 2022     | week 13  | |
 | **v1.25.0 released**                                          | Branch Manager | Tuesday 23rd August 2022                                                                                        | week 14  | |
 | Release blog published                                        | Comms | Tuesday 23rd August 2022                                                                                        | week 14  | |
 | **[Thaw]**                                                    | Branch Manager | Tuesday 23rd August 2022                                                                                        | week 14  | |


### PR DESCRIPTION
Update timeline item about release notes final version merged into `k/k` and not `k/sig-release`

#### What type of PR is this:
/kind documentation


#### What this PR does / why we need it:
To make it clear what's the task to be completed.



