### PR TITLE
remove tombstoned docs

### DIFF
--- a/release-team/role-handbooks/test-infra/OWNERS
+++ b/release-team/role-handbooks/test-infra/OWNERS
@@ -1,7 +1,0 @@
-# See the OWNERS docs at https://go.k8s.io/owners
-
-approvers:
-  - release-engineering-approvers
-reviewers:
-  - release-engineering-approvers
-  - release-engineering-reviewers

--- a/release-team/role-handbooks/test-infra/README.md
+++ b/release-team/role-handbooks/test-infra/README.md
@@ -1,8 +1,0 @@
-The Test Infra role was deprecated at the end of the Kubernetes 1.15 release cycle.
-Beginning with the Kubernetes 1.16 release cycle, the duties of the Test Infra role have been spread across the following:
-- Release Managers, specifically to the [Branch Manager](/release-engineering/role-handbooks/branch-manager.md)
-- [Test Infra On-call (SIG Testing)](https://go.k8s.io/oncall) (#testing-ops and #sig-testing on Slack)
-
-<!--
-This file is a placeholder to preserve links.  Please remove after 3 months or the release of Kubernetes 1.16, whichever comes first.
--->

--- a/releases/patch-releases.md
+++ b/releases/patch-releases.md
@@ -1,4 +1,0 @@
-This file has moved to https://git.k8s.io/website/content/en/releases/patch-releases.md.
-
-This file is a placeholder to preserve links.
-Please remove after 2021-12-31.


### PR DESCRIPTION
There are a couple well aged placeholders.  They're past their intended timeline and should be removed.

/kind cleanup
/kind documentation