### PR TITLE
Document PR blocking job requirements

### DIFF
--- a/release-blocking-jobs.md
+++ b/release-blocking-jobs.md
@@ -155,3 +155,23 @@ The general process to promote or demote jobs follows these steps:
 
 1. Open a kubernetes/test-infra PR that promotes or demotes the job to/from any
    of the sig-release boards.
+
+## Pull Request Blocking Jobs
+
+Blocking contributor PRs from merging is a serious consideration 
+and running a job on every PR push is expensive and potentially disruptive for
+contributors.
+Only after a job has met release blocking status AND shown to frequently go red 
+from bad code changes in Kubernetes should a job also be added to required on 
+all Kubernetes Pull Requests.
+
+When doing so you should contact SIG Testing and Release leads to discuss and
+provide evidence of the issues we've root caused that should've been caught prior
+to merge, and why existing presubmit coverage is not sufficient including new
+test cases within existing PR-blocking jobs (e.g. new unit and integreation tests)
+to regression test these bugs.
+
+If we catch a breakage in release-blocking but not PR blocking at most
+a few times per release, release-blocking is working as intended.
+Only when something is so poorly covered by presubmit that it breaks frequently
+should we escalate to requiring another PR-blocking job.

--- a/release-blocking-jobs.md
+++ b/release-blocking-jobs.md
@@ -47,6 +47,7 @@ meet the below criteria completely due to technical debt.  Blocking jobs must:
 - Run at least every 3 hours
 - Be able to pass 3 times in a row against the same commit
 - Be Owned by a SIG, or other team, that is responsive to addressing failures, and whose alert email is configured in the job.
+- Depend on accounts and resources owned by The Kubernetes Project through SIG K8s Infra, so the project has visibility into funding and management of resources
 - Have passed 75% of all of its runs in a week, and have failed for no more than 10 runs in a row
 
 *In the case of failures, there must be an issue in kubernetes/kubernetes


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this:

<!--
Add one of the following kinds:
/kind cleanup
/kind documentation
/kind feature
/kind design
-->

/kind documentatino

#### What this PR does / why we need it:

The current status quo is that SIG Testing owners of Prow config have informally enforced this every since the introduction of the "release blocking jobs" document, but we've not had a good place to document it. We've been over this many times in slack, github issues, etc., but never captured it properly.

The obvious move is to just append this detail to the release blocking jobs document.

PR blocking jobs already have all of the requirements of release-blocking and the additional requirement that there be high-value in blocking PRs instead of only blocking releases (due to frequent breakage and the high cost of keeping the release blocking signal green without PR coverage, if such a cost exists).



#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #
or
None
-->

#### Special notes for your reviewer:

Builds on https://github.com/kubernetes/sig-release/pull/2229


/sig testing
/sig release
/sig k8s-infra