### PR TITLE
Remove "Auth plugin removal" from Major Theme

### DIFF
--- a/releases/release-1.25/release-notes/release-notes-draft.md
+++ b/releases/release-1.25/release-notes/release-notes-draft.md
@@ -59,11 +59,6 @@ Promoted the `ServerSideFieldValidation` feature gate to beta (on by default). T
 
 Introduce KMS v2alpha1 API to add performance, rotation, and observability improvements. Encrypt data at rest (ie Kubernetes `Secrets`) with DEK using AES-GCM instead of AES-CBC for kms data encryption. No user action is required. Reads with AES-GCM and AES-CBC will continue to be allowed. See the guide [Using a KMS provider for data encryption](https://kubernetes.io/docs/tasks/administer-cluster/kms-provider/) for more information.
 
-
-### Removed AKS and GKE authentication from kubectl
-
-The `gcp` and `azure` auth plugins have been removed from client-go and kubectl. See [AKS](https://github.com/Azure/kubelogin) and [GKE](https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke) documentation for details about the cloud-specific replacements.
-
 ## Urgent Upgrade Notes
 
 ### (No, really, you MUST read this before you upgrade)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this:
/kind documentation
<!--
Add one of the following kinds:
/kind cleanup
/kind documentation
/kind feature
/kind design
-->

#### What this PR does / why we need it:
Since in-tree credential plugins is added back in https://github.com/kubernetes/kubernetes/pull/111918. Remove the topic from Major Theme.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #
or
None
-->

#### Special notes for your reviewer:
/hold 
until https://github.com/kubernetes/kubernetes/pull/111918 merged