### PR TITLE
Update the docs handbook to include responsibilities posting on Slack

### DIFF
--- a/release-team/role-handbooks/docs/Release-Timeline.md
+++ b/release-team/role-handbooks/docs/Release-Timeline.md
@@ -183,6 +183,42 @@ _Note:_ SIG Docs prefers and welcomes a status of yellow or red on anything that
 
 [ ] On the day of any deadline, are there any outstanding items or PRs?
 
+
+#### Weekly shadow assignments (template)
+
+Post this in the private Docs team Slack DM group at the beginning of each each week so everyone knows the owner for each task. A sample template is give below for reference. Tasks vary every week, so feel free to include whatever tasks fits the bill for that week. Refer to the Responsibilities spreadsheet to know who is the assigee/reviewer for the week.
+
+```
+Hey folks, welcome to Week <WEEK NUMBER>!:kubernetes-intensifies:
+
+The tasks for this week, along with the assigned owners, are as follows
+-----------------------------------------------------------------------------------
+Release Team Updates (Meeting Link)
+<DATE> (<DAY>)
+APAC Meeting (<TIME> UTC): @<handle>
+EMEA Meeting (<TIME> UTC): @<handle>
+
+-----------------------------------------------------------------------------------
+Weekly Branch Sync PR:
+<DATE> (<DAY>)
+Assignee: @<handle>
+
+-----------------------------------------------------------------------------------
+BURNDOWN Meeting
+<DATE> (<DAY>)
+APAC (<TIME> UTC): @<handle>
+EMEA (<TIME> UTC): @<handle>
+<DATE> (<DAY>)
+APAC (<TIME> UTC): @<handle>
+EMEA (<TIME> UTC): @<handle>
+
+-----------------------------------------------------------------------------------
+v<MAJOR>.<MINOR>.<PATCH>-rc.<N> release notes
+<DATE> (<DAY>)
+Assignee: @<handle>
+Reviewer: @<handle>
+```
+
 ### Read up on the release team
 
 Read this to learn more about the entire [release team and process](https://github.com/kubernetes/sig-release/tree/master/release-team)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this:

/kind documentation

<!--
Add one of the following kinds:
/kind cleanup
/kind documentation
/kind feature
/kind design
-->

#### What this PR does / why we need it:

In the v1.35 release, the Docs team clearly posted tasks and responsibilities in the Slack group, along with assigned owners and reviewers, throughout the release cycle. This greatly helped the team track progress and ensure work was completed on time without unnecessary interference. Documenting this approach will help future teams adopt the same practice.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #
or
None
-->

#### Special notes for your reviewer:

cc @Urvashi0109 
