### PR TITLE
Updating enhancements role handbook to disable GH project workflows

### DIFF
--- a/release-team/role-handbooks/enhancements/README.md
+++ b/release-team/role-handbooks/enhancements/README.md
@@ -131,6 +131,9 @@ It is important that this process be followed and documentation remain up-to-dat
     - Until this can be automated; manually create Views with the same Names and Fields from the previous release's project board.
       Tip: You can easily view all the Fields present in each view by clicking the `v` next to the View's name an selecting `Configuration` -> `Fields`
       Note: Remember to **save** each View. If there is a blue bubble next to the Views name there are unsaved changed for that view!
+  - Disable all Workflows for the project
+    - Click `...` -> `Workflows`
+    - For each workflow that enabled (has a green circle next to it), click the workflow and slide the toggle to 'Off'
   - Update automation to add issues to the correct Enhancement Tracking Board
     - Open a PR into kubernetes/test-infra which to update the [`GITHUB_PROJECT_BETA_NUMBER`](https://github.com/kubernetes/test-infra/blob/3de59f96b327c87c6d23a7308abc785268931707/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-release-release-team-jobs/release-team-periodics.yaml#L20-L21) variable used by automation to identity the enhancements tracking board for the current release.
 - Create a shortlink for the Tracking Board


### PR DESCRIPTION
Signed-off-by: Mark Rossetti <marosset@microsoft.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this:
/kind documentation

<!--
Add one of the following kinds:
/kind cleanup

/kind feature
/kind design
-->

#### What this PR does / why we need it:
Add steps to disable workflows for the enhancements project boards.
We are doing this because we noticed that the github automation was changing some states if the issues were accidently closed

Example right below this comment - https://github.com/kubernetes/enhancements/issues/3476#issuecomment-1423054144

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #
or
None
-->

#### Special notes for your reviewer:


/assign @Atharva-Shinde @salaxander @JamesLaverack 