### PR TITLE
PRR Freeze is now a hard deadline with exception request

### DIFF
--- a/releases/EXCEPTIONS.md
+++ b/releases/EXCEPTIONS.md
@@ -44,6 +44,9 @@ Email them to:
 
 [You should have *very high confidence* on the “additional time needed” number - we will not grant multiple exceptions for a enhancement. The same goes for over-estimating on the time needed. If the exception request is rejected on the basis that the asking time is too high, we will not re-evaluate if the asking time decreases.]
 
+Exceptions after PRR freeze:
+Due to the proximity to enhancements freeze, it is important to file an exception at your earliest convenience. You may file an exception request in advance if you know your KEP will miss the PRR freeze deadline. All requests will be reviewed and either approved or rejected as they come in.  The release team will be responsible for approving or rejecting exceptions based on the questions above.  
+
 Exceptions after enhancements freeze:
 If your issue was removed during the enhancements freeze please file an exception at your earliest convenience.  All requests will be reviewed and either approved or rejected as they come in.  The release team will be responsible for approving or rejecting exceptions based on the questions above.  
 

--- a/releases/release_phases.md
+++ b/releases/release_phases.md
@@ -2,7 +2,7 @@
 
 ## PRR Freeze
 
-The PRR freeze is a preliminary soft deadline, happening one week before the Enhancements Freeze.
+The PRR freeze is a hard deadline happening one week before the Enhancements Freeze. KEPs that will miss this deadline require an [Exception] or they will be removed from the milestone.
 
 As described by the PRR team [here](https://groups.google.com/a/kubernetes.io/g/dev/c/CQ33yPqp-H4/m/hHO-NaQiAQAJ):
 
@@ -94,7 +94,7 @@ branch.
 
 ## Exceptions
 
-Starting at [Enhancements Freeze], the release team will solicit and rule on
+Starting at [PRR Freeze], the release team will solicit and rule on
 [Exception] requests for enhancements and test work that is unlikely to be done
 by [Code Freeze]. The [Exception] approval is the responsibility of the SIG or SIGs
 labeled in the pull request. The release team may intervene or deny the request


### PR DESCRIPTION
#### What type of PR is this:

/kind documentation

#### What this PR does / why we need it:

Updates the PRR Freeze from a soft, unenforced deadline to a hard deadline with an exception process at the request of the production readiness subproject.

cc: @soltysh @drewhagen @kubernetes/sig-release-leads 
