### PR TITLE
Merge Docs and Release Notes subteams

### DIFF
--- a/release-team/role-handbooks/docs/README.md
+++ b/release-team/role-handbooks/docs/README.md
@@ -1,19 +1,30 @@
 # Kubernetes Docs Role Handbook
 - [Overview](#overview)
     - [Common Terms](#common-terms)
-- [Docs Lead Responsibilities](#docs-lead-responsibilities)
+- [Tasks and Responsibilities](#tasks-and-responsibilities)
 - [Prerequisites for Docs Lead and Shadows](#prerequisites-for-docs-lead-and-shadows)
     - [General Requirements](#general-requirements)
     - [Time Requirements](#time-requirements)
     - [Prerequisites for Docs Leads](#prerequisites-for-docs-leads)
     - [Prerequisites for Shadows](#prerequisites-for-shadows)
+    - [Machine and GitHub Setup](#machine-and-github-setup)
+      - [Set up krel](#set-up-krel)
+      - [Fork the kubernetes repositories](#fork-the-kubernetes-repositories)
 - [Release Timeline](#release-timeline)
+- [Tools](#tools)
+- [Debugging Tips](#debugging-tips)
+- [Release Notes File Structure](#release-notes-file-structure)
+- [TODOs](#todos)
 
 ## Overview
 
-This document covers the responsibilities, time commitments, and timeline for Docs Leads shepherding docs releases for Kubernetes. Docs Lead Shadows should also read through this document and understand the launch processes so they can do it in the future.
+This document covers the responsibilities, time commitments, and timeline for Docs Leads shepherding docs releases for Kubernetes, including the generation and fine-tuning of Release Notes. Docs Lead Shadows should also read through this document and understand the launch processes so they can do it in the future.
 
-**Please refer to the Docs [Release Timeline](/release-team/role-handbooks/docs/Release-Timeline.md) for an exhaustive list of the responsibilities of the Docs Lead.** 
+The Docs Lead will be responsible for introducing shadows to the team and the release notes subcommand in [krel](https://github.com/kubernetes/release/tree/master/docs/krel). Shadows should expect to perform this task at least once themselves. The Docs Lead should indicate pain points and known issues to the shadows (if there are any) and work on strategies for overcoming them to avoid their coalescence during the later weeks.
+
+If there are potential fixes to the issues indicated and team members are keen, fixes and automation of the process is very welcome but not expected.
+
+**Please refer to the Docs [Release Timeline](/release-team/role-handbooks/docs/Release-Timeline.md) for an exhaustive list of the responsibilities of the Docs Team.** 
 
 ### Common Terms
 
@@ -23,18 +34,19 @@ This document covers the responsibilities, time commitments, and timeline for Do
 | [future release]     | Release that the team is actively composing | 1.28                                                     |
 | [integration branch] | A PR [WIP] merging dev branch into main   | [Official 1.27 Release Docs dev branch](https://github.com/kubernetes/website/pull/39124) |                                                    
 
-## Docs Lead Responsibilities
+## Tasks and Responsibilities
 
-The Docs Lead is responsible for working with the Release Team to coordinate documentation updates for the next Kubernetes release. 
+The Docs Lead is responsible for working with the Release Team to coordinate documentation updates for the next Kubernetes release, including the generation of Release Notes.
 
-Responsibilities include:
+### Responsibilities Overview
 
 * Identifying new Kubernetes features and enhancements ([Kubernetes Enhancement Proposals, also referred to as KEPs](https://www.kubernetes.dev/resources/keps/)) that require new documentation and tracking them using the Enhancements Tracking sheet created for the release (e.g. [Example Enhancements Tracking sheet from the Kubernetes 1.26 Release](https://github.com/orgs/kubernetes/projects/117/views/3))
 * Creating a dev branch used by contributors to target documentation updates for the upcoming release
+* Generating, reviewing, and fixing Release Notes periodically throughout the release cycle
 * Offering guidance to contributors about how to contribute new feature and enhancements documentation and working with contributors to modify existing docs to accurately represent any upcoming changes 
 * Providing weekly updates to the Release Team about the current state of release-bound docs
 * Mentoring Docs Lead Shadows throughout this process and empowering them with the knowledge needed to be future Docs Leads
-* Working with SIG-Docs to review documentation PRs according to the website [Style Guide](https://kubernetes.io/docs/contribute/style/style-guide/) to ensure quality 
+* Working with SIG Docs to review documentation PRs according to the website [Style Guide](https://kubernetes.io/docs/contribute/style/style-guide/) to ensure quality 
 * Working with SIG owners to ensure documentation is reviewed for technical accuracy
 * Working with Release Comms to review the Release Blog
 * Approving reviewed documentation to ensure its inclusion in the upcoming release
@@ -58,6 +70,26 @@ General time requirements for leads and shadows are:
 - Between 1 and 2 hours a week to attend the majority of Release Team (weekly) and Burndown meetings (daily during Code Freeze), subject to time zone appropriateness
 - Up to 1 hour weekly to attend [SIG Docs meetings](https://github.com/kubernetes/community/tree/master/sig-docs#meetings) for status reports
 
+#### Onboarding Session (week 1) ~1 hour
+
+In the first week of the release cycle, the Docs Lead will organize an onboarding session with the shadows to go over general responsibilities and expectations.
+
+#### Early and mid release cycle (weeks 1-8) ~1-5 hours/week
+
+In the first 8 weeks of the cycle, the Docs team must attend weekly release meetings and run the [release-notes subcommand of krel](https://github.com/kubernetes/release/blob/master/docs/krel/release-notes.md) for every `alpha`, `beta` and `rc` to create an early draft of the release notes. This ensures that the overall quality of the release notes can be verified from the beginning of the release cycle.
+
+Weekly branch syncs must be run to ensure consistency from `main` to `dev-[future-release]`. The Docs team is responsible for the communication of documentation-related deadlines to KEP owners and SIG leads, as well as the tracking of documentation and enforcement of deadlines.
+
+All members of the Docs subteam should participate in PR reviews as time allows.
+
+#### Late release cycle (weeks 9-12+) ~4-10 hours/week
+
+This period has an increase in release team meetings each week and there is also significantly more work to do to ensure the release notes and documentation are in good working order for the release.
+
+The `release-notes` subcommand of `krel` must continue to be run on the release branch (for `beta` and `rc` releases) in order to pull in any outstanding PRs that are merged between the beginning of code freeze and the release.
+
+The Docs Lead will sync with the Comms team as well as SIG Docs and SIG Cluster-lifecycle, as well as begin prepping the website for the release day. On release day, the Docs Lead merges the documentation, publishes the release blog, and updates the website.
+
 **During the last weeks of the release, shadows should expect to spend at least 5 hours and leads at least 10 hours finalizing the launch.**
 
 ### Prerequisites for Docs Leads
@@ -74,12 +106,102 @@ In addition to the time requirements above, a Docs Lead must:
 
 Docs Lead Shadows are people who are preparing to be a Docs Lead in the future. In addition to the time requirements above, shadows must:
 
+- Strong written and verbal communications skills
+- A working knowledge of Kubernetes concepts
+- Project management experience is helpful but not required
 - Have signed the [contributor CLA](https://github.com/kubernetes/community/blob/master/CLA.md) for Kubernetes.
 - Be invested in becoming an org member within the release cycle. This can often be achieved during the release cycle with sponsorship from a role lead. See the [Release Team onboarding guide](/release-team/release-team-onboarding.md) for more details.
-- General knowledge of our SIG-Docs [areas of responsibility](https://github.com/kubernetes/community/tree/master/sig-docs#subprojects).
+- General knowledge of our SIG Docs [areas of responsibility](https://github.com/kubernetes/community/tree/master/sig-docs#subprojects).
 - Experience with the general process involved with [contributing](https://kubernetes.io/docs/contribute/start/) to Kubernetes website.
 - Be a [milestone maintainer](https://github.com/orgs/kubernetes/teams/website-milestone-maintainers/) in order to have the ability to add a milestone to an issue. Access can be requested by creating a [PR](https://github.com/kubernetes/org/pull/2235) against `kubernetes/org` repo.
+
+### Machine and GitHub Setup
+
+#### Setup krel
+
+[Install Go](https://golang.org/doc/install) in your machine and follow the [instructions to build the release tools](https://github.com/kubernetes/release/tree/master/docs/krel#installation) in your machine. Check the system requirements in the krel documentation.
+
+#### Fork the kubernetes repositories
+
+Fork the following repositories to your GitHub account, and clone them using SSH:
+
+ - [`kubernetes/sig-release`](https://github.com/kubernetes/sig-release): This is where you will push regular PRs to keep the Release Notes draft up to date.
+ - [`kubernetes-sigs/release-notes`](https://github.com/kubernetes-sigs/release-notes): This repo has the [release notes website](https://relnotes.k8s.io) sources
 
 ## Release Timeline
 
 Reference the Docs [Release Timeline](Release-Timeline.md) for key dates and responsibilities during the release cycle and the Kubernetes Release Information page for the specific release (e.g. [Kubernetes 1.28 Release Information page](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.28/README.md) for information regarding the current release cycle including important dates, Release Team contact information, tracking spreadsheets, and more.
+
+## Tools
+- [krel](https://github.com/kubernetes/release/tree/master/docs/krel) The Kubernetes Release Toolbox *(note: always use the latest version of krel to ensure you have the latest fixes/patches)*
+- [The krel `release-notes` subcommand](https://github.com/kubernetes/release/blob/master/docs/krel/release-notes.md)
+- [The old release notes tool](https://github.com/kubernetes/release/tree/master/cmd/release-notes)
+- [Release notes website](https://relnotes.k8s.io) *(note: release notes website is only required for the final release)*
+- [go-modiff](https://github.com/saschagrunert/go-modiff)
+- [Hackmd](https://hackmd.io/)
+- [LWKD](http://lwkd.info) *(note: consider contributing to LWKD as part of your role)*
+- [Kubernetes Documentation Style Guide](https://kubernetes.io/docs/contribute/style/style-guide/)
+
+## Debugging Tips
+
+If you are having trouble running the `krel` tool, here are some common issues and solutions:
+
+1. Try running with `--log-level=debug` or `--log-level=trace` to get more information about what is going wrong.
+2. A temp directory gets created at `/var/folders/7t/273pt80d51l70mj4rxznq_lm0000gn/T/<k8s-hash>` when the `krel` tool is called.
+If this data is stale, you can try clearing to remove old data with `rm -rf /var/folders/7t/273pt80d51l70mj4rxznq_lm0000gn/T/k8s`
+
+Checkout the documentation for the [krel `release-notes` subcommand](https://github.com/kubernetes/release/blob/master/docs/krel/release-notes.md).
+
+## Release Notes File Structure
+
+All the release notes for a release are stored under the [releases](https://github.com/kubernetes/sig-release/tree/master/releases) 
+directory in the sig-release repo. 
+
+For each release there is a JSON and markdown file that contains the collected release notes across path releases. For example,
+the 1.30 release [markdown file](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.30/release-notes/release-notes-draft.md)
+contains all the correctly formatted release notes text for the 1.30 release. The [JSON file](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.30/release-notes/release-notes-draft.json)
+contains the release notes metadata that is used to generate the markdown file. 
+
+When a Docs team member runs the `krel release-notes` command, a new session is created so that you can pause and resume
+the editing process. For example the 1.30 release notes sessions are stored in the [sessions](https://github.com/kubernetes/sig-release/tree/master/releases/release-1.30/release-notes/sessions)
+directory in the sig-release repo under `release-1.30`.
+
+If a Docs team member finds a mistake in the release notes, the edit will be saved as a map yaml file in the [maps](https://github.com/kubernetes/sig-release/tree/master/releases/release-1.30/release-notes/maps)
+directory. These maps are used to generate the markdown file and JSON file with the correctly edited release note. 
+
+## TODOs
+
+As a Docs shadow, if you are interested in contributing to the improvement of the release notes process, consider the following
+areas of improvement:
+
+#### Github Workflow to Detect Common Release Note Issues
+
+- YAML linter to block invalid yaml merging in from manually edited release notes. If suggestions are commited that have 
+invalid yaml, the krel tool will not be able to be run on the next release until the error is fixed in a separate pr. 
+See [example PR](https://github.com/kubernetes/sig-release/pull/2446) from the 1.30 release that unblocked the `v1.30.0-alpha.3` release.
+- Spell check based on dictionary of common Kubernetes terms.
+- Check for correct punctuation in release notes.
+- Check for incorrect tense in release notes.
+- Look into using [Vale.sh](https://vale.sh/) or the [Valve GitHub action](https://github.com/errata-ai/vale) to add editorial checks to the release notes PR
+
+Some initial work has been done in [this GitHub workflow](https://github.com/npolshakova/sig-release/blob/npolshak/workflow/.github/workflows/release-notes-checker.yaml) to introduce checks for common issues in release notes. 
+Here is an [example run of the workflow](https://github.com/rudrakshkarpe/sig-release/actions/runs/8073807523/job/22058097731) for the 1.30.0-alpha2 release. This is a good starting point for further improvements.
+
+#### Release Notes tool to automatically process language
+
+If any team members have NLP experience, implement functionality in release-notes tool to automatically process language in generated release notes file
+
+Goals:
+
+- Generate uniform style across release notes (ie. past tense, formatting).
+- Decrease copy editing time.
+
+#### Release Notes Machine Learning Classifier
+
+The idea is to build a continuous release notes improvement process to train a machine learning model to classify.
+release notes as good or bad. The input for the model should be created continuously during the whole release cycle.
+by Release Notes Team of SIG Release. See the [issue](https://github.com/kubernetes/enhancements/issues/1833) for more details.
+
+#### Krel tool improvements 
+
+- Update krel tool to show progress of how many PRs to review are left and other bugs.

--- a/release-team/role-handbooks/docs/README.md
+++ b/release-team/role-handbooks/docs/README.md
@@ -86,7 +86,7 @@ All members of the Docs subteam should participate in PR reviews as time allows.
 
 This period has an increase in release team meetings each week and there is also significantly more work to do to ensure the release notes and documentation are in good working order for the release.
 
-The `release-notes` subcommand of `krel` must continue to be run on the release branch (for `beta` and `rc` releases) in order to pull in any outstanding PRs that are merged between the beginning of code freeze and the release.
+The `release-notes` subcommand of `krel` must continue to be run on the release branch (for `alpha`, `beta` and `rc` releases) in order to pull in any outstanding PRs that are merged between the beginning of code freeze and the release.
 
 The Docs Lead will sync with the Comms team as well as SIG Docs and SIG Cluster-lifecycle, as well as begin prepping the website for the release day. On release day, the Docs Lead merges the documentation, publishes the release blog, and updates the website.
 

--- a/release-team/role-handbooks/docs/README.md
+++ b/release-team/role-handbooks/docs/README.md
@@ -140,7 +140,7 @@ Reference the Docs [Release Timeline](Release-Timeline.md) for key dates and res
 - [Release notes website](https://relnotes.k8s.io) *(note: release notes website is automatically updated)*
 - [go-modiff](https://github.com/saschagrunert/go-modiff)
 - [Hackmd](https://hackmd.io/)
-- [LWKD](http://lwkd.info) *(note: consider contributing to LWKD as part of your role)*
+- [LWKD](http://lwkd.info) *(note: contributing to LWKD is not a requirement as part of the Docs shadow role, but might be of interest to shadows.)*
 - [Kubernetes Documentation Style Guide](https://kubernetes.io/docs/contribute/style/style-guide/)
 
 ## Debugging Tips

--- a/release-team/role-handbooks/docs/README.md
+++ b/release-team/role-handbooks/docs/README.md
@@ -22,7 +22,7 @@ This document covers the responsibilities, time commitments, and timeline for Do
 
 The Docs Lead will be responsible for introducing shadows to the team and the release notes subcommand in [krel](https://github.com/kubernetes/release/tree/master/docs/krel). Shadows should expect to perform this task at least once themselves. The Docs Lead should indicate pain points and known issues to the shadows (if there are any) and work on strategies for overcoming them to avoid their coalescence during the later weeks.
 
-If there are potential fixes to the issues indicated and team members are keen, fixes and automation of the process is very welcome but not expected.
+If there are potential fixes to the issues indicated and team members are keen, fixes and automation of the process are encouraged but not required.
 
 **Please refer to the Docs [Release Timeline](/release-team/role-handbooks/docs/Release-Timeline.md) for an exhaustive list of the responsibilities of the Docs Team.** 
 
@@ -108,7 +108,8 @@ Docs Lead Shadows are people who are preparing to be a Docs Lead in the future. 
 
 - Strong written and verbal communications skills
 - A working knowledge of Kubernetes concepts
-- Project management experience is helpful but not required
+- Familiarity with Git and command line tools.
+- Project management experience is helpful but not required.
 - Have signed the [contributor CLA](https://github.com/kubernetes/community/blob/master/CLA.md) for Kubernetes.
 - Be invested in becoming an org member within the release cycle. This can often be achieved during the release cycle with sponsorship from a role lead. See the [Release Team onboarding guide](/release-team/release-team-onboarding.md) for more details.
 - General knowledge of our SIG Docs [areas of responsibility](https://github.com/kubernetes/community/tree/master/sig-docs#subprojects).
@@ -136,7 +137,7 @@ Reference the Docs [Release Timeline](Release-Timeline.md) for key dates and res
 - [krel](https://github.com/kubernetes/release/tree/master/docs/krel) The Kubernetes Release Toolbox *(note: always use the latest version of krel to ensure you have the latest fixes/patches)*
 - [The krel `release-notes` subcommand](https://github.com/kubernetes/release/blob/master/docs/krel/release-notes.md)
 - [The old release notes tool](https://github.com/kubernetes/release/tree/master/cmd/release-notes)
-- [Release notes website](https://relnotes.k8s.io) *(note: release notes website is only required for the final release)*
+- [Release notes website](https://relnotes.k8s.io) *(note: release notes website is automatically updated)*
 - [go-modiff](https://github.com/saschagrunert/go-modiff)
 - [Hackmd](https://hackmd.io/)
 - [LWKD](http://lwkd.info) *(note: consider contributing to LWKD as part of your role)*

--- a/release-team/role-handbooks/docs/README.md
+++ b/release-team/role-handbooks/docs/README.md
@@ -69,6 +69,9 @@ General time requirements for leads and shadows are:
 - ½ hour to 2 hours a day, reviewing incoming enhancements, tracking documentation PRs, and monitoring Slack
 - Between 1 and 2 hours a week to attend the majority of Release Team (weekly) and Burndown meetings (daily during Code Freeze), subject to time zone appropriateness
 - Up to 1 hour weekly to attend [SIG Docs meetings](https://github.com/kubernetes/community/tree/master/sig-docs#meetings) for status reports
+- Create [known issues issue](https://github.com/kubernetes/sig-release/blob/master/release-team/role-handbooks/release-notes/known-issues-bucket.md) in kubernetes/kubernetes to capture known issues for the release
+- Send [an email to SIG-leads](https://github.com/kubernetes/sig-release/blob/master/release-team/role-handbooks/release-notes/sig-leads-email.md) to ensure major changes for their SIGs are accurately reflected in the release notes
+- Send a slack message to the sig channels to ensure major changes for the SIGs are accurately reflected in the release notes 
 
 #### Onboarding Session (week 1) ~1 hour
 

--- a/release-team/role-handbooks/docs/Release-Timeline.md
+++ b/release-team/role-handbooks/docs/Release-Timeline.md
@@ -10,18 +10,24 @@
     - [Select Shadows](#select-shadows)
     - [Contact volunteers](#contact-volunteers)
     - [Meet with Shadows](#meet-with-shadows)
+    - [Define schedule](#define-schedule)
     - [Ensure access is set up](#ensure-access-is-set-up)
     - [Update the website configuration ahead of the release](#update-the-website-configuration-ahead-of-the-release)
   - [Middle Steps (Weeks 3-8)](#middle-steps-weeks-3-8)
     - [Track PRs](#track-prs)
     - [Communicate major deadlines](#communicate-major-deadlines)
+    - [Begin Generating Release Notes](#begin-generating-release-notes)
+        - [Set up the Tools and Generate the Release Notes](#set-up-the-tools-and-generate-the-release-notes)
+        - [Periodically review and fix new release notes](#periodically-review-and-fix-new-release-notes)
+        - [Maintain Known Issues](#maintain-known-issues)
+        - [Ensure Release Highlights are Reflected in the Notes](#ensure-release-highlights-are-reflected-in-the-notes)
+        - [Get feedback from SIG Leads](#get-feedback-from-sig-leads)
     - [Reach out to Enhancement Owners](#reach-out-to-enhancement-owners)
       - [Before the Open Placeholder PR Deadline](#before-the-open-placeholder-pr-deadline)
       - [Before the PRs Ready for Review Deadline](#before-the-prs-ready-for-review-deadline)
       - [Before the Docs Freeze Deadline](#before-the-docs-freeze-deadline)
       - [Week of Docs Freeze](#week-of-docs-freeze)
       - [After Docs Freeze](#after-docs-freeze)
-    - [Reach out to release notes team](#reach-out-to-release-notes-team)
     - [Maintain the current and upcoming `dev` branch](#maintain-the-current-and-upcoming-dev-branch)
       - [⚠️ Periodically merge `main` into `dev-[future release]`](#️-periodically-merge-main-into-dev-future-release)
     - [Monitor PRs](#monitor-prs)
@@ -33,6 +39,8 @@
   - [Late Steps (Weeks 9-11) - Prep for the release](#late-steps-weeks-9-11---prep-for-the-release)
     - [Touch base with SIG Docs](#touch-base-with-sig-docs)
     - [Touch base with SIG Cluster Lifecycle (kubeadm)](#touch-base-with-sig-cluster-lifecycle-kubeadm)
+    - [Clean up and edit the final Release Notes](#clean-up-and-edit-the-final-release-notes)
+    - [Curate the External Dependencies section](#curate-the-external-dependencies-section)
     - [Update Releases Page (the week before the release)](#update-releases-page-the-week-before-the-release)
   - [Release Week (Week 12)](#release-week-week-12)
     - [Update the site configuration files for previous releases](#update-the-site-configuration-files-for-previous-releases)
@@ -47,6 +55,7 @@
       - [Get approvals for open PRs](#get-approvals-for-open-prs)
       - [Review milestone](#review-milestone)
   - [Release Day](#release-day)
+    - [Publish final Release Notes](#publish-final-release-notes)
     - [Merge the integration branch](#merge-the-integration-branch)
     - [Publish the release blog post](#publish-the-release-blog-post)
     - [Create release with tag](#create-release-with-tag)
@@ -85,7 +94,7 @@ Responsibilities of the Docs Team:
 - Track Doc PRs for KEPs in the [website](https://github.com/kubernetes/website) project, plus all Doc PRs for the dev-[future release] branch that may include general updates without a KEP.
 - By default, all opted-in KEPs will `Need Docs`. Enhancement owners/contributors should confirm the enhancement does not need new or updated documentation.
 
-> Note: The blog-PR  is tracked by the Release-Comms Team.
+> Note: The blog-PR  is tracked by the Release Comms Team.
 
 > Note: The kubernetes/website repo changed from using a `master` branch to a `main` branch in 2021.
 > Be aware that several linked, example PRs uses the `master` branch.
@@ -120,13 +129,13 @@ Early in the release cycle, the Enhancements Lead opens a Github Project, e.g: [
 > Note: Until [1.25](https://tinyurl.com/k8s125-enhancements) was used tracking spreadsheet, e.g: [the 1.21 release spreadsheet](http://bit.ly/k8s121-enhancements).
 
 ⚠️ Tasks to DO:
-- [x] Make sure your team is included in the "current" release team file, e.g: [release 1.21](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.21/release-team.md). **If not submit a PR see a sample for 1.21 [here](https://github.com/kubernetes/sig-release/pull/1432)**.
-- [x] Please create a PR against kuberenetes/sig-release repo to include the Team Docs email of this release under release-team group in [sig-release/group.yaml](https://github.com/kubernetes/k8s.io/blob/main/groups/sig-release/groups.yaml)
-- [x] Open a PR to add the Docs Team in the release-1.xx. For example here is the Release Team of [1.26](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.26/release-team.md)
+- [ ] Make sure your team is included in the "current" release team file, e.g: [release 1.21](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.21/release-team.md). **If not submit a PR see a sample for 1.21 [here](https://github.com/kubernetes/sig-release/pull/1432)**.
+- [ ] Please create a PR against kuberenetes/sig-release repo to include the Team Docs email of this release under release-team group in [sig-release/group.yaml](https://github.com/kubernetes/k8s.io/blob/main/groups/sig-release/groups.yaml)
+- [ ] Open a PR to add the Docs Team in the release-1.xx. For example here is the Release Team of [1.26](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.26/release-team.md)
 
 ### Introduce yourself to docs localization teams
 
-- [x] Create a GitHub discussion in [k/sig-release](https://github.com/kubernetes/sig-release/discussions/) to introduce yourself to the current localization owners and to sync up early on the release timeline, e.g:
+- [ ] Create a GitHub discussion in [k/sig-release](https://github.com/kubernetes/sig-release/discussions/) to introduce yourself to the current localization owners and to sync up early on the release timeline, e.g:
 > Title: K8s 1.21 - Formalize docs release strategy with docs localization owners
 >
 > Hello :wave:,
@@ -152,6 +161,10 @@ _Note:_ SIG Docs prefers and welcomes a status of yellow or red on anything that
 [ ] Has the weekly branch sync been done? (a lapse in 1-2 branch syncs indicates 'yellow' status, 3 or more lapses should be deemed red)
 
 [ ] Has the PR for the weekly branch sync merged or does it need review? If assistance is needed to resolve merge conflicts, please flag others by communicating on the #release-docs Slack channel
+
+[ ] Is the Release Notes PR open, reviewed, and merged within the deadline?
+
+[ ] Is the Release Notes PR late or blocked?
 
 [ ] A week before the Docs PR Placeholder deadline, have 80% of the enhancements that opted in for docs created a placeholder PR? (anything below 60% opt-in for docs where placeholder PRs are needed should indicate yellow (or red) status, contingent on the amount)
 
@@ -187,7 +200,7 @@ Verify the shadow selections with the release lead and the emeritus advisor on S
 
 ### Contact volunteers
 
-- [x] Send a Slack message to those that you select, e.g:
+- [ ] Send a Slack message to those that you select, e.g:
 
 > Hey, you're officially on the SIG Docs 1.21 release team as a shadow! Let me know if there's any issues with being a shadow (as far as timing / availability / etc) and feel free to introduce yourself!
 >
@@ -240,6 +253,12 @@ Send a Slack message to those that you didn't select, e.g:
 Find .5-1 hour of time to meet with shadows and explain the release process. Walk through this entire document and review the flow with them. It helps to set expectations that the mantra is "hurry up and wait" but then it gets very hectic at the end. If you have the ability to, please record the meeting and share it with your Shadows for future review.
 
 1. Add contacts to the shadows release docs, e.g: [https://bit.ly/k8s121-contacts](https://bit.ly/k8s121-contacts)
+    
+### Define schedule
+
+Create a table to track `Release`, `Branch Created Day`, `Week of Release`, `PR Merge Deadline`, `Release Notes Assignee`
+and `Release Notes Reviewer` based on the release timeline. This will serve as an internal schedule and signup sheet for
+the release notes team to follow. The schedule is used to track progress and give status updates during release team meetings. 
 
 ### Ensure access is set up
 
@@ -364,6 +383,52 @@ Example notice:
 > Thanks! Important dates for v1.21: https://github.com/kubernetes/sig-release/blob/master/releases/release-1.21/README.md#tldr
 >
 > ![Bring out your docs](pics/meme-deadline.jpg)
+    
+### Begin generating Release Notes
+Begin running release-notes tool for the ongoing collection of release notes with the first alpha release, which has been cut directly after the latest minor.
+
+- Update the `release-notes-draft.md`
+- Verify release notes are available on (relnotes.k8s.io)[https://relnotes.k8s.io/]
+- Informal intro meeting with release notes team to discuss contact information and logistics
+
+#### Set up the Tools and Generate the Release Notes
+
+The Docs team is responsible for the generation of the release notes during the release cycle.
+
+At least one member of the Docs Team should be responsible for [setting up](https://github.com/kubernetes/release/tree/master/docs/krel#installation) and [running](https://github.com/kubernetes/release/blob/master/docs/krel/release-notes.md) the release-notes subcommand of krel to generate the release notes after each Patch Release:
+
+1. Update the release notes draft, a markdown file which will become the final document which will encompass all release notes written by contributors during the current release cycle. See previous drafts for versions [1.25](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.25/release-notes/release-notes-draft.md), [v1.24](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.24/release-notes/release-notes-draft.md) or [v1.23](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.23/release-notes/release-notes-draft.md).
+
+Detailed instructions for generating the release notes bundle is in the [krel release-notes subcommand documentation](https://github.com/kubernetes/release/blob/master/docs/krel/release-notes.md).
+
+#### Periodically review and fix new release notes
+
+The Docs team must make sure that the final document includes well-written and informative release notes. To achieve a high-quality document the team should review and edit the
+notes by running `krel release-notes --fix` weekly or as often as development pace
+demands.
+
+This command will enable the team to review each release note and edit the note's data. It is recommended that the team splits the work among all members and runs the editing flow on a weekly or biweekly basis. More information about the editing flow can be found in a separate document detailing the [editing process and tooling](editing-flow.md).
+
+The general style guide for release notes includes checking for:
+- Past tense: Release notes should be written in the past tense since the changes have already been implemented.
+- Technical jargon: While the notes are generally user-friendly, some technical terms like "VAC" or "scheduling hints" could be explained briefly with backticks or double quotes for users unfamiliar with them.
+- Additional context: In some cases, providing more context about the problem these changes address or the specific situations where they're relevant could be helpful for understanding their significance. You can find additional context referenced in the PR in k8s/k8s repo to check what the PR does for end users.
+
+Additional style guidelines can be found in the [Documentation Style Guide](https://kubernetes.io/docs/contribute/style/style-guide/).
+
+#### Maintain Known Issues
+
+A ["Known Issues Umbrella Issue"](known-issues-bucket.md) for the release must be created by the Docs team in [kubernetes/kubernetes](https://github.com/kubernetes/kubernetes/issues/new) so issues can be collected for the "Known Issues" section of the release notes. See previous known issues for [1.25](https://github.com/kubernetes/kubernetes/issues/110336), [1.24](https://github.com/kubernetes/kubernetes/issues/109027), [v1.23](https://github.com/kubernetes/kubernetes/issues/104885), [v1.22](https://github.com/kubernetes/kubernetes/issues/101728), [v1.21](https://github.com/kubernetes/kubernetes/issues/98232), [v1.19](https://github.com/kubernetes/kubernetes/issues/90304), [v1.18](https://github.com/kubernetes/kubernetes/issues/86882) or [v1.17](https://github.com/kubernetes/kubernetes/issues/83683).
+
+#### Ensure Release Highlights are Reflected in the Notes
+
+The Communications team will hold a meeting to discuss Release Highlights sometime around Code Freeze. Ensure that at least one person from the Docs team attends this meeting with the Release Lead and Enhancements Lead. The Docs team should ensure that the "Release Highlights" identified in this meeting are reflected in the "Release Highlights" section of the release notes. If no one is able to attend the meeting, reach out to the Communications team, Release Lead or Enhancements Lead to ensure messaging around Release Highlights is coordinated.
+
+#### Get feedback from SIG Leads
+
+Around Code Freeze, the Docs team will get in touch with the SIG Leads to ensure that the Release Notes accurately reflect the major themes for their SIGs. The team will also ensure that major issues captured in the release notes are confirmed by the SIG leads before release day.
+
+If gentle nudging of SIG Leads is not effective in retrieving feedback/confirmation, the Docs Team can use a reasonable amount of creative liberty in completing the notes.
 
 ### Reach out to Enhancement Owners
 
@@ -432,11 +497,6 @@ Once Docs Freeze has passed, if there are any docs PRs not marked "ready to merg
 >Hello 👋, {current release} Docs team here.
 This PR did not meet deadline for [docs freeze](https://github.com/kubernetes/sig-release/blob/master/releases/release_phases.md#docs-freeze).
 Enhancements without required documentation may be removed from the current release. If you still wish to include this enhancement in {current release}, please file an [exception](https://github.com/kubernetes/sig-release/blob/master/releases/EXCEPTIONS.md) request. Thanks!
-
-### Reach out to release notes team
-Reach out to release notes team to see if there's anything that might need docs that isn't already clearly known, e.g:
-
-> Hey :wave: Release Notes folks! I just wanted to touch base early in the cycle to introduce myself (Jim Angel, SIG Docs Lead for 1.14) and to ask that we stay in touch as you start drafting your release notes. This came up from previous SIG Docs Leads, who said they found things in the release notes that _probably needed docs_. Any questions?
 
 ### Maintain the current and upcoming `dev` branch
 
@@ -574,6 +634,14 @@ The Kubernetes API reference, kubectl, and components documentation are generate
 Validate that SIG Cluster Lifecycle has all of the docs in place for the upcoming release. These are mainly kubeadm docs (upgrading, installing, changes, etc). If unsure, send a message to their [Slack](https://kubernetes.slack.com/messages/sig-cluster-lifecycle/) channel, e.g:
 
 > Hi SIG Cluster Lifecylce :wave:  1.21 Docs Lead here, can someone confirm that all docs are in place for the upcoming 1.21 release?
+    
+### Clean up and edit the final Release Notes
+
+The confirmed release notes are cleaned up and copy edited by the Docs team to ensure uniform language/style is used. The team must make sure that the final document conforms to the [Documentation Style Guide](https://kubernetes.io/docs/contribute/style/style-guide/).
+
+### Curate the External Dependencies section
+
+A "Dependencies" section should be curated which outlines how external dependency versions have changed since the last release. These changes are currently [automatically aggregated](https://github.com/kubernetes/community/issues/2234), but should still be manually validated for correct content and formatting.
 
 ### Update Releases Page (the week before the release)
 
@@ -760,6 +828,13 @@ Review milestone for completion and outstanding PRs. For PRs that won't make the
 This process takes approximately 4 hours.
 
 Coordinate with the Release Team for the exact timing. Typically the release is 'officially' built, then you merge the docs, and then you approve the blog post to "make it official". For 1.21, we merged docs at 11:00 am PDT and the blog was merged at 11:30 am PDT - marking the release "complete".
+    
+### Publish final Release Notes
+
+- Final version of release notes committed for release
+- Close the _Known Issues_ Issue and make sure everything has been resolved
+- Release Notes must be merged into master prior to the release. If this is not done the release will include the latest draft.
+- Keep an eye on the #release-notes channel for any requests for any questions, edits or missed release notes.
 
 ### Merge the integration branch
 

--- a/release-team/role-handbooks/docs/editing-flow.md
+++ b/release-team/role-handbooks/docs/editing-flow.md
@@ -1,0 +1,255 @@
+# Release Notes Editing Flow
+  - [Introduction](#introduction)
+  - [Motivation](#motivation)
+  - [Workflow Operation](#workflow-operation)
+    - [krel release-notes --fix](#krel-release-notes--fix)
+      - [Starting the interactive mode](#starting-the-interactive-mode)
+      - [Reviewing and editing the release notes](#reviewing-and-editing-the-release-notes)
+      - [Exiting the review loop](#exiting-the-review-loop)
+    - [Submitting changes back](#submitting-changes-back)
+    - [Re-running the workflow](#re-running-the-workflow)
+      - [Modified Release Notes](#modified-release-notes)
+
+
+## Introduction
+
+Ensuring the production of a document comprised of well written and 
+informative release notes is one of the responsibilities of the 
+Release Team each cycle. 
+
+A good introduction talk is the "[Lightning Talk: Kubernetes Release Notes Tips & Tricks](https://www.youtube.com/watch?v=n62oPohOyYs)" 
+where you can find some general guidelines about the release notes 
+(wording, grammar, labels, etc).
+
+Release Engineering has developed various tools to help the Team 
+complete its duties. One of them is `krel` — the [Kubernetes Release
+Toolbox](https://github.com/kubernetes/release/tree/master/docs/krel).
+Krel has many subcommands that help the release process in many ways,
+among them the `release-notes` subcommand.
+
+This document details how to use krel to review and edit the 
+Kubernetes release notes during the cycle. 
+
+## Motivation
+
+The final Kubernetes Release Notes document is a large document composed of
+hundreds of entries that the contributors write into their Pull Requests. As
+an example, the [release notes document for Kubernetes 1.19](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.19.md)
+has 388 entries.
+
+Before v1.20, the Release Notes Team had to wait until code freeze to review
+and edit each Kubernetes release note in a short time. During the same
+timespan, the Team was expected to contact the sigs and edit the Major themes.
+Work was unbalanced with little to do most of the cycle and a packed 
+agenda during the last few weeks. 
+
+To balance the team's efforts evenly, tooling was developed to enable a new workflow.
+
+## Workflow Operation
+
+Reviewing the release notes involves running krel regularly to review new release
+notes in incoming pull requests, possibly editing some of them, and submitting
+changes back to the `sig-release` repository.
+
+### `krel release-notes --fix`
+
+The main interactive editing flow is started with the `--fix` flag. The interactive
+mode will show the user all release notes that need to be reviewed. After
+reviewing each note, the user can edit the note's attributes using their editor of
+choice.
+
+The `--fix` flag is available when invoking krel with the `--create-draft-pr` option.
+This is an example invocation to edit the release notes for Kubernetes v1.19:
+
+```bash
+krel release-notes --create-draft-pr --org=MyGitHubOrg --fix --tag=v1.19.0
+```
+As with all `krel release-notes` subcommands, a GitHub token must be exported in
+an environment variable called `GITHUB_TOKEN`. The user should supply their GitHub
+organization where krel will push changes and from where it will create pull
+requests.
+
+After invoking the subcommand, krel will clone the `kubernetes/kubernetes` repository
+and query GitHub for all pull requests filed during the specified range. Note that
+this process might take a long time, particularly at the end of the cycle when the
+branch has lots of commits.
+
+Since the note gatherer hits the GitHub API quite heavily, you will get rate limited.
+During a normal operation `krel` will handle them correctly, but you may find yourself
+forced to wait when doing several runs after one another. 
+
+
+#### Starting the interactive mode
+
+When `--fix` is used, krel will switch to interactive mode.
+It will print a short intro and prompt the user before starting:
+
+```
+Welcome to the Kubernetes Release Notes editing tool!
+
+This tool will allow you to review and edit all the release
+notes submitted by the Kubernetes contributors before publishing
+the updated draft.
+
+The flow will show each of the release notes that need to be
+reviewed once and you can choose to edit it or not.
+
+After you choose, it will be marked as reviewed and will not
+be shown during the next sessions unless you choose to do a
+full review of all notes.
+
+You can hit Ctrl+C at any time to exit the review process
+and submit the draft PR with the revisions made so far.
+
+Would you like to continue from the last session? (y/n):
+``` 
+
+#### Reviewing and editing the release notes
+
+Once started, the flow will present the user each release note to
+review. If the user's notices a field that needs to be changed, 
+they might choose to edit that note. Here is an example:
+
+```
+Release Note for PR 92546:
+==========================
+Pull Request URL: https://github.com/kubernetes/kubernetes/pull/92546
+    Author: @liggitt
+    SIGs: [api-machinery]
+    Kinds: [cleanup]
+    Areas: [custom-resources]
+    Feature: false
+    ActionRequired: false
+    ReleaseVersion: 1.19.0
+    Text:
+    │ kube-apiserver: openapi schemas published for custom resources now reference
+    │ standard ListMeta schema definitions
+
+- Fix note for PR #92546? (y/N): 
+
+```
+
+If the user chooses to edit the note when prompted, krel will open the current note
+in the default editor (defined in `$EDITOR`) for the user to edit:
+
+```
+---
+# This is the current map for this Pull Request.
+# The original note content is commented out, if you need to
+# change a field, remove the comment and change the value.
+# To cancel, exit without changing anything or leave the file blank.
+# Important! pr: and releasenote: have to be uncommented.
+#
+# pr: 92546
+# releasenote:
+#   text: 'kube-apiserver: openapi schemas published for custom resources now reference
+#     standard ListMeta schema definitions'
+#   documentation: []
+#   author: liggitt
+#   areas:
+#   - custom-resources
+#   kinds:
+#   - cleanup
+#   sigs:
+#   - api-machinery
+#   feature: false
+#   action_required: false
+#   release_version: 1.19.0
+~
+~                                  
+~                       
+```
+
+By default, all the note's fields are commented out. The user can choose one or more
+fields to uncomment and modify. If at least one field is modified, a [release note map
+file](https://github.com/kubernetes/release/blob/master/docs/release-notes-maps.md) 
+will be created in the release directory after saving the file and exiting the editor.
+
+__Note:__ A valid map file should have at least the PR number and the releasenote struct.
+
+If the user makes an error (a YAML syntax error for example), krel will prompt the user
+to retry editing the note:
+
+```
+ERRO The yaml code does not have a PR number      
+- An error occurred while editing PR #92546. Try again? (y/n)
+```
+
+#### Exiting the review loop
+
+When in the interactive cycle, krel will present the user with every release note that
+has not yet been reviewed. It is not necessary to review all the notes in one go, at
+any time the user may hit Ctrl+C and the interactive flow will exit at that point.
+
+To continue the editing process at a later time, `krel` will save its state
+in the release directory. It will store information about each review session inside of
+the `release-notes/sessions/`. The JSON files include the user's data and the release
+notes reviewed during the session.
+
+At this point, krel will create the current release notes draft. This file is the 
+latest version of the automatically generated release notes and is made public for
+any interested party to review. 
+
+### Submitting changes back
+
+After exiting the interactive mode, krel will prompt the user to create a pull request
+submitting all changes back to the sig-release repository:
+
+```
+INFO Release Notes Draft written to /tmp/k8s-730127624/releases/release-1.19/release-notes-draft.md 
+Create pull request with your changes? (y/n): 
+```
+
+If the user choses so, krel will create the pull request on their behalf by creating a
+branch in their sig-release fork, pushing the changes, and creating the PR in GitHub. 
+
+Note that the PR will include the release notes draft with all changes defined in
+the maps during the editing flow. All the mapping files and session data will be
+submitted in the same PR.
+
+If the user cancels the PR, the local fork of sig-release will be left in a temporary
+directory with all changes done by krel. To submit the changes back to sig-release, 
+the user will be required to push and create the PR manually. To assist them with this
+process, krel will show some instructions:
+
+```
+Create pull request with your changes? (y/n): n
+Pull request creation was canceled. Your local copy of k/sig-release
+has not been deleted for you to review your changes. You may
+push your changes to your fork and create the PR from there.
+
+Your fork of kubernetes/sig-release was cloned here:
+/tmp/k8s-730127624
+
+WARN Pull request canceled. Local changes were not pushed back.
+```
+
+Needless to say, all editing not PR'ed back to sig-release will be lost.
+
+### Re-running the workflow
+
+It is highly recommended that the Release Notes team runs the editing flow
+frequently (say on a weekly basis), alternating team members ensure the
+current user has a reasonable amount of work to do and the editing effort
+is split fairly.
+
+Thanks to the session files, each subsequent run of krel will remember where
+it left off. This means that each user will need to review only new Pull
+Requests that are filed after the last run.
+
+#### Modified Release Notes
+
+During the release cycle, each Pull Request author and/or admins may modify
+the release note and/or flags in GitHub. When this happens, krel will detect
+the change and will present the note again for review, flagging it so that the 
+user knows that the contents have been modified:
+
+```
+Release Note for PR 92546:
+✨ Note contents are modified with a map
+==========================
+Pull Request URL: https://github.com/kubernetes/kubernetes/pull/92546
+    Author: @liggitt
+    SIGs: [api-machinery]
+```
+

--- a/release-team/role-handbooks/docs/editing-flow.md
+++ b/release-team/role-handbooks/docs/editing-flow.md
@@ -62,7 +62,7 @@ The `--fix` flag is available when invoking krel with the `--create-draft-pr` op
 This is an example invocation to edit the release notes for Kubernetes v1.19:
 
 ```bash
-krel release-notes --create-draft-pr --org=MyGitHubOrg --fix --tag=v1.19.0
+krel release-notes --create-draft-pr --org=MyGitHubOrg --fix --tag=v1.19.0 --fork=MyGitHubUsername
 ```
 As with all `krel release-notes` subcommands, a GitHub token must be exported in
 an environment variable called `GITHUB_TOKEN`. The user should supply their GitHub

--- a/release-team/role-handbooks/docs/editing-flow.md
+++ b/release-team/role-handbooks/docs/editing-flow.md
@@ -74,6 +74,8 @@ and query GitHub for all pull requests filed during the specified range. Note th
 this process might take a long time, particularly at the end of the cycle when the
 branch has lots of commits.
 
+The `--fork` flag should be set to your GitHub user (the organization that owns your fork of k/sig-release). This is required to automatically create the release notes branch on your fork of sig-release.
+
 Since the note gatherer hits the GitHub API quite heavily, you will get rate limited.
 During a normal operation `krel` will handle them correctly, but you may find yourself
 forced to wait when doing several runs after one another. 

--- a/release-team/role-handbooks/docs/known-issues-bucket.md
+++ b/release-team/role-handbooks/docs/known-issues-bucket.md
@@ -1,0 +1,24 @@
+First search in [Kubernetes
+issues](https://github.com/kubernetes/kubernetes/issues) to ensure that an
+issue hasn't already been created for `known issues` in the current release. Create a regular issue in
+[kubernetes/kubernetes](https://github.com/kubernetes/kubernetes/issues/new)
+with a title such as:
+
+```
+<RELEASE NUMBER> Release Notes: "Known Issues"
+
+```
+
+And a body such as:
+
+```
+This issue is a bucket placeholder for collaborating on the "Known Issues" additions for the 1.13 Release Notes. If you know of issues or API changes that are going out in 1.13, please comment here so that we can coordinate incorporating information about these changes in the Release Notes.
+
+/assign @<RELEASE NOTES TEAM MEMBERS>
+
+/sig release
+/milestone v<RELEASE NUMBER>
+```
+
+Note: You need to be part of `kubernetes/kubernetes-milestone-maintainers` to
+use the `/milestone` label. If this does not currently apply to you, send a message to the release notes lead or release lead to set the milestone.

--- a/release-team/role-handbooks/docs/relnotes-template.md
+++ b/release-team/role-handbooks/docs/relnotes-template.md
@@ -1,0 +1,36 @@
+<!-- TODO: change the previous version number -->
+
+## Changelog since v1.x.0
+
+A complete changelog for the release notes is now hosted in a customizable
+format at [https://relnotes.k8s.io][1]. Check it out and please give us your
+feedback!
+
+<!-- TODO: change the version number -->
+
+[1]: https://relnotes.k8s.io/?releaseVersions=1.x.0
+
+## What’s New (Major Themes)
+
+<!-- Add themes from Comms Blog here -->
+
+## Known Issues
+
+<!-- Add issues from known issues bucket (known-issues-bucket.md) here -->
+
+<!-- Insert the generated release notes here. Usually they look like:
+## Urgent Upgrade Notes
+### (No, really, you MUST read this before you upgrade)
+## Changes by Kind
+### Deprecation
+### API Change
+### Feature
+### Design
+### Documentation
+### Failing Test
+### Other (Bug, Cleanup or Flake)
+-->
+
+## Dependencies
+
+<!-- Add here -->

--- a/release-team/role-handbooks/docs/sig-leads-email.md
+++ b/release-team/role-handbooks/docs/sig-leads-email.md
@@ -1,0 +1,33 @@
+Hey Everyone,
+
+My name is {NAME}, and I'm on the Release Notes Team for the {RELEASE NUMBER} release.
+
+We've put together a draft of the release notes document so far, but we need
+your help to make sure that the work each SIG has contributed is reflected accurately.
+Please check out the release notes draft document [here]({LINK HERE}) ASAP and:
+
+1. CTRL-F your SIG and edit/move notes to a more appropriate location--we just
+ask that you do it as a suggestion so it's easy for the release notes team to
+keep track of changes.
+
+For example, if you're the SIG lead of SIG CLI, then search for "SIG CLI". This
+will show release notes that were contributed by your SIG as well as release
+notes for features that were a collaboration between your SIG and other SIGs.
+
+2. If you know of anything that should appear in the "Known Issues" section of
+the Release Notes, please leave a comment with the issue and a draft of the note
+text on [this GitHub Issue]({LINK TO GITHUB ISSUE})
+
+3. If you have some more time and want to help shape your SIG's sections of the
+release notes for {RELEASE NUMBER}, there are a few more things you can do as well!
+
+- Copy-edit notes from your SIG that may contain what you know to be technical
+inaccuracies, grammar inconsistencies, etc.
+- Remove minor and/or non-user facing release notes contributed by your SIG
+- In the sections where notes are attributed to multiple SIGs (including yours),
+leave a comment if the note is more related to your SIG or one of the other SIGs.
+We can then use this to further categorize the notes!
+
+
+Thank you so much for helping put together release notes for your SIG, we know
+you're busy and appreciate your support of the {RELEASE NUMBER} release!


### PR DESCRIPTION
This PR merges the remainder of the Release Notes responsibilities with the Docs team.

#### What type of PR is this:

/kind documentation

#### What this PR does / why we need it:

Release Notes has very little to do in the early parts of the release and less than before in the middle to late parts of the release due to the moving of Release Highlights to the Comms team. Improvements over time made to the Docs team processes means they now have time to take on these responsibilities.

#### Which issue(s) this PR fixes:

None

cc: @kubernetes/sig-release-leads @gracenng @satyampsoni @npolshakova @drewhagen 