### PR TITLE
Add updating schedule.yaml as a release cut step

### DIFF
--- a/.github/ISSUE_TEMPLATE/cut-release.md
+++ b/.github/ISSUE_TEMPLATE/cut-release.md
@@ -91,6 +91,7 @@ Help? Ring @release-managers on slack!
 - [ ] Publish packages (debs & rpms) <!-- REMOVE THIS STEP FOR PRE-RELEASES -->
 - [ ] Notify #release-management: <!-- Paste link to slack -->
 - [ ] Send notification: <!-- Paste link to kubernetes-dev email -->
+- [ ] Update [`schedule.yaml` file](https://github.com/kubernetes/website/blob/main/data/releases/schedule.yaml) with the latest release <!-- Paste Pull Request URL here -->
 - [ ] Collect metrics and add them to the `Release steps` table below
 <!-- ONLY FOR RC.0 RELEASE - [ ] Finish post-release branch creation tasks -->
 


### PR DESCRIPTION
#### What type of PR is this:

/kind documentation

#### What this PR does / why we need it:

This task tends to get forgotten from time to time which causes confusion for the end users. Adding it to the task list should serve as a reminder so that we don't forget about this after cutting the release.

#### Which issue(s) this PR fixes:

xref https://kubernetes.slack.com/archives/C2C40FMNF/p1690472726609569

/assign @saschagrunert @Verolop @cpanato 
cc @kubernetes/release-engineering 