### PR TITLE
fix: use dl.k8s.io, not kubernetes-release bucket

### DIFF
--- a/release-engineering/role-handbooks/branch-manager.md
+++ b/release-engineering/role-handbooks/branch-manager.md
@@ -174,10 +174,10 @@ This can be done in one of two ways:
 - The `krel announce` sub command -- A [`SENDGRID_API_KEY`](https://sendgrid.com/docs/ui/account-and-settings/api-keys) will need to be configured correctly on your environment for this to work
   - If you haven't used SendGrid before, SendGrid might require you to go through the [Sender Identity Verification process][sendgrid-identity-verification] before you can send emails/announcements
 - Manually -- Send the email notification manually to [kubernetes-announce][k-announce-list] and [kubernetes-dev][k-dev-list]. You can take contents of the announcement in one of the following ways:
-  - By taking the contents from the Google Cloud Bucket: `gs://kubernetes-release/archive/anago-vX.Y.0-{alpha,beta,rc}.z`:
+  - By taking the contents from the Release Cloud Bucket: `https://dl.k8s.io/archive/anago-vX.Y.0-{alpha,beta,rc}.z/{announcement-subject.txt,announcement.html}`:
   - By using `krel announce` command with the `--print-only` flag
-  - [Example subject](https://gcsweb.k8s.io/gcs/kubernetes-release/archive/anago-v1.17.0-rc.2/announcement-subject.txt)
-  - [Example body](https://gcsweb.k8s.io/gcs/kubernetes-release/archive/anago-v1.17.0-rc.2/announcement.html)
+  - [Example subject](https://dl.k8s.io/archive/anago-v1.27.0-rc.1/announcement-subject.txt)
+  - [Example body](curl -L https://dl.k8s.io/archive/anago-v1.27.0-rc.1/announcement.html)
 
 ```shell
 # Only for the official release: Inform the Google team to complete the corresponding Deb and RPM builds and confirm with them whether Debian and RPM repositories have the packages before sending the email

--- a/release-team/role-handbooks/ci-signal/upgrade-job-versions.md
+++ b/release-team/role-handbooks/ci-signal/upgrade-job-versions.md
@@ -39,23 +39,23 @@ aka trust the CI
 ci/foo versions live in k8s-release-dev:
 ```shell
 $ for suffix in beta stable1 stable2 stable3; do
-  echo ci/k8s-$suffix: $(gsutil cat gs://k8s-release-dev/ci/k8s-$suffix.txt);
+  echo ci/k8s-$suffix: $(curl -sL https://dl.k8s.io/ci/k8s-$suffix.txt);
 done
 
-ci/k8s-beta: v1.12.0-beta.1.129+1d58f1aebfe1e3
-ci/k8s-stable1: v1.11.3-beta.0.71+a4529464e4629c
-ci/k8s-stable2: v1.10.8-beta.0.33+a963fce72fed31
-ci/k8s-stable3: v1.9.11-beta.0.36+06bf888123ca89
+ci/k8s-beta: v1.27.1-19+237d7362345728
+ci/k8s-stable1: v1.27.1-89+2555e0f90e80a1
+ci/k8s-stable2: v1.26.4-64+8b09b36478f65c
+ci/k8s-stable3: v1.25.9-45+0a7c2a9ad8e0c4
 ```
 
-release/foo versions live in kubernetes-release:
+release/foo versions live in kubernetes release:
 ```shell
 $ for prefix in latest stable; do
-  echo release/$prefix-1.11: $(gsutil cat gs://kubernetes-release/release/$prefix-1.11.txt)
-  done
+  echo release/$prefix-1.23: $(curl -sL https://dl.k8s.io/release/$prefix-1.23.txt)
+done
 
-release/latest-1.11: v1.11.4-beta.0
-release/stable-1.11: v1.11.3
+release/latest-1.26: v1.23.18-rc.0
+release/stable-1.26: v1.23.17
 ```
 references:
 - https://github.com/kubernetes/test-infra#release-branch-jobs--image-validation-jobs


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
There are still references to https://storage.googleapis.com/kubernetes-release instead of https://dl.k8s.io/

dl.k8s.io is the correct advertised download host and will eventually move to be fastly shielding a fully community-owned bucket

ref: https://github.com/kubernetes/k8s.io/issues/2396