### PR TITLE
Delay 1.27.0-rc.1 release to Thursday April 6th

### DIFF
--- a/releases/release-1.27/README.md
+++ b/releases/release-1.27/README.md
@@ -81,7 +81,7 @@ The 1.27 release cycle is as follows:
 | Major Themes complete                                         | Release Notes Lead | Tuesday 4th April 2023 | week 13  | |
 | Docs complete — All PRs reviewed and ready to merge           | Docs Lead | Tuesday 4th April 2023                                                                                                   | week 13  | |
 | Feature blogs ready to review                                 | Enhancement Owner / SIG Leads | Tuesday 4th April 2023                                                                               | week 13  | |
-| 1.27.0-rc.1 released                                          | Branch Manager | Tuesday 4th April 2023                                                                                              | week 13  | |
+| 1.27.0-rc.1 released                                          | Branch Manager | Thursday 6th April 2023                                                                                              | week 13  | |
 | Release Notes complete — reviewed & merged to https://github.com/kubernetes/kubernetes | Release Notes Lead | Tuesday 11th April 2023 | week 14  | |
 | **v1.27.0 released**                                          | Branch Manager | Tuesday 11th April 2023                                                                                               | week 14  | |
 | Release blog published                                        | Comms | Tueday 11th April 2023                                                                                                        | week 14  | |


### PR DESCRIPTION
#### What type of PR is this:

/kind documentation

#### What this PR does / why we need it:

We should consider delaying the upcoming 1.27.0-rc.1 release to be able to pick up Go 1.20.3 update. This Go update is supposed to fix 4 CVEs in the standard library.

Some notes:

* We might want to wait for the announcement to go out and then verify if we are affected
  * However, verifying if we are affected tends to be complicated because Kubernetes is a huge project
* I decided to go with Thursday to give us enough time to update because it tends to take up to one day for Go images to become available
* I left the 1.27.0 release date as it is, hoping that there should be enough time from Thursday to Tuesday for downstream consumers to verify rc.1

#### Which issue(s) this PR fixes:

xref https://github.com/kubernetes/release/issues/2991

/assign @salaxander @cici37 @jeremyrickard 
/hold for discussion