### PR TITLE
Add release team lead shadows as approvers

### DIFF
--- a/releases/release-1.32/OWNERS
+++ b/releases/release-1.32/OWNERS
@@ -3,6 +3,10 @@
 approvers:
     - fsmunoz               # 1.32 Release Team Lead
     - katcosgrove           # 1.32 Emeritus Advisor
+    - npolshakova           # 1.32 Release Team Lead Shadow
+    - sreeram-venkitesh     # 1.32 Release Team Lead Shadow
+    - salehsedghpour        # 1.32 Release Team Lead Shadow
+    - Vyom-Yadav            # 1.32 Release Team Lead Shadow
 
 reviewers:
     - mbianchidev           # 1.32 Communications Lead


### PR DESCRIPTION
#### What type of PR is this:

/kind documentation

#### What this PR does / why we need it:

Part of the [1.32 release team checklist ](https://github.com/kubernetes/sig-release/issues/2603) has a task to `Add an approvers entry in releases/release-1.XX/OWNERS`, 

For the [1.32 OWNERS](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.32/OWNERS) file, the last release we had only the release lead and Emeritus advisor as approvers, but in [previous releases](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.29/OWNERS#L3) all the lead shadows also had approval permissions. This allows release team lead shadows to also approve release-notes PRs going into 1.32. 

#### Which issue(s) this PR fixes:
None

