### PR TITLE
releases/1.26: add Cici and Xander as Branch Manager shadows

### DIFF
--- a/releases/release-1.26/release-team.md
+++ b/releases/release-1.26/release-team.md
@@ -10,7 +10,7 @@
 | Release Notes | Rodolfo Martínez Vega ([@ramrodo](https://github.com/ramrodo) / Slack: `ramrodo`) | Harsha Narayana ([@harshanarayana](https://github.com/harshanarayana) / Slack: `@Harsha Narayana`), Ana Margarita Medina ([@AnaMMedina21](https://github.com/AnaMMedina21) / Slack: `@Ana Margarita Medina`), Laxmikant Bhaskar Pandhare ([@laxmikantbpandhare](https://github.com/laxmikantbpandhare) / Slack: `@laxmikantbpandhare`), Sayantani Saha ([@sayantani11](https://github.com/sayantani11) / Slack: `@sayantani`) |
 | Communications | Frederico Serrano Muñoz ([@fsmunoz](https://github.com/fsmunoz) / Slack: `@fsm` ) | Harshita Sao ([@harshitasao](https://github.com/harshitasao) / Slack: `@Harshita Sao`), Brad McCoy ([@bradmccoydev](https://github.com/bradmccoydev) / Slack: `@Brad McCoy`), David Espejo ([@davidmirror](https://github.com/davidmirror-ops) / Slack:`@David Espejo`), Debabrata Panigrahi ([@Debanitrkl](https://github.com/Debanitrkl]) / Slack: `@Deba`) |
 | Emeritus Adviser | Nabarun Pal ([@palnabarun](https://github.com/palnabarun)) / Slack: `@palnabarun` | |
-| Branch Manager | Jeremy Rickard ([@jeremyrickard](https://github.com/jeremyrickard)) / Slack: `@jerickar` |  |
+| Branch Manager | Jeremy Rickard ([@jeremyrickard](https://github.com/jeremyrickard)) / Slack: `@jerickar` |  Cici Huang ([@cici37](https://github.com/cici37) / Slack: `@cici37`), Xander Grzywinski ([@salaxander](https://github.com/salaxander) / Slack: `@Xander`) |
 
 Review the [Release Managers page](https://github.com/kubernetes/website/blob/main/content/en/releases/release-managers.md) for up-to-date contact information on Release Engineering personnel.
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this:

<!--
Add one of the following kinds:
/kind cleanup
/kind documentation
/kind feature
/kind design
-->

#### What this PR does / why we need it:

After discussion with the other @kubernetes/sig-release-leads, this PR proposes @cici37 and @salaxander  as 1.26 Branch Manager shadows.

They have worked in/around the Release Team for several cycles in various roles and have the technical background to thrive in this role. This roster addition will implicitly make them Release Manager Associates. They will open a follow up PR to onboard themselves. 

/hold for approval from the folks below
 
SIG Release leads:
/assign @saschagrunert @cpanato @puerco @justaugustus 

1.26 Release Team lead:
/assign @leonardpahlke 





#### Special notes for your reviewer:


Signed-off-by: Jeremy Rickard <jeremyrrickard@gmail.com>

