### PR TITLE
fix yaml parse to draft alpha.3

### DIFF
--- a/releases/release-1.32/release-notes/maps/pr-125923-map.yaml
+++ b/releases/release-1.32/release-notes/maps/pr-125923-map.yaml
@@ -1,6 +1,7 @@
 pr: 125923
 releasenote:
-  text: 'Fixed a bug where the kubelet ephemerally failed with `failed to initialize
-    top level QOS containers: root container [kubepods] doesn't exist`, due to the
-    cpuset cgroup being deleted on cgroup v2 with systemd cgroup manager.'
+  text: >
+    Fixed a bug where the kubelet ephemerally failed with `failed to initialize top
+    level QOS containers: root container [kubepods] doesn't exist`, due to the cpuset
+    cgroup being deleted on cgroup v2 with systemd cgroup manager.
 pr_body: ""


### PR DESCRIPTION
This fixes the yaml indentation errors in the release-notes-v1.32 maps as that blocks the generation of release-notes-v.32-alpha.3 PR

cc @saschagrunert @satyampsoni @fsmunoz 