### PR TITLE
Removing newlines from GITHUB_TOKEN env var in sync project board scripts

### DIFF
--- a/release-team/hack/sync-bug-triage-github-project-beta.sh
+++ b/release-team/hack/sync-bug-triage-github-project-beta.sh
@@ -40,6 +40,8 @@ if [ "$MILESTONE" == "" ]; then
       exit 1
 fi
 
+GITHUB_TOKEN="$(echo "$GITHUB_TOKEN" | tr -d '\n')"
+
 milestone_issue_ids=()
 milestone_pr_ids=()
 

--- a/release-team/hack/sync-enhancements-github-project-beta.sh
+++ b/release-team/hack/sync-enhancements-github-project-beta.sh
@@ -30,6 +30,13 @@ if [ "$PROJECT_NUMBER" == "" ]; then
       exit 1
 fi
 
+if [ "$GITHUB_TOKEN" == "" ]; then
+      echo "[Error] Required environment variable \"GITHUB_TOKEN\" is not set."
+      exit 1
+fi
+
+GITHUB_TOKEN="$(echo "$GITHUB_TOKEN" | tr -d '\n')"
+
 milestone_issue_ids=()
 milestone_issue_numbers=()
 


### PR DESCRIPTION

Signed-off-by: Mark Rossetti <marosset@microsoft.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this:
/kind cleanup
<!--
Add one of the following kinds:

/kind documentation
/kind feature
/kind design
-->

#### What this PR does / why we need it:

This PR fixes an issue where if the secrets added to the PROW cluster are created from a file with trailing newline characters then the github cli will panic and print the PAT 

Slack discussion - https://kubernetes.slack.com/archives/CCK68P2Q2/p1674605632708979?thread_ts=1673639428.847029&cid=CCK68P2Q2

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #
or
None
-->

#### Special notes for your reviewer:
