### PR TITLE
Add internal schedule for release notes PRs

### DIFF
--- a/release-team/role-handbooks/release-notes/README.md
+++ b/release-team/role-handbooks/release-notes/README.md
@@ -167,15 +167,15 @@ Create an internal schedule for the release notes team to follow based on the re
 [v1.31 release](https://github.com/kubernetes/sig-release/tree/master/releases/release-1.31), create a table to track
 Release, Branch Created Day, Week of Release, PR merge deadline, and Release Notes Assignee.
 
-| **Release**                          | **Week** | **Branch Created Day** | **PR merge deadline**    | **Release Notes Assignee** | **Release Notes Reviewer** |
-|--------------------------------------|----------|------------------------|--------------------------|----------------------------|----------------------------|
-| 1.31.0-alpha.1 released              | week 4   | Tuesday 4th June 2024  | Tuesday 11th June 2024   | <Release Notes Member>     | <Release Notes Member>     |
-| 1.31.0-alpha.2 released              | week 6   | Tuesday 18th June 2024 | Tuesday 25th June 2024   | <Release Notes Member>     | <Release Notes Member>     |
-| 1.31.0-alpha.3 released              | week 8   | Tuesday 2nd July 2024  | Tuesday 13th July 2024   | <Release Notes Member>     | <Release Notes Member>     |
-| 1.31.0-beta.0 released               | week 10  | Tuesday 16th July 2024 | Tuesday 23rd July 2024   | <Release Notes Member>     | <Release Notes Member>     |
-| Start final draft of Release Notes   | week 11  | Tuesday 23rd July 2024 | Tuesday 13th August 2024 | Release Notes Lead         | Release Leads              |
-| 1.31.0-rc.0 released                 | week 12  | Tuesday 30th July 2024 | Tuesday 6th August 2024  | <Release Notes Member>     | <Release Notes Member>     |
-| 1.31.0-rc.1 released                 | week 13  | Tuesday 6th August 2024| Tuesday 13th August 2024 | <Release Notes Member>     | <Release Notes Member>     |
+| **Release**                          | **Week** | **Branch Created Day** | **PR merge deadline**    | **Release Notes Assignee** | **Release Notes Reviewers** |
+|--------------------------------------|----------|------------------------|--------------------------|----------------------|-----------------------------|
+| 1.31.0-alpha.1 released              | week 4   | Tuesday 4th June 2024  | Tuesday 11th June 2024   | Release Notes Member | Release Notes Member(s)     |
+| 1.31.0-alpha.2 released              | week 6   | Tuesday 18th June 2024 | Tuesday 25th June 2024   | Release Notes Member | Release Notes Member(s)     |
+| 1.31.0-alpha.3 released              | week 8   | Tuesday 2nd July 2024  | Tuesday 13th July 2024   | Release Notes Member | Release Notes Member(s)     |
+| 1.31.0-beta.0 released               | week 10  | Tuesday 16th July 2024 | Tuesday 23rd July 2024   | Release Notes Member | Release Notes Member(s)     |
+| Start final draft of Release Notes   | week 11  | Tuesday 23rd July 2024 | Tuesday 13th August 2024 | Release Notes Lead   | Release Leads               |
+| 1.31.0-rc.0 released                 | week 12  | Tuesday 30th July 2024 | Tuesday 6th August 2024  | Release Notes Member | Release Notes Member(s)     |
+| 1.31.0-rc.1 released                 | week 13  | Tuesday 6th August 2024| Tuesday 13th August 2024 | Release Notes Member | Release Notes Member(s)     |
 ##### Release Team Meeting Updates
 
 For the release team meeting, provide a `status` based on the following criteria:

--- a/release-team/role-handbooks/release-notes/README.md
+++ b/release-team/role-handbooks/release-notes/README.md
@@ -162,20 +162,11 @@ A "Dependencies" section should be curated which outlines how external dependenc
 ## Release Cycle Milestone Activities:
 
 ### Week 0 
+ 
+Create a table to track `Release`, `Branch Created Day`, `Week of Release`, `PR Merge Deadline`, `Release Notes Assignee`
+and `Release Notes Reviewer` based on the release timeline. This will serve as an internal schedule and signup sheet for
+the release notes team to follow. The schedule is used to track progress and give status updates during release team meetings. 
 
-Create an internal schedule for the release notes team to follow based on the release timeline. For example, for the 
-[v1.31 release](https://github.com/kubernetes/sig-release/tree/master/releases/release-1.31), create a table to track
-Release, Branch Created Day, Week of Release, PR merge deadline, and Release Notes Assignee.
-
-| **Release**                          | **Week** | **Branch Created Day** | **PR merge deadline**    | **Release Notes Assignee** | **Release Notes Reviewers** |
-|--------------------------------------|----------|------------------------|--------------------------|----------------------|-----------------------------|
-| 1.31.0-alpha.1 released              | week 4   | Tuesday 4th June 2024  | Tuesday 11th June 2024   | Release Notes Member | Release Notes Member(s)     |
-| 1.31.0-alpha.2 released              | week 6   | Tuesday 18th June 2024 | Tuesday 25th June 2024   | Release Notes Member | Release Notes Member(s)     |
-| 1.31.0-alpha.3 released              | week 8   | Tuesday 2nd July 2024  | Tuesday 13th July 2024   | Release Notes Member | Release Notes Member(s)     |
-| 1.31.0-beta.0 released               | week 10  | Tuesday 16th July 2024 | Tuesday 23rd July 2024   | Release Notes Member | Release Notes Member(s)     |
-| Start final draft of Release Notes   | week 11  | Tuesday 23rd July 2024 | Tuesday 13th August 2024 | Release Notes Lead   | Release Leads               |
-| 1.31.0-rc.0 released                 | week 12  | Tuesday 30th July 2024 | Tuesday 6th August 2024  | Release Notes Member | Release Notes Member(s)     |
-| 1.31.0-rc.1 released                 | week 13  | Tuesday 6th August 2024| Tuesday 13th August 2024 | Release Notes Member | Release Notes Member(s)     |
 ##### Release Team Meeting Updates
 
 For the release team meeting, provide a `status` based on the following criteria:

--- a/release-team/role-handbooks/release-notes/README.md
+++ b/release-team/role-handbooks/release-notes/README.md
@@ -167,15 +167,15 @@ Create an internal schedule for the release notes team to follow based on the re
 [v1.31 release](https://github.com/kubernetes/sig-release/tree/master/releases/release-1.31), create a table to track
 Release, Branch Created Day, Week of Release, PR merge deadline, and Release Notes Assignee.
 
-| **Release**                          | **Week** | **Branch Created Day** | **PR merge deadline**    | **Release Notes Assignee** |
-|--------------------------------------|----------|------------------------|--------------------------|----------------------------|
-| 1.31.0-alpha.1 released              | week 4   | Tuesday 4th June 2024  | Tuesday 11th June 2024   | <Release Notes Member>     |
-| 1.31.0-alpha.2 released              | week 6   | Tuesday 18th June 2024 | Tuesday 25th June 2024   | <Release Notes Member>     |
-| 1.31.0-alpha.3 released              | week 8   | Tuesday 2nd July 2024  | Tuesday 13th July 2024   | <Release Notes Member>     |
-| 1.31.0-beta.0 released               | week 10  | Tuesday 16th July 2024 | Tuesday 23rd July 2024   | <Release Notes Member>     |
-| Start final draft of Release Notes   | week 11  | Tuesday 23rd July 2024 | Tuesday 13th August 2024 | Release Notes Lead         |
-| 1.31.0-rc.0 released                 | week 12  | Tuesday 30th July 2024 | Tuesday 6th August 2024  | <Release Notes Member>     |
-| 1.31.0-rc.1 released                 | week 13  | Tuesday 6th August 2024| Tuesday 13th August 2024 | <Release Notes Member>     |
+| **Release**                          | **Week** | **Branch Created Day** | **PR merge deadline**    | **Release Notes Assignee** | **Release Notes Reviewer** |
+|--------------------------------------|----------|------------------------|--------------------------|----------------------------|----------------------------|
+| 1.31.0-alpha.1 released              | week 4   | Tuesday 4th June 2024  | Tuesday 11th June 2024   | <Release Notes Member>     | <Release Notes Member>     |
+| 1.31.0-alpha.2 released              | week 6   | Tuesday 18th June 2024 | Tuesday 25th June 2024   | <Release Notes Member>     | <Release Notes Member>     |
+| 1.31.0-alpha.3 released              | week 8   | Tuesday 2nd July 2024  | Tuesday 13th July 2024   | <Release Notes Member>     | <Release Notes Member>     |
+| 1.31.0-beta.0 released               | week 10  | Tuesday 16th July 2024 | Tuesday 23rd July 2024   | <Release Notes Member>     | <Release Notes Member>     |
+| Start final draft of Release Notes   | week 11  | Tuesday 23rd July 2024 | Tuesday 13th August 2024 | Release Notes Lead         | Release Leads              |
+| 1.31.0-rc.0 released                 | week 12  | Tuesday 30th July 2024 | Tuesday 6th August 2024  | <Release Notes Member>     | <Release Notes Member>     |
+| 1.31.0-rc.1 released                 | week 13  | Tuesday 6th August 2024| Tuesday 13th August 2024 | <Release Notes Member>     | <Release Notes Member>     |
 ##### Release Team Meeting Updates
 
 For the release team meeting, provide a `status` based on the following criteria:

--- a/release-team/role-handbooks/release-notes/README.md
+++ b/release-team/role-handbooks/release-notes/README.md
@@ -161,6 +161,29 @@ A "Dependencies" section should be curated which outlines how external dependenc
 
 ## Release Cycle Milestone Activities:
 
+### Week 0 
+
+Create an internal schedule for the release notes team to follow based on the release timeline. For example, for the 
+[v1.31 release](https://github.com/kubernetes/sig-release/tree/master/releases/release-1.31), create a table to track
+Release, Branch Created Day, Week of Release, PR merge deadline, and Release Notes Assignee. 
+
+| **Release**                                                                               | **Branch Created Day**                       | **Week**                                                              | **PR merge deadline** | **Release Notes Assignee** |
+| -------------------------------------------------------------------------------------- | ----------------------------- | --------------------------------------------------------------------- | ------- |----------------------------|
+| 1.31.0-alpha.1 released                                                                | Tuesday 4th June 2024                          | week 4                                               | Tuesday 11th June 2024  | <Release Notes Member>     |
+| 1.31.0-alpha.2 released                                                              | Tuesday 18th June 2024                         | week 6                                              | Tuesday 25th June 2024 | <Release Notes Member>     |
+| 1.31.0-alpha.3 released                                                               | Tuesday 2nd July 2024                         | week 8                                            | Tuesday 13th July 2024   | <Release Notes Member>     |
+| 1.31.0-beta.0 released                                                               | Tuesday 16th July 2024                       | week 10                                               | Tuesday 23rd July 2024  | <Release Notes Member>     |
+| Start final draft of Release Notes                                                              | Tuesday 23rd July 2024                         | week 11                                              | Tuesday 13th August 2024  | Release Notes Lead         |
+| 1.31.0-rc.0 released                                                             | Tuesday 30th July 2024                       | week 12                                         | Tuesday 6th August 2024 |          |
+| 1.31.0-rc.1 released                                                             | Tuesday 6th August 2024                        | week 13                                            | Tuesday 13th August 2024  |        |
+
+##### Release Team Meeting Updates
+
+For the release team meeting, provide a `status` based on the following criteria:
+- A `Red` on our release notes status means that something major is blocking our work when creating Release Notes pull requests. 
+- A `Yellow` status generally means that we are still in progress of creating the Release Notes pull request or we have some minor blockages that have caused a delay past the PR merge deadline.
+- A `Green` status means that everything looks good and done from Release Notes team side, i.e. the release notes pull requests are being created, reviewed and merged before the deadline. Everything is A-OK here.
+
 ### Week 1
 
 Begin running release-notes tool for the ongoing collection of release notes with the first alpha release, which has been cut directly after the latest minor.

--- a/release-team/role-handbooks/release-notes/README.md
+++ b/release-team/role-handbooks/release-notes/README.md
@@ -165,23 +165,23 @@ A "Dependencies" section should be curated which outlines how external dependenc
 
 Create an internal schedule for the release notes team to follow based on the release timeline. For example, for the 
 [v1.31 release](https://github.com/kubernetes/sig-release/tree/master/releases/release-1.31), create a table to track
-Release, Branch Created Day, Week of Release, PR merge deadline, and Release Notes Assignee. 
+Release, Branch Created Day, Week of Release, PR merge deadline, and Release Notes Assignee.
 
-| **Release**                                                                               | **Branch Created Day**                       | **Week**                                                              | **PR merge deadline** | **Release Notes Assignee** |
-| -------------------------------------------------------------------------------------- | ----------------------------- | --------------------------------------------------------------------- | ------- |----------------------------|
-| 1.31.0-alpha.1 released                                                                | Tuesday 4th June 2024                          | week 4                                               | Tuesday 11th June 2024  | <Release Notes Member>     |
-| 1.31.0-alpha.2 released                                                              | Tuesday 18th June 2024                         | week 6                                              | Tuesday 25th June 2024 | <Release Notes Member>     |
-| 1.31.0-alpha.3 released                                                               | Tuesday 2nd July 2024                         | week 8                                            | Tuesday 13th July 2024   | <Release Notes Member>     |
-| 1.31.0-beta.0 released                                                               | Tuesday 16th July 2024                       | week 10                                               | Tuesday 23rd July 2024  | <Release Notes Member>     |
-| Start final draft of Release Notes                                                              | Tuesday 23rd July 2024                         | week 11                                              | Tuesday 13th August 2024  | Release Notes Lead         |
-| 1.31.0-rc.0 released                                                             | Tuesday 30th July 2024                       | week 12                                         | Tuesday 6th August 2024 |          |
-| 1.31.0-rc.1 released                                                             | Tuesday 6th August 2024                        | week 13                                            | Tuesday 13th August 2024  |        |
-
+| **Release**                          | **Week** | **Branch Created Day** | **PR merge deadline**    | **Release Notes Assignee** |
+|--------------------------------------|----------|------------------------|--------------------------|----------------------------|
+| 1.31.0-alpha.1 released              | week 4   | Tuesday 4th June 2024  | Tuesday 11th June 2024   | <Release Notes Member>     |
+| 1.31.0-alpha.2 released              | week 6   | Tuesday 18th June 2024 | Tuesday 25th June 2024   | <Release Notes Member>     |
+| 1.31.0-alpha.3 released              | week 8   | Tuesday 2nd July 2024  | Tuesday 13th July 2024   | <Release Notes Member>     |
+| 1.31.0-beta.0 released               | week 10  | Tuesday 16th July 2024 | Tuesday 23rd July 2024   | <Release Notes Member>     |
+| Start final draft of Release Notes   | week 11  | Tuesday 23rd July 2024 | Tuesday 13th August 2024 | Release Notes Lead         |
+| 1.31.0-rc.0 released                 | week 12  | Tuesday 30th July 2024 | Tuesday 6th August 2024  | <Release Notes Member>     |
+| 1.31.0-rc.1 released                 | week 13  | Tuesday 6th August 2024| Tuesday 13th August 2024 | <Release Notes Member>     |
 ##### Release Team Meeting Updates
 
 For the release team meeting, provide a `status` based on the following criteria:
-- A `Red` on our release notes status means that something major is blocking our work when creating Release Notes pull requests. 
-- A `Yellow` status generally means that we are still in progress of creating the Release Notes pull request or we have some minor blockages that have caused a delay past the PR merge deadline.
+- A `Red` on our release notes status means that we are delayed past the deadline or there is a major blocker for our work to create Release Notes pull requests. 
+- A `Yellow` status generally means that we are still within the deadline of creating the Release Notes pull request, but 
+there are things (minor blockages, `krel` issues, etc.) that could cause a delay past the PR merge deadline.
 - A `Green` status means that everything looks good and done from Release Notes team side, i.e. the release notes pull requests are being created, reviewed and merged before the deadline. Everything is A-OK here.
 
 ### Week 1

--- a/releases/release-1.31/release-notes/README.md
+++ b/releases/release-1.31/release-notes/README.md
@@ -1,0 +1,15 @@
+### Release Notes Milestones
+
+This is the internal schedule for the Release Notes team to follow for creating Release Notes PRs. This is based on the
+[v1.31 release](https://github.com/kubernetes/sig-release/tree/master/releases/release-1.31) timeline.
+
+| **Release**                        | **Week** | **Branch Created Day**  | **PR merge deadline**    |
+|------------------------------------|----------|-------------------------|--------------------------|
+| 1.31.0-alpha.1 released            | week 4   | Tuesday 4th June 2024   | Tuesday 11th June 2024   |
+| 1.31.0-alpha.2 released            | week 6   | Tuesday 18th June 2024  | Tuesday 25th June 2024   |
+| 1.31.0-alpha.3 released            | week 8   | Tuesday 2nd July 2024   | Tuesday 13th July 2024   |
+| 1.31.0-beta.0 released             | week 10  | Tuesday 16th July 2024  | Tuesday 23rd July 2024   |
+| Start final draft of Release Notes | week 11  | Tuesday 23rd July 2024  | Tuesday 13th August 2024 |
+| 1.31.0-rc.0 released               | week 12  | Tuesday 30th July 2024  | Tuesday 6th August 2024  |
+| 1.31.0-rc.1 released               | week 13  | Tuesday 6th August 2024 | Tuesday 13th August 2024 |
+


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this:

/kind documentation

#### What this PR does / why we need it:

This adds an example for defining release notes draft PR merge deadline. Currently, the timeline only defines when a branch is created, and we assume to get the PR done sometime before the next branch is made. This would be only internally enforced and used to give status updates.

Previously Release Notes Leads have created similar schedules for assigning shadows to "own" a specific release: https://docs.google.com/spreadsheets/d/1xNNWdh-hFTVgg-zebp0-DdV-gCnx5l3uUv3RikjAzBg/edit?usp=sharing 

The 1.30 end of release retro suggested adding a release notes draft PR merge deadline that would be tied to status reports during release team update meetings. 

#### Which issue(s) this PR fixes:

https://github.com/kubernetes/sig-release/issues/2498

