### PR TITLE
🐛  Add missing lead shadow slack handle to the 1.28 release team doc

### DIFF
--- a/releases/release-1.28/release-team.md
+++ b/releases/release-1.28/release-team.md
@@ -2,7 +2,7 @@
 
 | **Team/Role** | **Lead Name** (**GitHub / Slack ID**) | **Shadow Name(s) (GitHub / Slack ID)** |
 |----------|----------------------------------|----------------------------------------|
-| Release Team Lead | Grace Nguyen ([@gracenng](https://github.com/gracenng) / Slack: `@Grace Nguyen`) | Angelos Kolaitis ([@neoaggelos](https://github.com/neoaggelos)/ Slack: `@Angelos Kolaitis`), Heba Elayoty ([@helayoty](https://github.com/helayoty) / Slack: `@helayoty`), Mark Rossetti ([@marosset](https://github.com/marosset) / Slack: `@Mark Rossetti`), Mickey Boxell ([@mickeyboxell](https://github.com/mickeyboxell))|
+| Release Team Lead | Grace Nguyen ([@gracenng](https://github.com/gracenng) / Slack: `@Grace Nguyen`) | Angelos Kolaitis ([@neoaggelos](https://github.com/neoaggelos) / Slack: `@Angelos Kolaitis`), Heba Elayoty ([@helayoty](https://github.com/helayoty) / Slack: `@helayoty`), Mark Rossetti ([@marosset](https://github.com/marosset) / Slack: `@Mark Rossetti`), Mickey Boxell ([@mickeyboxell](https://github.com/mickeyboxell) /  Slack: `@Mickey`) |
 | Emeritus Adviser | Leonard Pahlke ([@leonardpahlke](https://github.com/leonardpahlke) / Slack: `@leonardpahlke`) | N/A |
 | Enhancements | Atharva Shinde ([@Atharva-Shinde](https://github.com/Atharva-Shinde) / Slack: `@Atharva-Shinde`) | |
 | Release Notes | Sanchita Mishra ([@sanchita-07](https://github.com/sanchita-07) / Slack: `@Sanchita Mishra`) | |


### PR DESCRIPTION
Signed-off by: Furkat Gofurov (furkat.gofurov@suse.com)

<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this:
/kind documentation
<!--
Add one of the following kinds:
/kind cleanup
/kind documentation
/kind feature
/kind design
-->

#### What this PR does / why we need it:
Add missing slack handle for Release Lead shadow @mickeyboxell in the 1.28 RT document

#### Special notes for your reviewer:
Noticed it when working on https://github.com/kubernetes/sig-release/pull/2231