### PR TITLE
Update 1.26 timeline; postpone 1.26 release to Thursday the 8th of December

### DIFF
--- a/releases/release-1.26/README.md
+++ b/releases/release-1.26/README.md
@@ -45,7 +45,7 @@ The 1.26 release cycle is as follows:
 - **[01:00 UTC Wednesday 9th November 2022 / 17:00 PDT Tuesday 8th November 2022](https://everytimezone.com/s/d3187dcc)**: Week 10 — [Code Freeze](../release_phases.md#code-freeze)
 - **[01:00 UTC Wednesday 16th November 2022 / 17:00 PDT Tuesday 15th November 2022](https://everytimezone.com/s/dc1d29cb)**: Week 11 — [Test Freeze](../release_phases.md#test-freeze)
 - **Tuesday 29th November 2022**: Week 13 — Docs must be completed and reviewed
-- **Tuesday 6th December 2022**: Week 14 — Kubernetes v1.26.0 released
+- **Thursday 8th December 2022**: Week 14 — Kubernetes v1.26.0 released
 - **Tuesday 13th December**: Week 15 — [Release Retrospective][Retrospective Document] Part 2
 - **Wednesday 14th December**: Week 15 — [Release Retrospective][Retrospective Document] Part 3 (Note: Only if items get spill over from Retro Part 2, we will have Part 3)
 
@@ -88,9 +88,9 @@ The 1.26 release cycle is as follows:
 | Feature blogs ready to review                                 | Enhancement Owner / SIG Leads | Tuesday 29th November 2022                                                                               | week 13  | |
 | 1.26.0-rc.1 released                                          | Branch Manager | Tuesday 29th November 2022                                                                                              | week 13  | |
 | Release Notes complete — reviewed & merged to `k/k` | Release Notes Lead | [01:00 UTC Friday 2nd December 2022 / 17:00 PDT Thursday 1st December 2022](https://everytimezone.com/s/4496e96f)                | week 13  | |
-| **v1.26.0 released**                                          | Branch Manager | Tuesday 6th December 2022                                                                                               | week 14  | |
-| Release blog published                                        | Comms | Tuesday 6th December 2022                                                                                                        | week 14  | |
-| **[Thaw]**                                                    | Branch Manager | Tuesday 6th December 2022                                                                                               | week 14  | |
+| **v1.26.0 released**                                          | Branch Manager | Thursday 8th December 2022                                                                                               | week 14  | |
+| Release blog published                                        | Comms | Thursday 8th December 2022                                                                                                        | week 14  | |
+| **[Thaw]**                                                    | Branch Manager | Thursday 8th December 2022                                                                                               | week 14  | |
 | Release retrospective Part 2                                  | Community | [17:00 UTC / 09:00 PDT Tuesday 13th December](https://everytimezone.com/s/5ec45da4)                                                                                                                          | week 15  | |
 | Release retrospective part 3 (Note: Only if items get spill over from Retro Part 2, we will have Part 3) | Community | [17:00 UTC / 09:00 PDT Wednesday 14th December](https://everytimezone.com/s/1cba3371)                                                                                                                          | week 15  | |
 


### PR DESCRIPTION
Signed-off-by: leonardpahlke <leonard.pahlke@googlemail.com>


#### What type of PR is this:

/kind documentation

#### What this PR does / why we need it:

The Go team [announced to release new security patches on the 6th of December](https://groups.google.com/g/golang-announce/c/v2KvT18_yCg/m/WKTrlMftAAAJ).
This fall together with our release date unfortunately. To get new go version in the release we need to change the release date. 
We discussed over slack `#release-management` to change the date to the 8th of December.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

ref: [Slack Discussion](https://kubernetes.slack.com/archives/CJH2GBF7Y/p1669846712157929)

cc @kubernetes/sig-release-leads @kubernetes/release-managers @kubernetes/release-team 
