### PR TITLE
[1.29] Update release-team-* in OWNER_ALIAS

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -22,15 +22,14 @@ aliases:
     - jrsapi # Release Manager Associate
     - salaxander # Release Manager Associate
   release-team:
-    - cici37 # subproject owner
+    - cici37 # subproject owner/ 1.25 Release Team Lead
     - cpanato # subproject owner
     - gracenng # subproject owner / 1.28 Release Team Lead
-    - jameslaverack # subproject owner / 1.24 Release Team Lead
     - jeremyrickard # subproject owner
     - justaugustus # subproject owner
     - leonardpahlke # subproject owner / 1.26 Release Team Lead
+    - Priyankasaggu11929 # subproject owner / Kubernetes 1.29 Release Lead
     - puerco # subproject owner
-    - reylejano # subproject owner / 1.23 Release Team Lead
     - salaxander # subproject owner / 1.27 Release Team Lead
     - saschagrunert # subproject owner
   build-admins:
@@ -41,43 +40,42 @@ aliases:
   release-team-lead-role:
     - cici37 # Kubernetes 1.25 Release Lead
     - gracenng # Kubernetes 1.28 Release Lead
-    - jameslaverack # Kubernetes 1.24 Release Lead
     - leonardpahlke # Kubernetes 1.26 Release Lead
-    - reylejano # Kubernetes 1.23 Release Lead
+    - Priyankasaggu11929 # Kubernetes 1.29 Release Lead
     - salaxander # Kubernetes 1.27 Release Lead
   ci-signal-role:
-    - hosseinsalahi # 1.23
     - lauralorenz # 1.27
-    - leonardpahlke # 1.24
+    - mehabhalodiya # 1.28
     - Nivedita-coder # 1.26
     - RinkiyaKeDad # 1.25
+    - Vyom-Yadav # 1.29
   enhancements-role:
-    - gracenng # 1.24
+    - Atharva-Shinde # 1.28
     - marosset # 1.27
+    - npolshakova # 1.29
     - Priyankasaggu11929 # 1.25
     - rhockenbury # 1.26
-    - salaxander # 1.23
   bug-triage-role:
+    - furkatgofurov7 # 1.28
+    - hailkomputer # 1.29
     - helayoty # 1.25
     - hosseinsalahi # 1.26
-    - jyotimahapatra # 1.24
     - neoaggelos # 1.27
-    - voigt # 1.23
   docs-role:
-    - jlbutler # 1.23
+    - katcosgrove # 1.29
     - kcmartin # 1.25
     - krol3 # 1.26
     - mickeyboxell # 1.27
-    - nate-double-u # 1.24
+    - Rishit-dagli # 1.28
   release-notes-role:
-    - AuraSinis # 1.24
-    - cici37 # 1.23
     - csantanapr # 1.25
+    - fsmunoz # 1.29
     - harshanarayana # 1.27
     - ramrodo # 1.26
+    - sanchita-07 # 1.28
   communications-role:
+    - bradmccoydev # 1.28
     - fsmunoz # 1.26
     - harshitasao # 1.27
-    - karenhchu # 1.23
     - katcosgrove # 1.25
-    - mickeyboxell # 1.24
+    - krol3 # 1.29


### PR DESCRIPTION
Part of https://github.com/kubernetes/sig-release/issues/2329

#### What type of PR is this:

/kind cleanup
/priority important-soon

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

This PR:
- updates OWNER_ALISES for the 1.29 RT
- clean up entries for RT 1.23, 1.24 which are EOL

cc: @kubernetes/release-team-leads, @salaxander 