### PR TITLE
Add release team lead shadows for 1.26

### DIFF
--- a/releases/release-1.26/OWNERS
+++ b/releases/release-1.26/OWNERS
@@ -3,10 +3,10 @@
 approvers:
   - palnabarun            # Emeritus Adviser
   - leonardpahlke         # Release Team Lead
-  #-                      # Release Team Lead Shadow
-  #-                      # Release Team Lead Shadow
-  #-                      # Release Team Lead Shadow
-  #-                      # Release Team Lead Shadow
+  - gracenng              # Release Team Lead Shadow
+  - katcosgrove           # Release Team Lead Shadow
+  - Priyankasaggu11929    # Release Team Lead Shadow
+  - nate-double-u         # Release Team Lead Shadow
 
 reviewers:
   - rhockenbury           # Enhancements

--- a/releases/release-1.26/release-team.md
+++ b/releases/release-1.26/release-team.md
@@ -2,7 +2,7 @@
 
 | **Role** | **Name** (**GitHub / Slack ID**) | **Shadow Name(s) (GitHub / Slack ID)** |
 |----------|----------------------------------|----------------------------------------|
-| Lead | Leonard Vincent Simon Pahlke ([@leonardpahlke](https://github.com/leonardpahlke) / Slack: `@leonardpahlke`) |  |
+| Lead | Leonard Vincent Simon Pahlke ([@leonardpahlke](https://github.com/leonardpahlke) / Slack: `@leonardpahlke`) | Grace Nguyen ([@gracenng](https://github.com/gracenng) / Slack: `@Grace Nguyen`), Kat Cosgrove ([@katcosgrove](https://github.com/katcosgrove) / Slack: `@katcosgrove`), Priyanka Saggu ([@Priyankasaggu11929](https://github.com/Priyankasaggu11929) / Slack: `@psaggu`), Nate Waddington ([@nate-double-u](https://github.com/nate-double-u) / Slack: `@nate-double-u`) |
 | Enhancements | Ryler Hockenbury ([@rhockenbury](https://github.com/rhockenbury) / Slack: `@rhockenbury`) |  |
 | CI Signal | Nivedita Prasad ([@Nivedita-coder](https://github.com/Nivedita-coder) / Slack: `@Nivedita Prasad`) |  |
 | Bug Triage | Hossein Salahi ([@hosseinsalahi](https://github.com/hosseinsalahi) / Slack: `@hosseinsalahi`) |  |


### PR DESCRIPTION
Signed-off-by: leonardpahlke <leonard.pahlke@googlemail.com>

#### What type of PR is this:

/kind cleanup
/kind documentation

#### What this PR does / why we need it:

Add 1.26 release team lead shadows

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

/cc @palnabarun @saschagrunert 