### PR TITLE
Remove triage party reference

### DIFF
--- a/release-engineering/README.md
+++ b/release-engineering/README.md
@@ -114,7 +114,6 @@ We do not bypass the “at least one reviewer” rule, so please wait for a revi
 ### Tracking Progress
 
 - We use project boards linked in the [Roadmap and Vision document](https://github.com/kubernetes/sig-release/blob/master/roadmap.md) and try to review them during the Release Engineering meeting.
-- As of Autumn 2020 SIG Release is setting up an instance of Triage Party to accelerate and automate triaging issues.
 - We organize our work into sub-themes based on urgency and impact, and identify drivers of those topics.
 - We call out and celebrate achievements. Some suggested communication paths for amplifying:
     - **First order**: role promotions, finishing a PR, etc.:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this:

<!--
Add one of the following kinds:
/kind cleanup
/kind documentation
/kind feature
/kind design
-->

/kind cleanup

#### What this PR does / why we need it:

We don't use triage party anymore: https://github.com/kubernetes/k8s.io/commit/eb5b0bb4326edf78540f8a0f5ac7ff5217b9fdc0

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #
or
None
-->

Issue #2660 (Not 'Fixes' as fix spans across multiple repositories; will manually close)

#### Special notes for your reviewer:
