### PR TITLE
Fix rule of endOfLifeDate for Kubernetes releases

### DIFF
--- a/release-team/role-handbooks/docs/Release-Timeline.md
+++ b/release-team/role-handbooks/docs/Release-Timeline.md
@@ -569,7 +569,7 @@ The following fields are required:
   - `next`: <1.xy.1>
   - `cherryPickDeadline`: <YYYY-MM-DD> # the Friday before `targetDate`
   - `targetDate`: <YYYY-MM-DD> # the 2nd Wednesday of the next month
-  - `endOfLifeDate`: <YYYY-MM-DD> # the last Friday of the month after 1 year and 2 months after the release
+  - `endOfLifeDate`: <YYYY-MM-DD> # the 28th of the month after 1 year and 2 months after the release
 
 To update https://kubernetes.io/releases/patch-releases, update https://github.com/kubernetes/website/blob/main/content/en/releases/patch-releases.md.
 Add a subsection for [future-release] under `Detailed Release History for Active Branches` using the existing subsections as an example.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this:
/kind cleanup

#### What this PR does / why we need it:
@xmudrii advised that SIG release has long ago decided to always use the 28th and has asked me nicely to make a PR here.
