### PR TITLE
Fix unescaped single quote for PR 128219 map

### DIFF
--- a/releases/release-1.32/release-notes/maps/pr-128219-map.yaml
+++ b/releases/release-1.32/release-notes/maps/pr-128219-map.yaml
@@ -1,7 +1,7 @@
 pr: 128219
 releasenote:
-  text: 'kubelet: Fix - the volume manager didn't check the device mount state in
+  text: "kubelet: Fix - the volume manager didn't check the device mount state in
     the actual state of the world before marking the volume as detached. It
     may cause a pod to be stuck in the Terminating state due to the above issue
-    when it was deleted.'
+    when it was deleted."
 pr_body: ""


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this:

/kind documentation

#### What this PR does / why we need it:

Addresses invalid YAML causing KREL to crash with the following error message:

```
FATA creating Draft PR: while running release notes fix flow: while getting map for PR #128407: while reading release notes maps: while parsing note map in /var/folders/w3/_dnqx79918q9bvstrdym1_4m0000gn/T/k8s-1083787106/releases/release-1.32/release-notes/maps/pr-128219-map.yaml: decoding note map: yaml: line 2: did not find expected key  file="cmd/root.go:59"
```

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Need this to be merged before I can create the next draft for rc.0
