### PR TITLE
Update roadmap to reflect deb/rpm packaging status

### DIFF
--- a/roadmap.md
+++ b/roadmap.md
@@ -51,6 +51,13 @@ state.
 
    Enhancement: https://github.com/kubernetes/enhancements/issues/3031
 
+1. **Moving deb/rpm package builds to community infrastructure (Consumable)**
+
+   Outcome: Automated builds of signed `deb` and `rpm` Kubernetes packages
+   within community infrastructure.
+
+   Enhancement: https://github.com/kubernetes/enhancements/issues/1731
+
 ### To be done (TODO)
 
 1. **Enhance Kubernetes binary artifact management (Consumable)**
@@ -84,15 +91,6 @@ state.
 
    Outcome: Clear documentation about available version markers as well as their
    simplified automation.
-
-1. **Moving deb/rpm package builds to community infrastructure (Consumable)**
-
-   https://github.com/kubernetes/release/issues/913
-
-   Enhancement: _none_
-
-   Outcome: Automated builds of `deb` and `rpm` Kubernetes packages within
-   community infrastructure.
 
 ### Known Risks
 


### PR DESCRIPTION


#### What type of PR is this:


/kind documentation


#### What this PR does / why we need it:
We now link the KEP 1731 to the deb/rpm packaging efforts rather than the umbrella issue. Beside that we move the section to WIP, because we already started evaluating and updating the enhancement.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #
or
None
-->
Refers to https://github.com/kubernetes/enhancements/pull/3434
#### Special notes for your reviewer:
cc @kubernetes/sig-release-leads 