### PR TITLE
fix yaml file that will break krel release-note commands

### DIFF
--- a/releases/release-1.27/release-notes/maps/pr-113834-map.yaml
+++ b/releases/release-1.27/release-notes/maps/pr-113834-map.yaml
@@ -1,3 +1,3 @@
 pr: 113834
 releasenote:
-  text: `statefulset` status will now be consistent on API errors
+  text: '`statefulset` status will now be consistent on API errors'

--- a/releases/release-1.27/release-notes/maps/pr-115786-map.yaml
+++ b/releases/release-1.27/release-notes/maps/pr-115786-map.yaml
@@ -1,3 +1,3 @@
 pr: 115786
 releasenote:
-  text: `golang.org/x/net` updated to `v0.7.0` to fix CVE-2022-41723
+  text: '`golang.org/x/net` updated to `v0.7.0` to fix CVE-2022-41723'


### PR DESCRIPTION
#### What type of PR is this:
/kind cleanup

#### What this PR does / why we need it:
Cleanup yaml file that will break the `krel release-notes` command due to invalid start char for yaml files

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:
None