### PR TITLE
Link to `schedule-builder` in release cut template

### DIFF
--- a/.github/ISSUE_TEMPLATE/cut-release.md
+++ b/.github/ISSUE_TEMPLATE/cut-release.md
@@ -84,7 +84,7 @@ Help? Ring @release-managers on slack!
   - [ ] Release
 - [ ] Notify #release-management: <!-- Paste link to slack -->
 - [ ] Send notification: <!-- Paste link to kubernetes-dev email -->
-- [ ] Update [`schedule.yaml` file](https://github.com/kubernetes/website/blob/main/data/releases/schedule.yaml) with the latest release <!-- Paste Pull Request URL here -->
+- [ ] Update [`schedule.yaml` file](https://github.com/kubernetes/website/blob/main/data/releases/schedule.yaml) with the latest release using [`schedule-builder`](https://github.com/kubernetes/release/tree/master/cmd/schedule-builder) <!-- Paste Pull Request URL here -->
 - [ ] Collect metrics and add them to the `Release steps` table below
 <!-- ONLY FOR RC.0 RELEASE - [ ] Finish post-release branch creation tasks -->
 


### PR DESCRIPTION

#### What type of PR is this:


/kind documentation


#### What this PR does / why we need it:
Add a link to use the tool rather than doing a completely manual update.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #
or
None
-->
None
#### Special notes for your reviewer:
cc @kubernetes/release-engineering 