### PR TITLE
Add links to everytimezone to the 1.26 release schedule

### DIFF
--- a/releases/release-1.26/README.md
+++ b/releases/release-1.26/README.md
@@ -39,11 +39,11 @@ The 1.26 release cycle is as follows:
 
 - **Monday 5th September 2022**: Week 1 — Release cycle begins
 - **Thursday 29th September 2022**: Week 4 — [Production Readiness Freeze](https://groups.google.com/g/kubernetes-sig-architecture/c/a6_y81N49aQ)
-- **01:00 UTC Friday 7th October 2022 / 18:00 PDT Thursday 6th October**: Week 5 — [Enhancements Freeze](../release_phases.md#enhancements-freeze)
+- **[01:00 UTC Friday 7th October 2022 / 18:00 PDT Thursday 6th October 2022](https://everytimezone.com/s/3a6f71b0)**: Week 5 — [Enhancements Freeze](../release_phases.md#enhancements-freeze)
 - **Monday 24th - Friday 28th October 2022**: Week 8 - [KubeCon NA](https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/)
-- **Wednesday 2th November  2022**: Week 10 — [Release Retrospective][Retrospective Document] part 1
-- **01:00 UTC Wednesday 9th November 2022 / 02:00 BST Wednesday 9th November 2022 / 18:00 PDT Tuesday 8th November 2022**: Week 10 — [Code Freeze](../release_phases.md#code-freeze)
-- **01:00 UTC Wednesday 16th November 2022 / 02:00 BST Wednesday 16th November 2022 / 18:00 PDT Tuesday 15th November 2022**: Week 11 — [Test Freeze](../release_phases.md#test-freeze)
+- **[17:00 UTC Wednesday 2nd November 2022 / 10:00 PDT Wednesday 2nd November 2022](https://everytimezone.com/s/bb5725f4)**: Week 10 — [Release Retrospective][Retrospective Document] part 1
+- **[01:00 UTC Wednesday 9th November 2022 / 17:00 PDT Tuesday 8th November 2022](https://everytimezone.com/s/d3187dcc)**: Week 10 — [Code Freeze](../release_phases.md#code-freeze)
+- **[01:00 UTC Wednesday 16th November 2022 / 17:00 PDT Tuesday 15th November 2022](https://everytimezone.com/s/dc1d29cb)**: Week 11 — [Test Freeze](../release_phases.md#test-freeze)
 - **Tuesday 29th November 2022**: Week 13 — Docs must be completed and reviewed
 - **Tuesday 6th December 2022**: Week 14 — Kubernetes v1.26.0 released
 - **TBC**: Week 15 — [Release Retrospective][Retrospective Document] part 2
@@ -59,7 +59,7 @@ The 1.26 release cycle is as follows:
 | Start Release Notes Draft                                     | Release Notes Lead | Tuesday 20th September 2022                                                                                         | week 3   | |
 | 1.26.0-alpha.1 released                                       | Branch Manager | Wednesday 28th September 2022                                                                                           | Week 4   | |
 | Production Readiness Freeze                              | Enhancements Lead | Thursday 29th September 2022                                                                                         | week 4   | |
-| **Begin [Enhancements Freeze]**                               | Enhancements Lead | 01:00 UTC Friday 7th October 2022 / 18:00 PDT Thursday 6th October 2022                                              | week 5   | [master-blocking], [master-informing] |
+| **Begin [Enhancements Freeze]**                               | Enhancements Lead | [01:00 UTC Friday 7th October 2022 / 18:00 PDT Thursday 6th October 2022](https://everytimezone.com/s/3a6f71b0)                                              | week 5   | [master-blocking], [master-informing] |
 | 1.26.0-alpha.2 released                                       | Branch Manager | Tuesday 11th October 2022                                                                                               | Week 6   | |
 | Begin Friday APAC-friendly meetings                           | Lead | Friday 21th October 2022                                                                                                          | Week 7   | |
 | KubeCon NA                                                    | | October 24-28 2022                                                                                                                     | week 8   | |
@@ -67,25 +67,25 @@ The 1.26 release cycle is as follows:
 | **Begin [Burndown]** (Monday, Wednesday, and Friday meetings) | Lead | Monday 31st October 2022                                                                                                          | week 9   | [1.26-blocking], [master-blocking], [master-informing] |
 | **Call for [Exceptions][Exception]**                          | Lead | Monday 31st October 2022                                                                                                          | week 9   | |
 | Brace Yourself, Code Freeze is Coming                         | Comms / Bug Triage | Monday 31st October 2022                                                                                            | week 9   | |
-| **Begin Feature blog freeze**                                 | Comms Lead | 01:00 UTC Wednesday 2nd November 2022 / 18:00 PDT Tuesday 1st November 2022                                                 | week 9   | |
-| Release retrospective part 1                                  | Community | 17:00 UTC Wednesday 2nd November 2022 / 10:00 PDT Wednesday 2nd November 2022                                                | week 9   | |
+| **Begin Feature blog freeze**                                 | Comms Lead | [01:00 UTC Wednesday 2nd November 2022 / 18:00 PDT Tuesday 1st November 2022](https://everytimezone.com/s/09b6c7c8)                                                 | week 9   | |
+| Release retrospective part 1                                  | Community | [17:00 UTC Wednesday 2nd November 2022 / 10:00 PDT Wednesday 2nd November 2022](https://everytimezone.com/s/bb5725f4)                                                | week 9   | |
 | Burndown Meetings daily                                       | Lead | Monday 7th November 2022                                                                                                          | week 10  | |
-| **Begin [Code Freeze]**                                       | Branch Manager | 01:00 UTC Wednesday 9th November 2022 / 02:00 BST Wednesday 9th November 2022 / 18:00 PDT Tuesday 8th November 2022     | week 10  | |
+| **Begin [Code Freeze]**                                       | Branch Manager | [01:00 UTC Wednesday 9th November 2022 / 17:00 PDT Tuesday 8th November 2022](https://everytimezone.com/s/d3187dcc)     | week 10  | |
 | 1.26.0-beta.0 released                                        | Branch Manager | Thursday 10th November 2022                                                                                             | week 10  | |
 | Docs deadline — Open placeholder PRs                          | Docs Lead | Thursday 10th November 2022                                                                                                  | week 10  | |
 | Deprecations and Removals blog published                      | Comms | Thursday 10th November 2022                                                                                                      | week 10  | |
-| **[Test Freeze]**                                             | Branch Manager | 01:00 UTC Wednesday 16th November 2022 / 02:00 BST Wednesday 16th November 2022 / 18:00 PDT Tuesday 15th November 2022  | week 11  | |
+| **[Test Freeze]**                                             | Branch Manager | [01:00 UTC Wednesday 16th November 2022 / 17:00 PDT Tuesday 15th November 2022](https://everytimezone.com/s/dc1d29cb)  | week 11  | |
 | Docs deadline — PRs ready for review                          | Docs Lead | Tuesday 15th November 2022                                                                                                   | week 11  | |
 | 1.26.0-rc.0 released                                          | Branch Manager | Tuesday 15th November 2022                                                                                              | week 11  | |
 | release-1.26 branch created                                   | Branch Manager | Tuesday 15th November 2022                                                                                              | week 11  | |
 | release-1.26 jobs created                                     | Branch Manager | Tuesday 15th November 2022                                                                                              | week 11  | |
 | Start final draft of Release Notes                            | Release Notes Lead | Tuesday 15th November 2022                                                                                          | week 11  | |
-| Release blog ready to review                                  | Comms / Docs | 01:00 UTC Wednesday 16th November 2022 / 02:00 BST Wednesday 16th November 2022 / 18:00 PDT Tuesday 15th November 2022    | week 11  | |
+| Release blog ready to review                                  | Comms / Docs | [01:00 UTC Wednesday 16th November 2022 / 17:00 PDT Tuesday 15th November 2022](https://everytimezone.com/s/dc1d29cb)    | week 11  | |
 | Major Themes complete                                         | Release Notes Lead | Tuesday 29th November 2022                                                                                          | week 13  | |
 | Docs complete — All PRs reviewed and ready to merge           | Docs Lead | Tuesday 29th November 2022                                                                                                   | week 13  | |
 | Feature blogs ready to review                                 | Enhancement Owner / SIG Leads | Tuesday 29th November 2022                                                                               | week 13  | |
 | 1.26.0-rc.1 released                                          | Branch Manager | Tuesday 29th November 2022                                                                                              | week 13  | |
-| Release Notes complete — reviewed & merged to `k/k` | Release Notes Lead | 01:00 UTC Friday 2nd December 2022 / 02:00 BST Friday 2nd December 2022 / 18:00 PDT Thursday 1st December 2022                | week 13  | |
+| Release Notes complete — reviewed & merged to `k/k` | Release Notes Lead | [01:00 UTC Friday 2nd December 2022 / 17:00 PDT Thursday 1st December 2022](https://everytimezone.com/s/4496e96f)                | week 13  | |
 | **v1.26.0 released**                                          | Branch Manager | Tuesday 6th December 2022                                                                                               | week 14  | |
 | Release blog published                                        | Comms | Tuesday 6th December 2022                                                                                                        | week 14  | |
 | **[Thaw]**                                                    | Branch Manager | Tuesday 6th December 2022                                                                                               | week 14  | |


### PR DESCRIPTION
Signed-off-by: leonardpahlke <leonard.pahlke@googlemail.com>

#### What type of PR is this:

/kind documentation

#### What this PR does / why we need it:

Add links to everytimezone.com (proposed by @palnabarun in [slack](https://kubernetes.slack.com/archives/C2C40FMNF/p1662644430934429?thread_ts=1662577589.087379&cid=C2C40FMNF))

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

/cc @palnabarun 

