### PR TITLE
Update docs for fork-per-release workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/post-release-branch-creation.md
+++ b/.github/ISSUE_TEMPLATE/post-release-branch-creation.md
@@ -28,8 +28,7 @@ The trigger for removing such jobs should be solely the EOL date but we shouldn'
 -->
 - [ ] Update [`milestone_applier` rules](https://github.com/kubernetes/test-infra/blob/master/config/prow/plugins.yaml)
 - [ ] Update [`kubekins-e2e-v2/variants.yaml`](https://github.com/kubernetes/test-infra/blob/master/images/kubekins-e2e-v2/variants.yaml) with the new version config
-- [ ] Rotate configuration of release branch jobs in kubernetes/test-infra in particular `releng/test_config.yaml` for the upcoming release
-- [ ] Run test generation script, configure the new release dashboards and send a PR with both tests and dashboards config
+- [ ] Run `make -C releng prepare-release-branch` in kubernetes/test-infra, configure the new release dashboards and send a PR
 - [ ] Add a new variant for the `kube-cross` image (`kubernetes/release` repository) and ensure the image is built and pushed properly
 - [ ] Add new variants for `k8s-cloud-builder` and `k8s-ci-builder` images (`kubernetes/release` repository) and ensure images are built and pushed properly
 - [ ] Update references in `kubernetes/kubernetes` with the new kube-cross image (only after all images are pushed/promoted)


### PR DESCRIPTION


#### What type of PR is this:


/kind documentation


#### What this PR does / why we need it:
Update post-release-branch-creation handbook and issue template to reflect the simplified fork-per-release workflow in kubernetes/test-infra. The manual test_config.yaml rotation and generate-tests steps have been replaced by an idempotent prepare-release-branch tool.

Also fix broken link in branch-manager.md pointing to a non-existent post-rc0-release-tasks.md file.

#### Which issue(s) this PR fixes:

Refers to https://github.com/kubernetes/test-infra/issues/29390

#### Special notes for your reviewer:

Requires https://github.com/kubernetes/test-infra/pull/36445

/hold 