### PR TITLE
fixed yaml indentations

### DIFF
--- a/releases/release-1.31/release-notes/maps/pr-122176-map.yaml
+++ b/releases/release-1.31/release-notes/maps/pr-122176-map.yaml
@@ -1,3 +1,4 @@
 pr: 122176
 releasenote:
-  text: 'kube-apiserver: Added support to disable http/2 serving with a `--disable-http2-serving` flag.
+  text: |
+    kube-apiserver: Added support to disable http/2 serving with a `--disable-http2-serving` flag.

--- a/releases/release-1.31/release-notes/maps/pr-124017-map.yaml
+++ b/releases/release-1.31/release-notes/maps/pr-124017-map.yaml
@@ -1,5 +1,6 @@
 pr: 124017
 releasenote:
-  text: 'Removed deprecated command flags --volume-host-cidr-denylist
-    and --volume-host-allow-local-loopback from kube-controller-manager.'
-    and --volume-host-allow-local-loopback'
+  text: |
+    Removed deprecated command flags --volume-host-cidr-denylist
+    and --volume-host-allow-local-loopback from kube-controller-manager.
+

--- a/releases/release-1.31/release-notes/maps/pr-124361-map.yaml
+++ b/releases/release-1.31/release-notes/maps/pr-124361-map.yaml
@@ -1,3 +1,8 @@
 pr: 124361
 releasenote:
-  text: 'kubeadm: Removed support for mounting /etc/pki as an additional Linux system CA location in kube-apisever and kube-controller-manager pods. Instead, it shifted to supporting the mounting of /etc/pki/ca-trust and /etc/pki/tls/certs. The locations /etc/ca-certificate, /usr/share/ca-certificates, /usr/local/share/ca-certificates, and /etc/ssl/certs continued to be supported.'.'
+  text: |
+    kubeadm: Removed support for mounting /etc/pki as an additional Linux system CA location
+    in kube-apisever and kube-controller-manager pods. Instead, it shifted to supporting the
+    mounting of /etc/pki/ca-trust and /etc/pki/tls/certs. The locations /etc/ca-certificate,
+    /usr/share/ca-certificates, /usr/local/share/ca-certificates, and /etc/ssl/certs continued
+    to be supported.

--- a/releases/release-1.31/release-notes/maps/pr-124589-map.yaml
+++ b/releases/release-1.31/release-notes/maps/pr-124589-map.yaml
@@ -1,3 +1,5 @@
 pr: 124589
 releasenote:
-  text: 'Fixed the ResourceClaim controller forgetting to wait for `podSchedulingSynced` and `templatesSynced`.
+  text: |
+    "Fixed the ResourceClaim controller forgetting to wait for `podSchedulingSynced` 
+    and `templatesSynced`."

--- a/releases/release-1.31/release-notes/maps/pr-124598-map.yaml
+++ b/releases/release-1.31/release-notes/maps/pr-124598-map.yaml
@@ -1,4 +1,4 @@
 pr: 124598
 releasenote:
-  text: `kubectl describe service` and `kubectl describe ingress` will now use endpointslices instead of
-    endpoints.
+  text: |
+    "`kubectl describe service`" and "`kubectl describe ingress`" will now use endpointslices instead of endpoints.


### PR DESCRIPTION
This fixes the yaml indentation errors in the release-notes-v1.31 maps as that blocks the generation of `release-notes-v.31-alpha.3`  PR