### PR TITLE
Add OWNERS file for release-signal handbook

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -45,6 +45,12 @@ aliases:
     - leonardpahlke # Kubernetes 1.26 Release Lead
     - Priyankasaggu11929 # Kubernetes 1.29 Release Lead
     - salaxander # Kubernetes 1.27 Release Lead
+  release-signal-role:
+    - Vyom-Yadav # 1.29 CI Signal Lead
+    - pacoxu # 1.30 Release Signal Lead
+    - mehabhalodiya # 1.28 CI Signal Lead
+    - furkatgofurov7 # 1.28 Bug Triage Lead
+    - hailkomputer # 1.29 Bug Triage Lead
   ci-signal-role:
     - lauralorenz # 1.27
     - mehabhalodiya # 1.28

--- a/release-team/role-handbooks/release-signal/OWNERS
+++ b/release-team/role-handbooks/release-signal/OWNERS
@@ -1,0 +1,6 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - release-signal-role
+reviewers:
+  - release-signal-role


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this:

<!--
Add one of the following kinds:
/kind cleanup
/kind documentation
/kind feature
/kind design
-->

/kind cleanup

#### What this PR does / why we need it:

The Release Signal team was introduced in v1.30. The OWNERS file was missing from the release signal handbook. We may also remove the ci signal and the bug triage handbook in the upcoming cycles.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #
or
None
-->

None

#### Special notes for your reviewer:
