### PR TITLE
Fix release notes yaml lint errors

### DIFF
--- a/releases/release-1.30/release-notes/maps/pr-119177-map.yaml
+++ b/releases/release-1.30/release-notes/maps/pr-119177-map.yaml
@@ -3,4 +3,4 @@ releasenote:
   text: "kube-scheduler implemented scheduling hints for the `NodeResourceFit` plugin.
     The scheduling hints allowed the scheduler to only retry scheduling a Pod that had 
     been previously rejected by the `NodeResourceFit` plugin if a new Node or a Node update 
-    matched the Pod's resource requirements or if an old pod update or delete matched the Pod's resource requirements".
+    matched the Pod's resource requirements or if an old pod update or delete matched the Pod's resource requirements."

--- a/releases/release-1.30/release-notes/maps/pr-121983-map.yaml
+++ b/releases/release-1.30/release-notes/maps/pr-121983-map.yaml
@@ -1,3 +1,3 @@
 pr: 121983
 releasenote:
-  text: 'cleanup: removed `getStorageAccountName` warning messages'.
+  text: 'cleanup: removed `getStorageAccountName` warning messages.'

--- a/releases/release-1.30/release-notes/maps/pr-122477-map.yaml
+++ b/releases/release-1.30/release-notes/maps/pr-122477-map.yaml
@@ -1,3 +1,3 @@
 pr: 122477
 releasenote:
-  text: `kubeadm completion` error message now displays supported shell types when an invalid shell was specified.
+  text: "`kubeadm completion` error message now displays supported shell types when an invalid shell was specified."

--- a/releases/release-1.30/release-notes/maps/pr-122614-map.yaml
+++ b/releases/release-1.30/release-notes/maps/pr-122614-map.yaml
@@ -1,3 +1,3 @@
 pr: 122614
 releasenote:
-  text: 'kube-proxy: fixed `LoadBalancerSourceRanges` not working for `nftables` mode'.
+  text: 'kube-proxy: fixed `LoadBalancerSourceRanges` not working for `nftables` mode.'


### PR DESCRIPTION
#### What type of PR is this:

/kind cleanup

#### What this PR does / why we need it:

The misformatted yaml release notes merged into sig-release are blocking the krel command from running for `v1.30.0-alpha.3`:


```
Press enter to start (1/10)

INFO + /usr/bin/git config --get user.email        file="command/command.go:326"
INFO + /usr/bin/git config --get user.name         file="command/command.go:326"
DEBU Reading session data from maps-1706895622.json  file="cmd/release_notes.go:1035"
DEBU Reading session data from maps-1708071507.json  file="cmd/release_notes.go:1035"
INFO Read 245 PR reviews from previous sessions    file="cmd/release_notes.go:1052"

Welcome to the Kubernetes Release Notes editing tool!

This tool will allow you to review and edit all the release
notes submitted by the Kubernetes contributors before publishing
the updated draft.

The flow will show each of the release notes that need to be
reviewed once and you can choose to edit it or not.

After you choose, it will be marked as reviewed and will not
be shown during the next sessions unless you choose to do a
full review of all notes.

You can hit Ctrl+C at any time to exit the review process
and submit the draft PR with the revisions made so far.

Would you like to continue from the last session? (Y/n) (1/10)
Y

Release Note for PR 121461:
===========================
Pull Request URL: https://github.com/kubernetes/kubernetes/pull/121461
FATA creating Draft PR: while running release notes fix flow: while getting map for PR #121461: while reading release notes maps: while parsing note map in /var/folders/7t/273pt80d51l70mj4rxznq_lm0000gn/T/k8s-518856267/releases/release-1.30/release-notes/maps/pr-119177-map.yaml: decoding note map: yaml: line 5: did not find expected key  file="cmd/root.go:61"
```

Slack thread: https://kubernetes.slack.com/archives/CN1KH4K9A/p1709327978866689 

