### PR TITLE
Update release manager onboarding template

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-manager.md
+++ b/.github/ISSUE_TEMPLATE/release-manager.md
@@ -39,6 +39,7 @@ e.g., permanent, temporary
     - [#release-management](https://kubernetes.slack.com/messages/CJH2GBF7Y)
   - [ ] Is a [Kubernetes GitHub org member](https://github.com/kubernetes/community/blob/master/community-membership.md#member)
 - [ ] Update [Release Managers](https://git.k8s.io/website/content/en/releases/release-managers.md) page to include the new Release Manager
+- [ ] Update the [`cherry_pick_approved` prow plugin configuration](https://github.com/kubernetes/test-infra/blob/ce9ca27/config/prow/plugins.yaml#L1104-L1115) section to contain the new approver.
 
 <!-- 
 Uncomment the appropriate checklist for the Release Manager role the new candidate will hold.


### PR DESCRIPTION


#### What type of PR is this:


/kind documentation


#### What this PR does / why we need it:
The template now contains the prow config update for the cherrypickapproved plugin

cc @kubernetes/sig-release-leads @kubernetes/release-managers 
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None