### PR TITLE
Update docs handbook timeline with additional note about end-of-year releases

### DIFF
--- a/release-team/role-handbooks/docs/Release-Timeline.md
+++ b/release-team/role-handbooks/docs/Release-Timeline.md
@@ -66,6 +66,7 @@ For each release, the schedule with deliverables is added to the release directo
 
 > Note: The kubernetes/website repo changed from using a `master` branch to a `main` branch in 2021.
 > Be aware that several linked, example PRs uses the `master` branch.
+> For the end-of-year release, KubeCon NA and the US Thanksgiving holiday can be additional impediments to Docs-related deadlines. Please communicate to enhancement owners/contributors about upcoming deadlines earlier and more frequently.
 
 
 ## Early Steps (Weeks 1-2)


### PR DESCRIPTION
This PR updates the Docs handbook timeline with an additional note about end-of-year releases and to communicate Docs-related deadlines earlier and more frequent. Future Docs leads may not have experience with end-of-year releases and how US Thanksgiving and KubeCon NA can affect docs-related deadlines until it's already near the deadlines 