### PR TITLE
List container image for kubectl

### DIFF
--- a/release-engineering/artifacts.md
+++ b/release-engineering/artifacts.md
@@ -7,6 +7,7 @@
 | kube-controller-manager | ✅  |  ✅   |  ✅   |   ✅    |  ✅   |
 | kube-proxy              | ✅  |  ✅   |  ✅   |   ✅    |  ✅   |
 | kube-scheduler          | ✅  |  ✅   |  ✅   |   ✅    |  ✅   |
+| kubectl                 | ✅  |  ✅   |  ✅   |   ✅    |  ✅   |
 
 ## Storage
 


### PR DESCRIPTION
Starting 1.28, a standalone image for `kubectl` will be released as part of the official images.

#### What type of PR is this:

/kind documentation


#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #
or
None
-->

#### Special notes for your reviewer:
