### PR TITLE
clarify existing policy: release blocking jobs must only depend on community resources

### DIFF
--- a/release-blocking-jobs.md
+++ b/release-blocking-jobs.md
@@ -47,6 +47,7 @@ meet the below criteria completely due to technical debt.  Blocking jobs must:
 - Run at least every 3 hours
 - Be able to pass 3 times in a row against the same commit
 - Be Owned by a SIG, or other team, that is responsive to addressing failures, and whose alert email is configured in the job.
+- Depend on accounts and resources owned by The Kubernetes Project through SIG K8s Infra, so the project has visibility into funding and management of resources
 - Have passed 75% of all of its runs in a week, and have failed for no more than 10 runs in a row
 
 *In the case of failures, there must be an issue in kubernetes/kubernetes


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this:

<!--
Add one of the following kinds:
/kind cleanup
/kind documentation
/kind feature
/kind design
-->

/kind documentation

#### What this PR does / why we need it:

AFAICT this has been the defacto policy for some time now, however we've not clearly stated it here.

This is an important requirement that avoids serious surprise issue like https://github.com/kubernetes/test-infra/issues/10043 (where we suddenly ran out of AWS quota pre-SIG-K8s-infra credits management and had to pull kops-AWS from kubernetes PR and release blocking jobs suddenly mid-release and never recovered this test coverage)

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #
or
None
-->

#### Special notes for your reviewer:

/sig release
/sig k8s-infra
/sig testing