### PR TITLE
Update release team handbook to define major themes collection

### DIFF
--- a/release-team/role-handbooks/release-notes/README.md
+++ b/release-team/role-handbooks/release-notes/README.md
@@ -1,37 +1,43 @@
 # Kubernetes Release Team: Release Notes
 
-- [Overview](#overview)
-- [Prerequisites for Release Notes Lead and Shadows](#prerequisites-for-release-notes-lead-and-shadows)
-  - [General Requirements](#general-requirements)
-  - [Skills and Experience Requirements](#skills-and-experience-requirements)
-  - [Time Requirements](#general-requirements)
-    - [Early and mid release cycle (weeks 1-8)](#early-and-mid-release-cycle-weeks-1-8)
-    - [Late release cycle (weeks 9-12+)](#late-release-cycle-weeks-9-12)
-  - [Machine and GitHub Setup](#machine-and-github-setup)
-    - [Setup krel](#setup-krel)
-    - [Get a GitHub token](#get-a-github-token)
-    - [Fork the kubernetes repositories](#fork-the-kubernetes-repositories)
-- [Tasks and Responsibilities](#tasks-and-responsibilities)
-  - [Manage permissions](#manage-permissions)
-  - [Setup the Tools and Generate the Release Notes](#setup-the-tools-and-generate-the-release-notes)
-  - [Periodically review and fix new release notes](#periodically-review-and-fix-new-release-notes)
-  - [Attend Release Meetings and follow #sig-release](#attend-Release-Meetings-and-follow-sig-release)
-  - [Maintain the _Known Issues_ Issue](#maintain-the-known-issues-issue)
-  - [Ensure Major Themes are Reflected in the Notes](#ensure-major-themes-are-reflected-in-the-notes)
-  - [Get feedback from SIG Leads](#get-feedback-from-sig-leads)
-  - [Clean up and edit the final document](#clean-up-and-edit-the-final-document)
-  - [Curate the External Dependencies Section](#curate-the-external-dependencies-section)
-- [Release Milestone Activities](#release-milestone-activities)
-  - [Week 1](#week-1)
-  - [Weeks 2 - 10](#weeks-2-10)
-  - [Week 11 (Begin of Code Freeze)](#week-11-begin-of-code-freeze)
-  - [Week 13-16](#week-13-16)
-  - [Week 15](#week-15)
-  - [Week 16](#week-16)
-  - [Week 17](#week-17)
-  - [Week 19](#week-19)
-- [Tools](#tools)
-- [TODOs](#todos)
+- [Kubernetes Release Team: Release Notes](#kubernetes-release-team-release-notes)
+  - [Overview:](#overview)
+  - [Prerequisites for Release Notes Lead and Shadows](#prerequisites-for-release-notes-lead-and-shadows)
+    - [General Requirements](#general-requirements)
+    - [Skills and Experience Requirements](#skills-and-experience-requirements)
+    - [Time Requirements](#time-requirements)
+      - [Onboarding Session (week 1) ~1 hour](#onboarding-session-week-1-1-hour)
+      - [Early and mid release cycle (weeks 1-8) ~1-5 hours/week](#early-and-mid-release-cycle-weeks-1-8-1-5-hoursweek)
+      - [Late release cycle (weeks 9-12+) ~4-10 hours/week](#late-release-cycle-weeks-9-12-4-10-hoursweek)
+    - [GitHub Organization Membership](#github-organization-membership)
+    - [Machine and GitHub Setup](#machine-and-github-setup)
+      - [Setup krel](#setup-krel)
+      - [Fork the kubernetes repositories](#fork-the-kubernetes-repositories)
+  - [Tasks and Responsibilities](#tasks-and-responsibilities)
+    - [Manage permissions](#manage-permissions)
+    - [Setup the Tools and Generate the Release Notes](#setup-the-tools-and-generate-the-release-notes)
+    - [Periodically review and fix new release notes](#periodically-review-and-fix-new-release-notes)
+    - [Attend Release Meetings and follow #sig-release](#attend-release-meetings-and-follow-sig-release)
+    - [Maintain the _Known Issues_ Issue](#maintain-the-known-issues-issue)
+    - [Ensure Major Themes are Reflected in the Notes](#ensure-major-themes-are-reflected-in-the-notes)
+    - [Get feedback from SIG Leads](#get-feedback-from-sig-leads)
+    - [Clean up and edit the final document](#clean-up-and-edit-the-final-document)
+    - [Curate the External Dependencies Section](#curate-the-external-dependencies-section)
+  - [Release Cycle Milestone Activities:](#release-cycle-milestone-activities)
+    - [Week 1](#week-1)
+    - [Weeks 2 - 10](#weeks-2---10)
+      - [Week 4](#week-4)
+      - [Week 10](#week-10)
+    - [Week 11 (Begin of Code Freeze)](#week-11-begin-of-code-freeze)
+    - [Weeks 13-16](#weeks-13-16)
+    - [Week 15](#week-15)
+    - [Week 16](#week-16)
+    - [Week 17](#week-17)
+    - [Week 19](#week-19)
+  - [Tools](#tools)
+  - [TODOs](#todos)
+    - [Post 1.17 TODOs](#post-117-todos)
+      - [If any team members have NLP experience](#if-any-team-members-have-nlp-experience)
 
 ## Overview:
 
@@ -181,6 +187,14 @@ Begin running release-notes tool for the ongoing collection of release notes wit
 
 - Begin attending burndown meetings
 - Same as above, but generate the notes for each `alpha` and `beta`
+
+#### Week 4
+
+- Create an issue to start collecting the main themes of the publication, and reach out to all SIGs on and off over the next few weeks to ask for main themes and explain why this is important to the community.
+
+#### Week 10
+
+- Make sure major themes of the release are checked in before Code Freeze; reach out to SIGs and release leads if additional coordination is needed
 
 ### Week 11 (Begin of Code Freeze)
 

--- a/release-team/role-handbooks/release-notes/README.md
+++ b/release-team/role-handbooks/release-notes/README.md
@@ -190,7 +190,7 @@ Begin running release-notes tool for the ongoing collection of release notes wit
 
 #### Week 4
 
-- Create an issue to start collecting the main themes of the publication, and reach out to all SIGs on and off over the next few weeks to ask for main themes and explain why this is important to the community.
+- With Enhancement freeze in effect, create an issue to start collecting the main themes of the publication, and reach out to all SIGs on and off over the next few weeks to ask for main themes and explain why this is important to the community.
 
 #### Week 10
 

--- a/release-team/role-handbooks/release-notes/README.md
+++ b/release-team/role-handbooks/release-notes/README.md
@@ -190,7 +190,7 @@ Begin running release-notes tool for the ongoing collection of release notes wit
 
 #### Week 4
 
-- With Enhancement freeze in effect, create an issue to start collecting the main themes of the publication, and reach out to all SIGs on and off over the next few weeks to ask for main themes and explain why this is important to the community.
+- With Enhancement freeze in effect, create a GitHub discussion ([example 1.26](https://github.com/kubernetes/sig-release/discussions/2047)) to start collecting the major themes of the release, and reach out to all SIGs on and off over the next few weeks to ask for major themes and explain why this is important to the community.
 
 #### Week 10
 

--- a/release-team/role-handbooks/release-team-lead/README.md
+++ b/release-team/role-handbooks/release-team-lead/README.md
@@ -263,7 +263,7 @@ Coordinate with SIG-Release Chairs (who have access to the CNCF Service Desk as 
 - Remind the community about Enhancements Freeze
 - Make sure everything is in synch between the [enhancements repo][k/enhancements] and the enhancements tracking spreadsheet
 - If there are enhancements with questions or concerns, help coordinate those conversations between the team and the SIG/owners
-- Start collecting SIG release themes in the release notes draft, outlining what they are delivering this release milestone, and how it aligns with their mission statements - start with SIGs identifying enhancements in the enhancements repo, and focus on those since not every SIG will be delivering something
+- Assist Release Notes with the start of collecting major release themes
 
 ### Week 5
 
@@ -300,6 +300,7 @@ Coordinate with SIG-Release Chairs (who have access to the CNCF Service Desk as 
 - Check in with SIGs on their enhancement work to make sure they know Code Freeze is 3 weeks away, as well as emailing the [kubernetes-dev] list, and notifying the community at the weekly meeting
   - Verify with SIGs if there are any planned deprecations or removals targeting the release.
 - Adjust the enhancements repo/tracking spreadsheet as necessary (this may also require modifying themes that can’t be delivered)
+- Check in with Release Notes and Release Comms the status of major themes of the release
 
 ### Week 10
 
@@ -321,7 +322,7 @@ Coordinate with SIG-Release Chairs (who have access to the CNCF Service Desk as 
 - Make sure everyone knows the Docs deadline (PRs ready for review) is coming the following week.
 - The Deprecations and Removals blog is scheduled for next week shortly after Code Freeze. A draft of the blog should 
   be started as reviews and iterations will be needed before publication next week.
-- Follow up with SIGs on release themes.
+- Follow up with SIGs on major themes of the release.
 
 #### Code Freeze Day
 


### PR DESCRIPTION
Signed-off-by: leonardpahlke <leonard.pahlke@googlemail.com>

#### What type of PR is this:

/kind documentation

#### What this PR does / why we need it:

When the collection of major themes should start is currently not documented properly.

On Slack, we discussed that it would be good to start the collection with enhancements freeze and completing major themes with code freeze.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

/cc @ramrodo @fsmunoz @palnabarun 

slack thread: https://kubernetes.slack.com/archives/CN1KH4K9A/p1664365650976149