### PR TITLE
Remove publishing packages from the release cut template

### DIFF
--- a/.github/ISSUE_TEMPLATE/cut-release.md
+++ b/.github/ISSUE_TEMPLATE/cut-release.md
@@ -54,12 +54,6 @@ Notify #release-management on Slack:
 Announce the release in a message in the Channel and paste the link
 Direct link to slack: https://kubernetes.slack.com/messages/CJH2GBF7Y
 
-Publish packages (skip for prereleases):
-Coordinate with @google-build-admin before starting. Once the
-NoMock Release is done (which builds the packages to the production bucket) and
-**before sending the announcement** notify @google-build-admin to start
-publishing the packages.
-
 Send notification:
 Use `krel announce` using your Sendgrid token
 http://bit.ly/relmanagers-handbook#sending-mail
@@ -88,7 +82,6 @@ Help? Ring @release-managers on slack!
   - [ ] Stage
   - [ ] Image Promotion: <!-- Paste Pull Request URL here -->
   - [ ] Release
-- [ ] Publish packages (debs & rpms) <!-- REMOVE THIS STEP FOR PRE-RELEASES -->
 - [ ] Notify #release-management: <!-- Paste link to slack -->
 - [ ] Send notification: <!-- Paste link to kubernetes-dev email -->
 - [ ] Update [`schedule.yaml` file](https://github.com/kubernetes/website/blob/main/data/releases/schedule.yaml) with the latest release <!-- Paste Pull Request URL here -->


### PR DESCRIPTION
#### What type of PR is this:

/kind cleanup
/kind documentation

#### What this PR does / why we need it:

Packages are published automatically by krel so `Publishing packages` step is not needed any longer. We also publish packages for prereleases (alpha/beta/rc).

/assign @saschagrunert @cpanato @Verolop @jeremyrickard 
cc @kubernetes/release-engineering 