### PR TITLE
release-1.35: avoid 404 error while under discussion

### DIFF
--- a/releases/release-1.35/README.md
+++ b/releases/release-1.35/README.md
@@ -1,0 +1,15 @@
+---
+title: "Kubernetes v1.35 Release Information"
+weight: 98
+slug: "release"
+aliases: [ "/release" ]
+description: |
+  Information regarding the current release cycle including important dates,
+  Release Team contact information, tracking spreadsheets and more!
+---
+
+# :construction: Under construction :construction:
+
+Release information will be published here once it is finalized.
+For the on-going discussion around that see the
+[timeline PR](https://github.com/kubernetes/sig-release/pull/2860).


### PR DESCRIPTION
#### What type of PR is this:

/kind documentation

#### What this PR does / why we need it:

The ["Kubernetes 1.35 Sneak Peak"](https://groups.google.com/a/kubernetes.io/g/dev/c/TOSpfATnr64) email links to this page before providing a link to the discussion. Providing some content here avoids confusion when some reader of that email doesn't understand that the link wasn't meant to be working yet.

#### Which issue(s) this PR fixes:

N/A

#### Special notes for your reviewer:

The procedure for future releases could be:
- create discussion PR
- create "under construction" PR with tentative content like this one, with the new discussion PR
- merge that PR
- rebase discussion PR
- send announcement email
