### PR TITLE
Adds 1.30 Docs Shadow to the Release Team

### DIFF
--- a/releases/release-1.30/release-team.md
+++ b/releases/release-1.30/release-team.md
@@ -8,7 +8,7 @@
 | Release Notes | Rashan Smith ([@rashansmith](https://github.com/rashansmith) / Slack: `@Rashan`) |
 | Communications | Kristin Martin ([@kcmartin](https://github.com/kcmartin) / Slack: `@kcmartin`) |
 | Release Signal | Paco Xu ([@pacoxu](https://github.com/pacoxu) / Slack: `@pacoxu` ) |
-| Docs | Drew Hagen ([@drewhagen](https://github.com/drewhagen) / Slack: `@Drew Hagen`) |
+| Docs | Drew Hagen ([@drewhagen](https://github.com/drewhagen) / Slack: `@Drew Hagen`) | Vyom Yadav ([@Vyom-Yadav](https://github.com/Vyom-Yadav) / Slack: `@Vyom Yadav` ), Daniel Chan ([@chanieljdan](https://github.com/chanieljdan) / Slack : `@dchan`), Oluebube Princess Egbuna ([@Princesso](https://github.com/Princesso) / Slack: `@Bube`), Celeste Hogan ([@celestehorgan](https://github.com/celestehorgan) / Slack: `@Celeste Horgan`) |
 | Branch Manager |  |  |
 
 Review the [Release Managers page](https://github.com/kubernetes/website/blob/main/content/en/releases/release-managers.md) for up-to-date contact information on Release Engineering personnel.


### PR DESCRIPTION
Description:
#### What type of PR is this:
/kind documentation

#### What this PR does / why we need it:
Adds 1.30 Docs Shadows to the release team page

/assign @katcosgrove @gracenng @neoaggelos @ramrodo @sanchita-07 @fsmunoz

#### Note
If we plan to merge in one PR for the whole SIG Release team, please let me know and I will close this PR.