### PR TITLE
Add docs for lead shadow pairing

### DIFF
--- a/release-team/role-handbooks/release-team-lead/README.md
+++ b/release-team/role-handbooks/release-team-lead/README.md
@@ -9,6 +9,7 @@ The release team leader role is responsible for coordinating release activities,
 - [Skills and Experience Required](#skills-and-experience-required)
 - [Time Commitments](#time-commitments)
 - [Choosing a Release Team](#choosing-a-release-team)
+  - [Lead Shadows](#lead-shadows)
 - [Standards](#standards)
   - [Mailing List Standards](#mailing-list-standards)
 - [Release theme gifts](#release-theme-gifts)
@@ -76,6 +77,12 @@ Please lead by example and encourage everyone to work within their working hours
 One of your first and definitely most important duties as Release Lead is to ensure a Release Team is in place.
 
 Release Team selection should happen in accordance with the [Release Team selection process][selection].
+
+### Lead Shadows
+
+Once you have selected your Lead Shadows, each Shadow should get assigned to support two teams. One should be a team they have previously led or have extensive experience in. The other will be a team they have had no exposure to prior. This will make sure that they are well-rounded to step up to lead, and the subteams will get timely support.
+
+In the event that a subteam loses a shadow, we might ask the paired Lead Shadow to step in as backup Shadow.
 
 ## Standards
 


### PR DESCRIPTION
As an action item from v1.29, trialled in v1.30 and implemented henceforth, Release Lead assign their Lead Shadows to support two teams. This is the documentation for that process.

I will also make another PR to add to Release Lead checklist <3

/kind documentation
