### PR TITLE
[Comms handbook] Add ready-for-review deadline reminder template

### DIFF
--- a/release-team/role-handbooks/communications/templates/feature-blog-messages.md
+++ b/release-team/role-handbooks/communications/templates/feature-blog-messages.md
@@ -1,4 +1,6 @@
-# Initial Reach-out
+# Feature Blog Opt-in
+
+## Initial Reach-out
 
 This is a message to send to enhancement owners to opt in to write a feature blog for their enhancement, it should be sent on the KEP issue.
 After this message is sent, the Comms team will follow up with the enhancement owner to help them keep in mind the timeline for the feature blog, every 1-2 weeks.
@@ -64,7 +66,7 @@ With this one, you'd need to update the following placeholders:
   - `<<BLOG_READY>> WEEKDAY, DAY MONTH`: Deadline for the Feature Blogs being ready for review, which is usually on week 13
 - `LINK`: Add a link to the release document, such as `https://github.com/kubernetes/sig-release/tree/master/releases/release-1.33#timeline`
 
-# Follow-up
+## Follow-up
 
 ```
 Hi @xx 👋, x.yy Communications Team here again!
@@ -90,3 +92,20 @@ With this one, you'd need to update the following placeholders:
   - `<<BLOG_READY>> WEEKDAY, DAY MONTH`: Deadline for the Feature Blogs being ready for review, which is usually on week 13
 - `LINK`: Add a link to the release document, such as `https://github.com/kubernetes/sig-release/tree/master/releases/release-1.33#timeline`
 
+# Feature Blog PR
+
+## "ready for review" deadline reminder
+This is a message to send Feature Blog authors in their Feature Blog PR if they haven't marked it as "ready for review" days before the deadline.
+```
+Hi @xx 👋 -- this is YOURNAME (@your_github_id) from the x.yy Communications Team!
+
+Just a friendly reminder that we are approaching the feature blog "ready for review" deadline: **<<BLOG_READY>> WEEKDAY, DAY MONTH**. By this deadline, your blog should be complete with all content finalized for review. If you are still working on it, please prioritize finishing it by the deadline mentioned above.
+
+If you have any questions or need help, please don't hesitate to reach out to me or any of the Communications Team members. We are here to help you!
+```
+In this template, you'd need to update the following placeholders:
+- `@xx`: Mention Feature Blog PR author(s)
+- `YOURNAME`: Your name, as you prefer
+- `your_github_id`: Your GitHub ID
+- `x.yy`: The upcoming Kubernetes version, such as 1.33, 1.34, etc.
+- `<<BLOG_READY>> WEEKDAY, DAY MONTH`: Deadline for the Feature Blogs being ready for review, which is usually on week 13


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this:
/kind documentation
<!--
Add one of the following kinds:
/kind cleanup
/kind documentation
/kind feature
/kind design
-->

#### What this PR does / why we need it:
Adds a message template to remind Feature Blog authors of the ready-for-review deadline on week 13

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #
or
None
-->

#### Special notes for your reviewer:
