### PR TITLE
Move Major Themes responsibility from Release Notes to Comms

### DIFF
--- a/release-team/role-handbooks/communications/README.md
+++ b/release-team/role-handbooks/communications/README.md
@@ -53,10 +53,19 @@ There is a channel on the Kubernetes Slack workspace, `#release-comms`, which is
 ## Release deliverables
 
 Throughout the release cycle, the main Communications deliverables include:
-* **Authoring the Kubernetes release blog.** The Communications team writes the release blog, which is the official announcement of the Kubernetes release.
+* **Collection of Major Themes.** The Communications team coordinates with SIG Leads to solicit Major Themes for the release, to be used in both the Release Blog and Release Notes.
+* **Authoring the Kubernetes release blog.** The Communications team writes the release blog, which is the official announcement of the Kubernetes release. This includes the Major Themes from SIG leads.
 * **Coordination and support of the feature blog series.** SIGs opt-in to author feature blogs for the release. These blogs are written by technical owners, and the Communications team supports authors from the early stages through facilitating editorial and tech reviews as well as publication.
 * **Coordination and support of an optional Deprecations and Removals blog.** Depending upon the content of a given release, it may be necessary to prepare the community for upcoming deprecations and removals. This is decided per release cycle around the time of Code Freeze.
 * **Scheduling press activities and the post-release webinar with the CNCF.** The Communications Coordinator works with the CNCF to schedule press release activities around the release, and to schedule the release webinar (typically scheduled 3-4 weeks post-release).
+
+### Collect Major Themes
+
+A GitHub Discussion must be open to invite all SIG leads and members to add Major Themes for inclusion in the Release Blog and Release Notes. The discussion must be opened in kubernetes/sig-release under General Category. Past discussions: [1.25](https://github.com/kubernetes/sig-release/pull/1987), [1.24](https://github.com/kubernetes/sig-release/discussions/1868), [1.23](https://github.com/kubernetes/sig-release/discussions/1709), [1.22](https://github.com/kubernetes/sig-release/discussions/1575), [1.21](https://github.com/kubernetes/sig-release/discussions/1436).
+
+In the case of a low reponse rate in the Github discussion, each SIG should be pinged via their individual Slack channels and the #chairs-and-techleads channel.
+
+The Communications team should hold a meeting to discuss Major Themes sometime around Code Freeze. Ensure that at least one person from the Release Notes team attends this meeting with the Release Lead and Enhancements Lead.
 
 ### Release blog
 
@@ -216,6 +225,7 @@ This is an example of a typical release cycle and the order of how tasks will fl
         <ul>
         <li>Work with the enhancements lead to understand big-ticket items to be included in the release
         <li>Start monitoring the <code>Feature blog opt-in</code> sheet for new entries and use the <code>Assigment tab</code> sheet to assign and track status throughout the cycle (<a href="https://docs.google.com/spreadsheets/d/1hgFWig6YBSYORP3huwEyU0VlXGcYi6wMxjYW-swzCIY">for example</a>)
+        <li> With Enhancement freeze in effect, create a GitHub discussion (<a href="https://github.com/kubernetes/sig-release/discussions/2047">example v1.26</a>) to start collecting the major themes of the release, and reach out to all SIGs on and off over the next few weeks to ask for major themes and explain why this is important to the community.
         <ul>
         </ul>
         </ul>
@@ -251,6 +261,7 @@ This is an example of a typical release cycle and the order of how tasks will fl
         <ul>
         <li>Send out final reminders for feature blog opt-in on the SIG slack channels
         <li>Facilitate or start writing the optional Deprecations and Removals blog
+        <li>Coordinate with Release Notes to ensure major themes are checked in before Code Freeze.
         </ul>
         </td>
     </tr>
@@ -276,6 +287,7 @@ This is an example of a typical release cycle and the order of how tasks will fl
         <td>
         <ul>
         <li>Begin the release blog draft, if not yet started
+        <li>Host a meeting with the Release Lead, Enhancements Lead, and Release Notes to discuss the Major Themes to be highlighted in the release blog and ensure consistency with Release Notes
         <li>Optional 'Deprecations and Removals' blog ready for review
         <li>Schedule the release Live Webinar with CNCF by emailing <code>webinars@cncf.io</code>. You may be referred to <a href="https://calendly.com/cncfonlineprograms">Calendly</a>. The webinar is typically scheduled for 3-4 weeks after the release
         <li>Schedule press and analyst pre-briefings and interviews for the release lead with CNCF by emailing <code>pr@cncf.io</code>
@@ -290,7 +302,7 @@ This is an example of a typical release cycle and the order of how tasks will fl
         <ul>
         <li>Finalize and publish the 'Deprecations and Removals' blog once code freeze is in place.
         <li>Update release blog draft, post-Code Freeze
-        <li>Check status with Release Notes lead on content for Major Themes and Known Issues sections of the release blog (short summaries to be included in the release blog)
+        <li>Check status with Release Notes lead on content for the Known Issues section of the release blog
         <li>Check status on all feature blog PRs. Keep <code>#sig-docs-blog</code> up-to-date for editorial review, and establish tech reviewers are available 
         </ul>
         </td>

--- a/release-team/role-handbooks/release-notes/README.md
+++ b/release-team/role-handbooks/release-notes/README.md
@@ -70,7 +70,7 @@ In the first week of the release cycle, the Release Notes Lead will organize an 
 
 #### Early and mid release cycle (weeks 1-8) ~1-5 hours/week
 
-In the first 8 weeks of the cycle, the Release Notes team should/must, attend weekly release meetings and run the [release-notes subcommand of krel](https://github.com/kubernetes/release/blob/master/docs/krel/release-notes.md) for every `alpha`, `beta` and `rc` to create an early draft of the release notes. This ensures that the overall quality of the release notes can be verified from the beginning of the release cycle.
+In the first 8 weeks of the cycle, the Release Notes team must attend weekly release meetings and run the [release-notes subcommand of krel](https://github.com/kubernetes/release/blob/master/docs/krel/release-notes.md) for every `alpha`, `beta` and `rc` to create an early draft of the release notes. This ensures that the overall quality of the release notes can be verified from the beginning of the release cycle.
 
 #### Late release cycle (weeks 9-12+) ~4-10 hours/week
 
@@ -138,17 +138,13 @@ A ["Known Issues Umbrella Issue"](known-issues-bucket.md) for the release must b
 
 ### Ensure Major Themes are Reflected in the Notes
 
-The Communications team will hold meetings to discuss blogposts and media releases regarding the release sometime before code freeze. Ensure that at least one person from the release notes team attends this meeting with the release lead and enhancements lead. The release notes team should ensure that the "Major Themes" identified in this meeting are reflected in the "Major Themes" section of the release notes. If no one is able to attend the meeting, reach out to the communications team, release lead or enhancements lead to ensure messaging around Major Themes is coordinated.
-
-Besides a meeting with the Communications team a GitHub Discussion must be open to invite all SIGs members and volunteers to update Major Themes with topics that can be discussed in collaborative way. The discussion must be open in kubernetes/sig-release under General Category, past discussions: [1.25](https://github.com/kubernetes/sig-release/pull/1987), [1.24](https://github.com/kubernetes/sig-release/discussions/1868), [1.23](https://github.com/kubernetes/sig-release/discussions/1709), [1.22](https://github.com/kubernetes/sig-release/discussions/1575), [1.21](https://github.com/kubernetes/sig-release/discussions/1436).
-
-In the case of still low reponse rate in the Github discussion each SIG can be ping via Slack as a reminder. To speed up the proccess an issue can be raised to allow multiple people to reach out to different groups, just like: [1615](https://github.com/kubernetes/sig-release/issues/1615) and [1502](https://github.com/kubernetes/sig-release/pull/1502)
+The Communications team will hold a meeting to discuss Major Themes sometime around Code Freeze. Ensure that at least one person from the Release Notes team attends this meeting with the Release Lead and Enhancements Lead. The Release Notes team should ensure that the "Major Themes" identified in this meeting are reflected in the "Major Themes" section of the release notes. If no one is able to attend the meeting, reach out to the Communications team, Release Lead or Enhancements Lead to ensure messaging around Major Themes is coordinated.
 
 ### Get feedback from SIG Leads
 
-Around Code Freeze, the release notes team will get in touch with the SIG Leads to capture the major themes of their SIGs. The team will also ensure that major issues captured in the release notes are confirmed by the SIG leads before release day.
+Around Code Freeze, the Release Notes team will get in touch with the SIG Leads to ensure that the Release Notes accurately reflect the major themes for their SIGs. The team will also ensure that major issues captured in the release notes are confirmed by the SIG leads before release day.
 
-If gentle nudging of SIG Leads is not effective in retrieving feedback/confirmation, the Release Notes Team can use a reasonable amount of creative liberty in completing the notes
+If gentle nudging of SIG Leads is not effective in retrieving feedback/confirmation, the Release Notes Team can use a reasonable amount of creative liberty in completing the notes.
 
 ### Clean up and edit the final document
 
@@ -187,19 +183,15 @@ Begin running release-notes tool for the ongoing collection of release notes wit
 - Begin attending burndown meetings
 - Same as above, but generate the notes for each `alpha` and `beta`
 
-#### Week 4
-
-- With Enhancement freeze in effect, create a GitHub discussion ([example 1.26](https://github.com/kubernetes/sig-release/discussions/2047)) to start collecting the major themes of the release, and reach out to all SIGs on and off over the next few weeks to ask for major themes and explain why this is important to the community.
-
 #### Week 10
 
-- Make sure major themes of the release are checked in before Code Freeze; reach out to SIGs and release leads if additional coordination is needed
+- Coordinate with Release Comms to ensure major themes of the release are checked in before Code Freeze; reach out to SIGs and release leads if additional coordination is needed.
 
-### Week 11 (Begin of Code Freeze)
+### Week 11 (Beginning of Code Freeze)
 
 - Create [known issues issue](known-issues-bucket.md) in `kubernetes/kubernetes` to capture known issues for the release.
 - Share created doc with release-team
-- Send [an email to SIG-leads](sig-leads-email.md) to capture major themes from their SIG.
+- Send [an email to SIG-leads](sig-leads-email.md) to ensure major changes for their SIGs are accurately reflected in the release notes
 - Start determining major themes for release notes template to send to SIG-leads
 
 ### Weeks 13-16
@@ -209,7 +201,7 @@ Begin running release-notes tool for the ongoing collection of release notes wit
 
 ### Week 15
 
-- Finalize lead and shadow roles for subsequent release
+- Finalize subteam lead for subsequent release
 - Work with SIG-leads to finalize major themes for release-notes
 - Copy edit notes for spelling, grammar and uniform style
 

--- a/release-team/role-handbooks/release-notes/sig-leads-email.md
+++ b/release-team/role-handbooks/release-notes/sig-leads-email.md
@@ -1,9 +1,10 @@
 Hey Everyone,
 
-<Brief intro>, I'm on the Release Notes Team for the <RELEASE NUMBER> release.
+My name is {NAME}, and I'm on the Release Notes Team for the {RELEASE NUMBER} release.
+
 We've put together a draft of the release notes document so far, but we need
 your help to make sure that the work each SIG has contributed is reflected accurately.
-Please check out the release notes draft document <LAZY LINK> ASAP and:
+Please check out the release notes draft document [here]({LINK HERE}) ASAP and:
 
 1. CTRL-F your SIG and edit/move notes to a more appropriate location--we just
 ask that you do it as a suggestion so it's easy for the release notes team to
@@ -15,11 +16,11 @@ notes for features that were a collaboration between your SIG and other SIGs.
 
 2. If you know of anything that should appear in the "Known Issues" section of
 the Release Notes, please leave a comment with the issue and a draft of the note
-text on this GitHub Issue: [<LINK TO GITHUB ISSUE>](known-issue-bucket.md)
-
+text on [this GitHub Issue]({LINK TO GITHUB ISSUE})
 
 3. If you have some more time and want to help shape your SIG's sections of the
-release notes for 1.15, there are a few more things you can do as well!
+release notes for {RELEASE NUMBER}, there are a few more things you can do as well!
+
 - Copy-edit notes from your SIG that may contain what you know to be technical
 inaccuracies, grammar inconsistencies, etc.
 - Remove minor and/or non-user facing release notes contributed by your SIG
@@ -29,4 +30,4 @@ We can then use this to further categorize the notes!
 
 
 Thank you so much for helping put together release notes for your SIG, we know
-you're busy and appreciate your support of the <RELEASE NUMBER> release!
+you're busy and appreciate your support of the {RELEASE NUMBER} release!


### PR DESCRIPTION
#### What type of PR is this:

/kind cleanup
/kind documentation

#### What this PR does / why we need it:

The collection of Major Themes is currently handled by Release Notes, when it is more in line with the duties of the Comms team and most prominently consumed by the Comms team. To better reflect the actual behavior of the teams, I have moved the primary responsibility for collection of Major Themes to Comms, and put Release Notes in a supporting role for this duty.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:
