### PR TITLE
update 1.29 release date to Dec 13, 2023

### DIFF
--- a/releases/release-1.29/README.md
+++ b/releases/release-1.29/README.md
@@ -16,6 +16,9 @@ This release is inspired by the beautiful art form that is Mandala—a symbol of
 
 In the spirit of Mandala’s transformative symbolism, Kubernetes 1.29 celebrates our project’s evolution. Like stars in the Kubernetes universe, each contributor, user, and supporter lights the way. Together, we create a universe of possibilities—one release at a time.
 
+The release logo, made by [Mario Jason Braganza](https://janusworx.com) (base Mandala art, courtesy - [Fibrel Ojalá](https://pixabay.com/users/fibrel-3502541/)), symbolizes the little universe that is the Kubernetes project and all its people.
+
+
 #### Links
 
 * [This document](https://git.k8s.io/sig-release/releases/release-1.29/README.md)
@@ -90,10 +93,11 @@ The 1.29 release cycle is as follows:
 | Major Themes complete                                                                  | Release Notes Lead            | Tuesday 28th November 2023                                                                                            | week 13  |                                                        |
 | Docs complete — All PRs reviewed and ready to merge                                    | Docs Lead                     | Tuesday 28th November 2023                                                                                            | week 13  |                                                        |
 | 1.29.0-rc.1 released                                                                   | Branch Manager                | Tuesday 28th November 2023                                                                                            | week 13  |                                                        |
-| Release Notes complete — reviewed & merged to https://github.com/kubernetes/kubernetes | Release Notes Lead            | Tuesday 5th December, 2023                                                                                            | week 14  |                                                        |
-| **v1.29.0 released**                                                                   | Branch Manager                | Tuesday 5th December 2023                                                                                             | week 14  |                                                        |
-| Release blog published                                                                 | Comms                         | Tuesday 5th December 2023                                                                                             | week 14  |                                                        |
-| **[Thaw]**                                                                             | Branch Manager                | Tuesday 5th December 2023                                                                                             | week 14  |                                                        |
+| 1.29.0-rc.2 released                                                                   | Branch Manager                | Thursday 7th December 2023                                                                                            | week 14  | [1.29-blocking], [master-blocking], [master-informing] |
+| Release Notes complete — reviewed & merged to https://github.com/kubernetes/kubernetes | Release Notes Lead            | Wednesday 13th December 2023                                                                                          | week 15  |                                                        |
+| **v1.29.0 released**                                                                   | Branch Manager                | Wednesday 13th December 2023                                                                                          | week 15  |                                                        |
+| Release blog published                                                                 | Comms                         | Wednesday 13th December 2023                                                                                          | week 15  |                                                        |
+| **[Thaw]**                                                                             | Branch Manager                | Wednesday 13th December 2023                                                                                          | week 15  |                                                        |
 
 ## Phases
 


### PR DESCRIPTION
#### What type of PR is this:

/kind cleanup
/kind documentation

#### What this PR does / why we need it:

Due to the upcoming security release of go1.21.5 and go1.20.12, SIG Release Leads and 1.29 Release Team have made the [decision to postpone](https://kubernetes.slack.com/archives/C2C40FMNF/p1701393571230529?thread_ts=1701372168.588369&cid=C2C40FMNF) the release of Kubernetes v1.29.0 until Wednesday, December 13th.

This will afford the team time to integrate the new Golang version and give it a few days to soak across CI.

- [[ANNOUNCE] Kubernetes v1.29.0 release and December patch releases will be delayed](https://groups.google.com/g/kubernetes-announce/c/uyO3QrJnf90/m/ih_j1q0QAgAJ)
- [[security] Go 1.21.5 and Go 1.20.12 pre-announcement](https://groups.google.com/g/golang-announce/c/TABUsV4-FiU/m/cajfhO09AgAJ)

