### PR TITLE
[v1.28] Add release timeline and initialize team

### DIFF
--- a/releases/release-1.28/OWNERS
+++ b/releases/release-1.28/OWNERS
@@ -1,0 +1,18 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+    - leonardpahlke # Emeritus Advisor
+    - gracenng # Release Team Lead
+    - helayoty # Lead Shadow
+    - marosset # Lead Shadow
+    - mickeyboxell # Lead Shadow
+    - neoaggelos # Lead Shadow
+
+reviewers:
+    - Atharva-Shinde # Enhancements Lead
+    - sanchita-07 # Release Notes Lead
+    - bradmccoydev # Communications Lead
+    - furkatgofurov7 # Bug Triage Lead
+    - mehabhalodiya # CI Signal Lead
+    - Rishit-dagli # Docs Lead
+ 

--- a/releases/release-1.28/README.md
+++ b/releases/release-1.28/README.md
@@ -8,14 +8,14 @@ description: |
   Release Team contact information, tracking spreadsheets and more!
 ---
 
-# Kubernetes 1.27
+# Kubernetes 1.28
 
 #### Links
 
 * [This document](https://git.k8s.io/sig-release/releases/release-1.28/README.md)
 * [Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.28/release-team.md)
 * [Meeting Minutes](https://bit.ly/k8s128-releasemtg) (members of [release-team@] receive meeting invites)
-* [v1.27 Release Calendar][k8s128-calendar]
+* [v1.28 Release Calendar][k8s128-calendar]
 * Contact: [#sig-release] on slack, [release-team](mailto://release-team@kubernetes.io) on e-mail
 * [Internal Contact Info] (accessible only to members of [release-team@])
 
@@ -109,7 +109,7 @@ Please refer to the [release phases document](../release_phases.md).
 
 [master-blocking]: https://testgrid.k8s.io/sig-release-master-blocking#Summary
 [master-informing]: https://testgrid.k8s.io/sig-release-master-informing#Summary
-[1.27-blocking]: https://testgrid.k8s.io/sig-release-1.27-blocking#Summary
+[1.28-blocking]: https://testgrid.k8s.io/sig-release-1.28-blocking#Summary
 
 [exception requests]: ../EXCEPTIONS.md
 [release phases document]: ../release_phases.md

--- a/releases/release-1.28/README.md
+++ b/releases/release-1.28/README.md
@@ -90,9 +90,9 @@ The 1.28 release cycle is as follows:
 
 Please refer to the [release phases document](../release_phases.md).
 
-[k8s127-calendar]: https://bit.ly/k8s-release-cal
-[Internal Contact Info]: https://bit.ly/k8s127-contacts
-[Retrospective Document]: https://bit.ly/k8s127-retro
+[k8s128-calendar]: https://bit.ly/k8s-release-cal
+[Internal Contact Info]: https://bit.ly/k8s128-contacts
+[Retrospective Document]: https://bit.ly/k8s128-retro
 
 [Enhancements Freeze]: ../release_phases.md#enhancements-freeze
 [Burndown]: ../release_phases.md#burndown

--- a/releases/release-1.28/README.md
+++ b/releases/release-1.28/README.md
@@ -1,0 +1,115 @@
+---
+title: "Kubernetes 1.28 Release Information"
+weight: 98
+slug: "release"
+aliases: [ "/release" ]
+description: |
+  Information regarding the current release cycle including important dates,
+  Release Team contact information, tracking spreadsheets and more!
+---
+
+# Kubernetes 1.27
+
+#### Links
+
+* [This document](https://git.k8s.io/sig-release/releases/release-1.28/README.md)
+* [Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.28/release-team.md)
+* [Meeting Minutes](https://bit.ly/k8s128-releasemtg) (members of [release-team@] receive meeting invites)
+* [v1.27 Release Calendar][k8s128-calendar]
+* Contact: [#sig-release] on slack, [release-team](mailto://release-team@kubernetes.io) on e-mail
+* [Internal Contact Info] (accessible only to members of [release-team@])
+
+#### Tracking docs
+
+* [Enhancements Tracking Board](https://bit.ly/k8s128-enhancements)
+* [Feature blog Tracking Board](#)
+* [Bug Triage Tracking Board](https://bit.ly/k8s128-bug-triage-tracking)
+* [CI Signal Project Board & Issue Tracking](#)
+* [Retrospective Document](https://bit.ly/k8s128-retro)
+* [kubernetes/sig-release v1.28 milestone](https://github.com/kubernetes/kubernetes/milestone/61)
+
+#### Guides
+
+* [Targeting Issues and PRs to This Milestone](https://git.k8s.io/community/contributors/devel/sig-release/release.md)
+* [Triaging and Escalating Test Failures](https://git.k8s.io/community/contributors/devel/sig-testing/testing.md#troubleshooting-a-failure)
+
+## Summary
+
+The 1.28 release cycle is as follows:
+
+- **Monday 15th May 2023**: Week 1 — Release cycle begins
+- **Thursday 8th June 2023**: Week 4 — [Production Readiness Freeze](https://groups.google.com/g/kubernetes-sig-architecture/c/a6_y81N49aQ)
+- **[01:00 UTC Friday 16th June 2023 / 18:00 PDT Thursday 15th June 2023](https://everytimezone.com/s/7babb4d3)(https://everytimezone.com/s/cc15bd3a)**: Week 5 — [Enhancements Freeze](../release_phases.md#enhancements-freeze)
+- **[01:00 UTC Wednesday 19th July 2023 / 18:00 PDT Tuesday 18th July 2023](https://everytimezone.com/s/72ee8496)**: Week 10 — [Code Freeze](../release_phases.md#code-freeze)
+- **[01:00 UTC Wednesday 26nd July 2023 / 17:00 PDT Tuesday 25th July 2023](https://everytimezone.com/s/92d31472)**: Week 11 — [Test Freeze](../release_phases.md#test-freeze)
+- **Tuesday 8th August 2023**: Week 13 — Docs must be completed and reviewed
+- **Tuesday 15th August 2023**: Week 14 — Kubernetes v1.28.0 released
+
+## Timeline
+
+| **What**                                                      | **Who** | **When**                                                                                                        | **Week** | **CI Signal** |
+|---------------------------------------------------------------|---|-----------------------------------------------------------------------------------------------------------------|----------|---|
+| Start of Release Cycle                                        | Lead | Monday 15th May 2023                                                                                                         | week 1   | [master-blocking] |
+| Start Enhancements Tracking                                   | Enhancements Lead | Monday 15th May 2023                                                                                           | week 1   | |
+| Schedule finalized                                            | Lead | Friday 19th May 2023                                                                                                         | week 1   | |
+| Team finalized                                                | Lead | Friday 19th May 2023                                                                                                          | week 1   | |
+| 1.28.0-alpha.1 released                                       | Branch Manager | Tuesday 30th May 2023                                                                                           | Week 3   | |
+| Start Release Notes Draft                                     | Release Notes Lead | Tuesday 30th May 2023                                                                                          | week 3   | |
+| Production Readiness Freeze                              | Enhancements Lead | Thursday 8th June 2023                                                                                         | week 4   | |
+| **Begin [Enhancements Freeze]**                               | Enhancements Lead | [01:00 UTC Friday 16th June 2023 / 18:00 PDT Thursday 15th June 2023](https://everytimezone.com/s/7babb4d3)                                              | week 5   | [master-blocking], [master-informing] |
+| 1.28.0-alpha.2 released                                       | Branch Manager | Tuesday 20th June 2023                                                                                               | Week 6   | |
+| Begin Friday APAC-friendly meetings                           | Lead | Friday 30th June 2023                                                                                                          | Week 7   | |
+| 1.28.0-alpha.3 released                                       | Branch Manager | Thursday 6th July 2023                                                                                                                                    | week 8   | [1.28-blocking], [master-blocking], [master-informing] |
+| **Call for [Exceptions][Exception]**                          | Lead | Monday 10th July 2023                                                                                                          | week 9   | |
+| Brace Yourself, Code Freeze is Coming                         | Comms / Bug Triage | Monday 10th July 2023                                                                                            | week 9   | |
+| **Begin Feature blog freeze**                                 | Comms Lead | [01:00 UTC Wednesday 12th July 2023 / 18:00 PDT Tuesday 11th July 2023](https://everytimezone.com/s/9fd4bc29)                                                 | week 9   | |
+| **Begin [Code Freeze]**                                       | Branch Manager | [01:00 UTC Wednesday 19th July 2023 / 18:00 PDT Tuesday 18th July 2023](https://everytimezone.com/s/72ee8496)     | week 10  | |
+| 1.28.0-beta.0 released                                        | Branch Manager | Thursday 20th July 2023                                                                                             | week 10  | |
+| Docs deadline — Open placeholder PRs                          | Docs Lead | Thursday 20th July 2023                                                                                                  | week 10  | |
+| Deprecations and Removals blog published                      | Comms | Thursday 20th July 2023                                                                                                      | week 10  | |
+| **Begin [Burndown]** (Monday, Wednesday, and Friday meetings) | Lead           | Monday 24th July 2023 | Week 11   | |
+| **[Test Freeze]**                                             | Branch Manager | [01:00 UTC Wednesday 26nd July 2023 / 17:00 PDT Tuesday 25th July 2023](https://everytimezone.com/s/92d31472)  | week 11  | |
+| Docs deadline — PRs ready for review                          | Docs Lead | Tuesday 25th July 2023 | Week 11   | |
+| 1.28.0-rc.0 released                                          | Branch Manager | Tuesday 25th July 2023                                                                                              | week 11  | |
+| release-1.28 branch created                                   | Branch Manager | Tuesday 25th July 2023                                                                                              | week 11  | |
+| release-1.28 jobs created                                     | Branch Manager | Tuesday 25th July 2023                                                                                              | week 11  | |
+| Major Themes deadline                                     | Comms | Tuesday 25th July 2023                                                                                              | week 11  | |
+| Start final draft of Release Notes                            | Release Notes Lead | Tuesday 25th July 2023                                                                                          | week 11  | |
+| Release blog ready to review                                  | Comms / Docs | [01:00 UTC Wednesday 26nd July 2023 / 17:00 PDT Tuesday 25th July 2023](https://everytimezone.com/s/92d31472)    | week 11  | |
+| Burndown Meetings daily (Tuesday & Thursday over Slack)       | Lead               | Monday 31st July 2023  | week 12  | |
+| Major Themes complete                                         | Release Notes Lead | Tuesday 8th August 2023 | week 13  | |
+| Docs complete — All PRs reviewed and ready to merge           | Docs Lead | Tuesday 8th August 2023                                                                                                   | week 13  | |
+| Feature blogs ready to review                                 | Enhancement Owner / SIG Leads | Tuesday 8th August 2023                                                                               | week 13  | |
+| 1.28.0-rc.1 released                                          | Branch Manager | Thursday 10th August 2023                                                                                              | week 13  | |
+| Release Notes complete — reviewed & merged to https://github.com/kubernetes/kubernetes | Release Notes Lead | Tuesday 15th August 2023 | week 14  | |
+| **v1.28.0 released**                                          | Branch Manager | Tuesday 15th August 2023                                                                                               | week 14  | |
+| Release blog published                                        | Comms | Tuesday 15th August 2023                                                                                                        | week 14  | |
+| **[Thaw]**                                                    | Branch Manager | Tuesday 15th August 2023                                                                                               | week 14  | |                                                                                                  | week 15   | |
+
+## Phases
+
+Please refer to the [release phases document](../release_phases.md).
+
+[k8s127-calendar]: https://bit.ly/k8s-release-cal
+[Internal Contact Info]: https://bit.ly/k8s127-contacts
+[Retrospective Document]: https://bit.ly/k8s127-retro
+
+[Enhancements Freeze]: ../release_phases.md#enhancements-freeze
+[Burndown]: ../release_phases.md#burndown
+[Code Freeze]: ../release_phases.md#code-freeze
+[Exception]: ../release_phases.md#exceptions
+[Thaw]: ../release_phases.md#thaw
+[Test Freeze]: ../release_phases.md#test-freeze
+
+[release-team@]: https://groups.google.com/a/kubernetes.io/g/release-team
+[kubernetes-sig-release@]: https://groups.google.com/forum/#!forum/kubernetes-sig-release
+[#sig-release]: https://kubernetes.slack.com/messages/sig-release/
+[kubernetes-release-calendar]: https://bit.ly/k8s-release-cal
+[kubernetes/kubernetes]: https://github.com/kubernetes/kubernetes
+
+[master-blocking]: https://testgrid.k8s.io/sig-release-master-blocking#Summary
+[master-informing]: https://testgrid.k8s.io/sig-release-master-informing#Summary
+[1.27-blocking]: https://testgrid.k8s.io/sig-release-1.27-blocking#Summary
+
+[exception requests]: ../EXCEPTIONS.md
+[release phases document]: ../release_phases.md

--- a/releases/release-1.28/exceptions.yaml
+++ b/releases/release-1.28/exceptions.yaml
@@ -1,0 +1,78 @@
+# Exception requests in 1.27
+# Google Group: https://groups.google.com/g/kubernetes-sig-release
+# Release Team Lead: Xander Grzywinski ([@salaxander](https://github.com/salaxander))
+# Release Team Shadows : Kat Cosgrove ([@katcosgrove](https://github.com/katcosgrove))
+# / Priyanka Saggu ([@Priyankasaggu11929](https://github.com/Priyankasaggu11929))
+# / Heba Elayoty ([@helayoty](https://github.com/helayoty))
+# / Hossein Salahi ([@hosseinsalahi](https://github.com/hosseinsalahi))
+
+# Enhancements Freeze Exceptions requested in 1.27
+enhancementFreeze:
+
+# None!
+
+# Code Freeze Exceptions requested in 1.27
+
+codeFreeze:
+
+- name: "Retriable and non-retriable Pod failures for Jobs"
+  issue: 3329
+  date_requested: 2023-03-13
+  date_reviewed: 2023-03-13
+  thread: "https://groups.google.com/u/0/g/kubernetes-sig-release/c/8hY9EZRQjNk"
+  pull_requests:
+    - "https://github.com/kubernetes/kubernetes/pull/115331"
+  status: "approved"
+
+- name: "In-place Update of Pod Resources"
+  issue: 1287
+  date_requested: 2023-03-14
+  date_reviewed: 2023-03-14
+  thread: "https://groups.google.com/u/0/g/kubernetes-sig-release/c/TAwJ6IijEoI"
+  pull_requests:
+    - "https://github.com/kubernetes/kubernetes/pull/116504"
+    - "https://github.com/kubernetes/kubernetes/pull/116119"
+    - "https://github.com/kubernetes/kubernetes/pull/116628"
+    - "https://github.com/kubernetes/kubernetes/pull/116631"
+    - "https://github.com/kubernetes/kubernetes/pull/116575"
+  status: "approved"
+
+- name: "cloud dual-stack node IPs"
+  issue: 3705 
+  date_requested: 2023-03-15
+  date_reviewed: 2023-03-15
+  thread: "https://groups.google.com/u/0/g/kubernetes-sig-release/c/EJxmkws_SQ8"
+  pull_requests:
+    - "https://github.com/kubernetes/kubernetes/pull/116305"
+  status: "approved"
+
+- name: "AdmissionWebhookMatchConditions"
+  issue: 3716
+  date_requested: 2023-03-14
+  date_reviewed: 2023-03-14
+  thread: "https://groups.google.com/u/0/g/kubernetes-sig-release/c/N2kwnN0kFBA"
+  pull_requests:
+    - "https://github.com/kubernetes/kubernetes/pull/116261"
+    - "https://github.com/kubernetes/kubernetes/pull/116350"
+  status: "approved"
+
+  
+- name: "CELValidatingAdmission"
+  issue: 3488
+  date_requested: 2023-03-14
+  date_reviewed: 2023-03-14
+  thread: "https://groups.google.com/u/0/g/kubernetes-sig-release/c/N2kwnN0kFBA"
+  pull_requests:
+    - "https://github.com/kubernetes/kubernetes/pull/116261"
+    - "https://github.com/kubernetes/kubernetes/pull/116350"
+  status: "approved"
+
+  
+- name: "ClusterTrustBundles"
+  issue: 3257
+  date_requested: 2023-03-16
+  date_reviewed: 2023-03-16
+  thread: "https://groups.google.com/u/0/g/kubernetes-sig-release/c/kkA4F4LvMrM"
+  pull_requests:
+    - "https://github.com/kubernetes/kubernetes/pull/113218"
+  status: "approved"

--- a/releases/release-1.28/exceptions.yaml
+++ b/releases/release-1.28/exceptions.yaml
@@ -1,78 +1,13 @@
-# Exception requests in 1.27
+# Exception requests in 1.28
 # Google Group: https://groups.google.com/g/kubernetes-sig-release
-# Release Team Lead: Xander Grzywinski ([@salaxander](https://github.com/salaxander))
-# Release Team Shadows : Kat Cosgrove ([@katcosgrove](https://github.com/katcosgrove))
-# / Priyanka Saggu ([@Priyankasaggu11929](https://github.com/Priyankasaggu11929))
+# Release Team Lead: Grace Nguyen ([@gracenng](https://github.com/gracenng)
+# Release Team Shadows : Angelos Kolaitis ([@neoaggelos](https://github.com/neoaggelos))
 # / Heba Elayoty ([@helayoty](https://github.com/helayoty))
-# / Hossein Salahi ([@hosseinsalahi](https://github.com/hosseinsalahi))
+# / Mark Rossetti ([@marosset](https://github.com/marosset))
+# / Mickey Boxell ([@mickeyboxell](https://github.com/mickeyboxell))
 
-# Enhancements Freeze Exceptions requested in 1.27
+# Enhancements Freeze Exceptions requested in 1.28
 enhancementFreeze:
 
-# None!
 
-# Code Freeze Exceptions requested in 1.27
-
-codeFreeze:
-
-- name: "Retriable and non-retriable Pod failures for Jobs"
-  issue: 3329
-  date_requested: 2023-03-13
-  date_reviewed: 2023-03-13
-  thread: "https://groups.google.com/u/0/g/kubernetes-sig-release/c/8hY9EZRQjNk"
-  pull_requests:
-    - "https://github.com/kubernetes/kubernetes/pull/115331"
-  status: "approved"
-
-- name: "In-place Update of Pod Resources"
-  issue: 1287
-  date_requested: 2023-03-14
-  date_reviewed: 2023-03-14
-  thread: "https://groups.google.com/u/0/g/kubernetes-sig-release/c/TAwJ6IijEoI"
-  pull_requests:
-    - "https://github.com/kubernetes/kubernetes/pull/116504"
-    - "https://github.com/kubernetes/kubernetes/pull/116119"
-    - "https://github.com/kubernetes/kubernetes/pull/116628"
-    - "https://github.com/kubernetes/kubernetes/pull/116631"
-    - "https://github.com/kubernetes/kubernetes/pull/116575"
-  status: "approved"
-
-- name: "cloud dual-stack node IPs"
-  issue: 3705 
-  date_requested: 2023-03-15
-  date_reviewed: 2023-03-15
-  thread: "https://groups.google.com/u/0/g/kubernetes-sig-release/c/EJxmkws_SQ8"
-  pull_requests:
-    - "https://github.com/kubernetes/kubernetes/pull/116305"
-  status: "approved"
-
-- name: "AdmissionWebhookMatchConditions"
-  issue: 3716
-  date_requested: 2023-03-14
-  date_reviewed: 2023-03-14
-  thread: "https://groups.google.com/u/0/g/kubernetes-sig-release/c/N2kwnN0kFBA"
-  pull_requests:
-    - "https://github.com/kubernetes/kubernetes/pull/116261"
-    - "https://github.com/kubernetes/kubernetes/pull/116350"
-  status: "approved"
-
-  
-- name: "CELValidatingAdmission"
-  issue: 3488
-  date_requested: 2023-03-14
-  date_reviewed: 2023-03-14
-  thread: "https://groups.google.com/u/0/g/kubernetes-sig-release/c/N2kwnN0kFBA"
-  pull_requests:
-    - "https://github.com/kubernetes/kubernetes/pull/116261"
-    - "https://github.com/kubernetes/kubernetes/pull/116350"
-  status: "approved"
-
-  
-- name: "ClusterTrustBundles"
-  issue: 3257
-  date_requested: 2023-03-16
-  date_reviewed: 2023-03-16
-  thread: "https://groups.google.com/u/0/g/kubernetes-sig-release/c/kkA4F4LvMrM"
-  pull_requests:
-    - "https://github.com/kubernetes/kubernetes/pull/113218"
-  status: "approved"
+# Code Freeze Exceptions requested in 1.28

--- a/releases/release-1.28/release-team.md
+++ b/releases/release-1.28/release-team.md
@@ -2,7 +2,7 @@
 
 | **Team/Role** | **Lead Name** (**GitHub / Slack ID**) | **Shadow Name(s) (GitHub / Slack ID)** |
 |----------|----------------------------------|----------------------------------------|
-| Release Team Lead | Grace Nguyen ([@gracenng](https://github.com/gracenng) / Slack: `@Grace Nguyen`) | Angelos Kolaitis ([@neoaggelos](https://github.com/neoaggelos)/ Slack: `@Angelos Kolaitis`), Heba Elayoty ([@helayoty](https://github.com/helayoty) / Slack: `@helayoty`), Mark Rossetti ([@marosset](https://github.com/marosset) / Slack: `@Mark Rossetti`), Mickey Boxell ([@mickeyboxell](https://github.com/mickeyboxell)|
+| Release Team Lead | Grace Nguyen ([@gracenng](https://github.com/gracenng) / Slack: `@Grace Nguyen`) | Angelos Kolaitis ([@neoaggelos](https://github.com/neoaggelos)/ Slack: `@Angelos Kolaitis`), Heba Elayoty ([@helayoty](https://github.com/helayoty) / Slack: `@helayoty`), Mark Rossetti ([@marosset](https://github.com/marosset) / Slack: `@Mark Rossetti`), Mickey Boxell ([@mickeyboxell](https://github.com/mickeyboxell))|
 | Emeritus Adviser | Leonard Pahlke ([@leonardpahlke](https://github.com/leonardpahlke) / Slack: `@leonardpahlke`) | N/A |
 | Enhancements | Atharva Shinde ([@Atharva-Shinde](https://github.com/Atharva-Shinde) / Slack: `@Atharva-Shinde`) | |
 | Release Notes | Sanchita Mishra ([@sanchita-07](https://github.com/sanchita-07) / Slack: `@Sanchita Mishra`) | |

--- a/releases/release-1.28/release-team.md
+++ b/releases/release-1.28/release-team.md
@@ -1,0 +1,17 @@
+# Kubernetes 1.28 Release Team
+
+| **Team/Role** | **Lead Name** (**GitHub / Slack ID**) | **Shadow Name(s) (GitHub / Slack ID)** |
+|----------|----------------------------------|----------------------------------------|
+| Release Team Lead | Grace Nguyen ([@gracenng](https://github.com/gracenng) / Slack: `@Grace Nguyen`) | Angelos Kolaitis ([@neoaggelos](https://github.com/neoaggelos)/ Slack: `@Angelos Kolaitis`), Heba Elayoty ([@helayoty](https://github.com/helayoty) / Slack: `@helayoty`), Mark Rossetti ([@marosset](https://github.com/marosset) / Slack: `@Mark Rossetti`), Mickey Boxell ([@mickeyboxell](https://github.com/mickeyboxell)|
+| Emeritus Adviser | Leonard Pahlke ([@leonardpahlke](https://github.com/leonardpahlke) / Slack: `@leonardpahlke`) | N/A |
+| Enhancements | Atharva Shinde ([@Atharva-Shinde](https://github.com/Atharva-Shinde) / Slack: `@Atharva-Shinde`) | |
+| Release Notes | Sanchita Mishra ([@sanchita-07](https://github.com/sanchita-07) / Slack: `@Sanchita Mishra`) | |
+| Communications | Brad McCoy ([@bradmccoydev](https://github.com/bradmccoydev) / Slack: `@Brad McCoy` ) | |
+| Bug Triage | Furkat Gofurov ([@furkatgofurov7](https://github.com/furkatgofurov7) / Slack: `@Furkat Gofurov`) | |
+| CI Signal | Meha Bhalodiya ([@mehabhalodiya](https://github.com/mehabhalodiya) / Slack: `@Meha Bhalodiya`) | |
+| Docs | Rishit Dagli ([@Rishit-dagli](https://github.com/Rishit-dagli) / Slack: `@Rishit Dagli`) | |
+| Branch Manager | | |
+
+Review the [Release Managers page](https://github.com/kubernetes/website/blob/main/content/en/releases/release-managers.md) for up-to-date contact information on Release Engineering personnel.
+
+The schedule for all patch releases can be found at [Patch Releases page](https://github.com/kubernetes/website/blob/main/content/en/releases/patch-releases.md). It will be updated to include 1.28, once the 1.28 release cycle concludes.


### PR DESCRIPTION

#### What type of PR is this:
/kind documentation


#### What this PR does / why we need it:
Commencing 1.28 documentation including timeline and leads

/assign @kubernetes/sig-release-leads @leonardpahlke
