### PR TITLE
Add experience to diversity list in team selection

### DIFF
--- a/release-team/release-team-selection.md
+++ b/release-team/release-team-selection.md
@@ -39,6 +39,7 @@ Most importantly, strive for diversity in:
 - nationality
 - locality
 - company affiliation
+- experience
 
 ## Selection Criteria
 


### PR DESCRIPTION
#### What type of PR is this:

/kind documentation

#### What this PR does / why we need it:
This PR will add experience to the diversity list in the release team selection to raise awareness for when leads select people that this is a mentorship program and we should also strive to have different levels of experience throughout the teams as discussed in a Slack thread of the team leads.
