### PR TITLE
Merge Bug Triage team tasks into CI Signal and remove Bug Triage block

### DIFF
--- a/release-team/README.md
+++ b/release-team/README.md
@@ -214,15 +214,12 @@ graph LR
         FDRN --> RNC[Release Note Complete]
     end
 
-    subgraph Bug Triage
-        TA[Track All Issues and PRs] --> EIP[Escalate Issues and PRs]
-        TF --> EAARB[Ensure Attention on Any Release-Blocking and Major Bug Fix PRs]
-    end
-
     subgraph CI Signal
+        TA[Track All Issues and PRs] --> EIP[Escalate Issues and PRs]
         MONITOR[Monitor E2E Tests and All Jobs In SIG Release Dashboards]
         MONITOR --> OPEN[Open Issues For Failing Or Flaking Jobs]
         CF --> ESCALATE[Escalate Any New Failures]
+        TF --> EAARB[Ensure Attention on Any Release-Blocking and Major Bug Fix PRs]
         OPEN --> ESCALATE
         EAARB --> TEST[Ensure Tests have Stabilized]
         ESCALATE --> TEST
@@ -236,8 +233,7 @@ graph LR
     class DPD,DRD,DCF k8s;
     class FBOD,RBRD,FBRD k8s;
     class CMT,FDRN,RNC k8s;
-    class TA,EIP,TF k8s;
-    class MONITOR,OPEN,CF,ESCALATE,EAARB,TEST k8s;
+    class MONITOR,OPEN,CF,ESCALATE,EAARB,TEST,TA,EIP,TF k8s;
 ```
 
 The diagram below provides an overview of the work done by KEP authors during the release process and how it relates to release deadlines.


### PR DESCRIPTION
#### What type of PR is this:
/kind documentation

#### What this PR does / why we need it:
Bug Triage team now is deprecated, Being in the diagram might be misleading especially it's removed from the handbooks and [this roles table](https://github.com/kubernetes/sig-release/tree/master/release-team#kubernetes-release-team-roles)
This PR removes the Bug Triage and includes its tasks within the CI Signal team block.
#### Which issue(s) this PR fixes:
Fixes #2868 

#### Special notes for your reviewer:

#### Before
<img width="1104" height="713" alt="Screenshot 2025-09-16 at 5 36 48 PM" src="https://github.com/user-attachments/assets/d1e79316-6129-421e-a14f-542c81c05f67" />

---
#### After
<img width="1104" height="713" alt="Screenshot 2025-09-16 at 5 35 24 PM" src="https://github.com/user-attachments/assets/dfccb953-f81d-4ddd-ab80-6983fb617dc9" />
