### PR TITLE
Fix release notes text in map files

### DIFF
--- a/releases/release-1.31/release-notes/maps/pr-125163-map.yaml
+++ b/releases/release-1.31/release-notes/maps/pr-125163-map.yaml
@@ -1,6 +1,7 @@
 pr: 125163
 releasenote:
-  text: 'ACTION REQUIRED: The Dynamic Resource Allocation (DRA) driver's DaemonSet must be deployed
-    with a service account that enables writing ResourceSlice and reading ResourceClaim
-    objects.'
+  text: |
+    'ACTION REQUIRED: The Dynamic Resource Allocation (DRA) driver's DaemonSet
+    must be deployed with a service account that enables writing ResourceSlice
+    and reading ResourceClaim objects.'
 pr_body: ""

--- a/releases/release-1.31/release-notes/maps/pr-126108-map.yaml
+++ b/releases/release-1.31/release-notes/maps/pr-126108-map.yaml
@@ -3,8 +3,8 @@ releasenote:
   text: |-
     Reduced state change noise when volume expansion fails. Also mark certain failures as infeasible.
 
- ACTION REQUIRED:  If you are using the `RecoverVolumeExpansionFailure` alpha feature gate
- then after upgrading to this release, you need to update some objects.
- For any existing PersistentVolumeClaimss with `status.allocatedResourceStatus` set to either
- "ControllerResizeFailed" or "NodeResizeFailed", clear the `status.allocatedResourceStatus`.
+    ACTION REQUIRED:  If you are using the `RecoverVolumeExpansionFailure` alpha feature gate
+    then after upgrading to this release, you need to update some objects.
+    For any existing PersistentVolumeClaimss with `status.allocatedResourceStatus` set to either
+    "ControllerResizeFailed" or "NodeResizeFailed", clear the `status.allocatedResourceStatus`.
 pr_body: ""


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this:
/kind cleanup
<!--
Add one of the following kinds:
/kind cleanup
/kind documentation
/kind feature
/kind design
-->

#### What this PR does / why we need it:
This PR fixes the syntax error in map yaml files since krel was throwing error while trying to create release notes draft PR for `v1.31.0-rc.1`.
```
FATA creating Draft PR: while running release notes fix flow: while getting map for PR #125828: while reading release notes maps: while parsing note map in /var/folders/8s/8mhcz0cx1_7g258xfrl991m00000gq/T/k8s-4068473374/releases/release-1.31/release-notes/maps/pr-125163-map.yaml: decoding note map: yaml: line 2: did not find expected key  file="cmd/root.go:59"
```
