### PR TITLE
Add comms shadows for 1.28 release team

### DIFF
--- a/releases/release-1.28/release-team.md
+++ b/releases/release-1.28/release-team.md
@@ -6,7 +6,7 @@
 | Emeritus Adviser | Leonard Pahlke ([@leonardpahlke](https://github.com/leonardpahlke) / Slack: `@leonardpahlke`) | N/A |
 | Enhancements | Atharva Shinde ([@Atharva-Shinde](https://github.com/Atharva-Shinde) / Slack: `@Atharva-Shinde`) | |
 | Release Notes | Sanchita Mishra ([@sanchita-07](https://github.com/sanchita-07) / Slack: `@Sanchita Mishra`) | |
-| Communications | Brad McCoy ([@bradmccoydev](https://github.com/bradmccoydev) / Slack: `@Brad McCoy` ) | |
+| Communications | Brad McCoy ([@bradmccoydev](https://github.com/bradmccoydev) / Slack: `@Brad McCoy` ) | Carolina Valencia ([@krol](https://github.com/krol3) / Slack: `@krol`), Maria Ashby ([@mashby2022](https://github.com/mashby2022) / Slack: `@Maria Ashby`), Rodolfo Martínez Vega ([@ramrodo](https://github.com/ramrodo) / Slack: `@ramrodo`), Thomas Schuetz ([@thschue](https://github.com/thschue) / Slack: `@thschue`) |
 | Bug Triage | Furkat Gofurov ([@furkatgofurov7](https://github.com/furkatgofurov7) / Slack: `@Furkat Gofurov`) | Anhelina Zelyk ([zelenushechka](https://github.com/zelenushechka) / Slack: `@Anhelina`), Mofi Rahman ([moficodes](https://github.com/moficodes) / Slack: `@mofi`), Parthvi Vala ([valaparthvi](https://github.com/valaparthvi) / Slack: `@valaparthvi`), Yigit Demirbas ([hailkomputer](https://github.com/hailkomputer) / Slack: `@Yigit Demirbas`) |
 | CI Signal | Meha Bhalodiya ([@mehabhalodiya](https://github.com/mehabhalodiya) / Slack: `@Meha Bhalodiya`) | |
 | Docs | Rishit Dagli ([@Rishit-dagli](https://github.com/Rishit-dagli) / Slack: `@Rishit Dagli`) | |


### PR DESCRIPTION
What type of PR is this:
/kind documentation

What this PR does / why we need it:
Adding 1.28 Bug Triage shadows to the RT document

Signed-off by: Brad McCoy([bradmccoydev@gmail.com](mailto:bradmccoydev@gmail.com))