### PR TITLE
Issue template: add note about krel-fast forward

### DIFF
--- a/.github/ISSUE_TEMPLATE/cut-release.md
+++ b/.github/ISSUE_TEMPLATE/cut-release.md
@@ -6,6 +6,11 @@ labels: sig/release, area/release-eng
 ---
 ## Scheduled to happen: <!-- Tue, 2021-MM-DD -->
 
+_Note for v1.x.0 releases: Having this issue in open state will stop the
+periodic run of [`krel fast-forward`](https://testgrid.k8s.io/sig-release-releng-blocking#git-repo-kubernetes-fast-forward)
+to avoid conflicts with releases running in parallel. The fast-forward will
+automatically stop once the v1.x.0 tag is available._
+
 ## Release Blocking Issues
 <!--
 


### PR DESCRIPTION


#### What type of PR is this:


/kind documentation


#### What this PR does / why we need it:
We now add a note about how `krel fast-forward` behaves when cutting v1.x.0 releases.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #
or
None
-->
Refers to https://github.com/kubernetes/release/issues/2807
#### Special notes for your reviewer:
PTAL @kubernetes/release-managers 