### PR TITLE
Fix broken links and references in release-engineering docs

### DIFF
--- a/release-engineering/README.md
+++ b/release-engineering/README.md
@@ -131,7 +131,7 @@ We do not bypass the “at least one reviewer” rule, so please wait for a revi
 
 ## Roles, Responsibilities, and Notes for Newcomers
 
-[This page](https://github.com/kubernetes/sig-release/blob/master/release-managers.md) provides details about the different roles in Release Engineering, along with requirements for moving up the "career ladder."
+[This page](https://github.com/kubernetes/website/blob/main/content/en/releases/release-managers.md) provides details about the different roles in Release Engineering, along with requirements for moving up the "career ladder."
 
 ### For Newcomers
 At Release Engineering meetings, we like to give newcomers a happy and warm welcome. We also give space for newcomers to introduce themselves and their motivations/interests for joining. However, if you prefer not to speak during your first meeting we'll respect that. 
@@ -143,7 +143,7 @@ As of Autumn 2020 we're developing a Buddy Program to improve our onboarding. He
 - Buddies will come from the same general time zone area and, as often as possible, share the same language.
 - Work-related conversations should take place in the Slack channel as much as possible to help other newcomers onboard.
  
-More information about the Buddy Program is available [on this page](https://github.com/kubernetes/sig-release/blob/master/release-managers.md).
+More information about the Buddy Program is available [on this page](https://github.com/kubernetes/website/blob/main/content/en/releases/release-managers.md).
 
 ## Schedule of Recurring Work
 

--- a/release-engineering/baseimage-exception-list.md
+++ b/release-engineering/baseimage-exception-list.md
@@ -41,10 +41,10 @@ Please feel free to edit this file when you find any updates. Links to detailed 
 | [etcd-empty-dir-cleanup] | [debian-base] | https://github.com/kubernetes/kubernetes/blob/master/cluster/images/etcd-empty-dir-cleanup/OWNERS | U | Requires shell to do some cleanup |
 | [fluentd-elasticsearch] | `ruby:2.7-slim-buster` | https://github.com/kubernetes/kubernetes/blob/master/cluster/addons/fluentd-elasticsearch/OWNERS | U | Requires shell to install fluentd via ruby |
 | [ip-masq-agent] | [distroless-iptables] | https://github.com/kubernetes-sigs/ip-masq-agent/blob/master/OWNERS | U | Requires `iptables` |
-| [k8s-dns-dnsmasq-nanny] | [debian-base] | https://github.com/kubernetes/dns/blob/master/OWNERS | U | Requires [container debugging tooling](https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/20190212-ephemeral-containers.md) |
-| [k8s-dns-kube-dns] | [debian-base] | https://github.com/kubernetes/dns/blob/master/OWNERS | U | Requires [container debugging tooling](https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/20190212-ephemeral-containers.md) |
-| [k8s-dns-node-cache] | [debian-base] | https://github.com/kubernetes/dns/blob/master/OWNERS | U | Requires [container debugging tooling](https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/20190212-ephemeral-containers.md) |
-| [k8s-dns-sidecar] | [debian-base] | https://github.com/kubernetes/dns/blob/master/OWNERS | U | Requires [container debugging tooling](https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/20190212-ephemeral-containers.md) |
+| [k8s-dns-dnsmasq-nanny] | [debian-base] | https://github.com/kubernetes/dns/blob/master/OWNERS | U | Requires [container debugging tooling](https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/277-ephemeral-containers/README.md) |
+| [k8s-dns-kube-dns] | [debian-base] | https://github.com/kubernetes/dns/blob/master/OWNERS | U | Requires [container debugging tooling](https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/277-ephemeral-containers/README.md) |
+| [k8s-dns-node-cache] | [debian-base] | https://github.com/kubernetes/dns/blob/master/OWNERS | U | Requires [container debugging tooling](https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/277-ephemeral-containers/README.md) |
+| [k8s-dns-sidecar] | [debian-base] | https://github.com/kubernetes/dns/blob/master/OWNERS | U | Requires [container debugging tooling](https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/277-ephemeral-containers/README.md) |
 | [kube-addon-manager] | [debian-base] | https://github.com/kubernetes/kubernetes/blob/master/cluster/addons/addon-manager/OWNERS | U | Requires [shell](https://github.com/kubernetes/kubernetes/blob/master/cluster/addons/addon-manager/kube-addons.sh) |
 | [node-problem-detector] | [debian-base] | https://github.com/kubernetes/node-problem-detector/blob/master/OWNERS | U | Requires `libsystemd0` |
 

--- a/release-engineering/gcp.md
+++ b/release-engineering/gcp.md
@@ -55,4 +55,4 @@ To date, the following projects have access to decrypt KMS assets:
 - `k8s-staging-kubernetes`
 - `k8s-staging-releng`
 
-[release-managers]: /release-managers.md
+[release-managers]: https://github.com/kubernetes/website/blob/main/content/en/releases/release-managers.md

--- a/release-engineering/handbooks/go.md
+++ b/release-engineering/handbooks/go.md
@@ -92,7 +92,7 @@ https://github.com/kubernetes/test-infra/blob/master/config/jobs/image-pushing/k
 
 - promote the image from staging to production, for it to be an official image
 - create PR in kubernetes/k8s.io
-  - Update the docker image digest and its version tag @ https://github.com/kubernetes/k8s.io/blob/main/k8s.gcr.io/images/k8s-staging-build-image/images.yaml
+  - Update the docker image digest and its version tag @ https://github.com/kubernetes/k8s.io/blob/main/registry.k8s.io/images/k8s-staging-build-image/images.yaml
   - indicate the image, a link to the staging run, signature ( e.g. "Signed off by : Stephen Augustus saugustus@example.com"), CC @kubernetes/release-engineering & relevant reviewers
   - the structure of the file is structured by the digests' SHAs
 
@@ -168,4 +168,4 @@ Update release-1.x branches to build/release using go 1.N *after* all of these c
    In go1.21+, the go runtime is expected to match previous runtime behavior by default
    if we leave the go version indicated in `go.mod` files in release branches unchanged.
 
-[release-managers]: /release-managers.md
+[release-managers]: https://github.com/kubernetes/website/blob/main/content/en/releases/release-managers.md

--- a/release-engineering/handbooks/k8s-release-cut.md
+++ b/release-engineering/handbooks/k8s-release-cut.md
@@ -550,7 +550,7 @@ The release step will also be extended, but not substantially longer in time.
 
 #### Post branch creation release tasks
 
-See [here](post-rc0-release-tasks.md) for the complete list of post branch creation release tasks.
+See [here](post-release-branch-creation.md) for the complete list of post branch creation release tasks.
 
 Such list resides in a different document to mainain this one in a bite-sized SRE style format.
 

--- a/release-engineering/role-handbooks/branch-manager.md
+++ b/release-engineering/role-handbooks/branch-manager.md
@@ -504,7 +504,7 @@ See [this section](../handbooks/k8s-release-cut.md#next-release-branch-creation)
 
 #### Post new release branch creation tasks
 
-Run through the following tasks detailed [here](../handbooks/post-rc0-release-tasks.md) after the `rc.0` release is communicated and therefore the release branch has been created.
+Run through the following tasks detailed [here](../handbooks/post-release-branch-creation.md) after the `rc.0` release is communicated and therefore the release branch has been created.
 
 ---
 
@@ -653,7 +653,7 @@ For example, [#79044](https://github.com/kubernetes/kubernetes/pull/79044) is th
 
 There has been quite a bit of recent discussion (see: [1](https://github.com/kubernetes/community/pull/2408), [2](https://github.com/kubernetes/community/pull/1980)) around improving both the cherry pick process process and its documentation.
 
-After the official release has been published, the [Release Managers](../../release-managers.md#release-managers) will take over in handling cherry picks. In the time between [code thaw](#code-thaw) and the official release, cherry picks are the responsibility of the branch management team.
+After the official release has been published, the [Release Managers][release-managers] will take over in handling cherry picks. In the time between [code thaw](#code-thaw) and the official release, cherry picks are the responsibility of the branch management team.
 
 Consider the following when assessing the cherry-picks:
 
@@ -746,7 +746,7 @@ See the branch management process prior to v1.12 when `anago` was still used.
 [image-promotion]: https://sigs.k8s.io/promo-tools/docs/promotion-pull-requests.md
 [kubernetes-release-team]: https://groups.google.com/a/kubernetes.io/g/release-team
 [release-branch-job-creation]: https://git.k8s.io/test-infra/releng/README.md
-[release-managers]: /release-managers.md#release-managers
+[release-managers]: https://github.com/kubernetes/website/blob/main/content/en/releases/release-managers.md
 [release-managers-group]: https://groups.google.com/a/kubernetes.io/forum/#!forum/release-managers
 
 # Visual Release Cut Process

--- a/release-engineering/role-handbooks/patch-release-team.md
+++ b/release-engineering/role-handbooks/patch-release-team.md
@@ -69,7 +69,7 @@ access to multiple build and release tools:
 
 * Add your name and contact info, and if applicable a new section
   for the current release, to the [Patch Releases landing
-  page](/releases/patch-release.md) so the community knows you're the
+  page](https://github.com/kubernetes/website/blob/main/content/en/releases/patch-releases.md) so the community knows you're the
   point of contact.  If your work is specific to one particular
   release, add your name to that release's release team in the patch
   release manager row, for example [here for
@@ -92,9 +92,9 @@ access to multiple build and release tools:
   much of the tooling and process used by the branch manager pre-release
   relates to the post-release duties of Patch Release management.
   Pay close attention to the
-  [Pre-requirements](/release-team/role-handbooks/branch-manager#pre-requirements),
-  [Safety Check](/release-team/role-handbooks/branch-manager#safety-check), and
-  [Build and Release](/release-team/role-handbooks/branch-manager#build-and-release)
+  [Pre-requirements](/release-engineering/role-handbooks/branch-manager.md#prerequisites),
+  [Safety Check](/release-engineering/role-handbooks/branch-manager.md#releases-management), and
+  [Build and Release](/release-engineering/role-handbooks/branch-manager.md#releases-management)
   sections.  This outlines current requirements for running `krel stage/release` to do
   builds.
 
@@ -471,7 +471,7 @@ When you have a plan for the next patch release, send an announcement
 * *BCC*: [kubernetes-dev-announce@googlegroups.com](https://groups.google.com/forum/#!forum/kubernetes-dev-announce)
 
 several working days in advance, including a release notes preview.  Also
-update the [posted schedule](https://git.k8s.io/sig-release/releases/patch-releases.md).
+update the [posted schedule](https://git.k8s.io/website/content/en/releases/patch-releases.md).
 
 You generate the preview with the [relnotes](https://git.k8s.io/release/relnotes)
 script, run against a local checkout of the release branch, and querying
@@ -538,7 +538,7 @@ kubernetes-dev and kubernetes-announce mailing lists.
 After the release cut, reapply the `cherry-pick-approved` label to any PRs that
 had it before the freeze, and go through the backlog of new cherry-picks.
 
-Update the [posted schedule](https://git.k8s.io/sig-release/releases/patch-releases.md)
+Update the [posted schedule](https://git.k8s.io/website/content/en/releases/patch-releases.md)
 to reflect the actual release date and any initial info on the next release's timing.
 
 ### Hotfix release
@@ -586,19 +586,19 @@ corresponding command line help (`-h`) outputs.
 | Configure branch | n/a |
 | Mock build staging | `krel stage --type=official --branch=release-x.y` |
 | Mock build staging success? | Visually confirm yes |
-| Mock release | `krel release --type=official --branch=release.x.y --build-verison=…` (get the build-version from the Google Cloud console output of `krel stage`) |
+| Mock release | `krel release --type=official --branch=release-x.y --build-version=…` (get the build-version from the Google Cloud console output of `krel stage`) |
 | Mock release success? | Visually confirm yes |
 | Mock email notify test | ```krel announce send --tag v1.13.3-beta.1``` |
 | Check mail arrives, list has expected commits? | manual/visual |
 | Official build staging | `krel stage --nomock --type=official --branch=release-x.y` |
 | Official build staging success? | Visually confirm yes |
-| Official release | `krel release --nomock --type=official --branch=release.x.y --build-verison=…` |
+| Official release | `krel release --nomock --type=official --branch=release-x.y --build-version=…` |
 | Official email notify test | ```krel announce send --tag vX.Y.Z``` |
 | Check mail arrives, list has expected commits? | manual/visual |
-| Package creation (needs its own improved workflow; work starting on that) | Ping [Build Admins](https://git.k8s.io/sig-release/release-managers.md#build-admins) by name on Slack for package building |
+| Package creation (needs its own improved workflow; work starting on that) | Ping [Build Admins](https://github.com/kubernetes/website/blob/main/content/en/releases/release-managers.md) by name on Slack for package building |
 | Package testing (needs improvement) | Visually validate [yum repo](https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64/repodata/primary.xml) and [apt repo](https://packages.cloud.google.com/apt/dists/kubernetes-xenial/main/binary-amd64/Packages) have entries for "1.13.3" in package NVRs (Name-Version-Release) |
 | Official email notify | ```krel announce send --tag v1.13.3 --nomock``` |
 | Check mail arrives | manual/visual check that [k-announce](https://groups.google.com/forum/#!forum/kubernetes-announce) and [k-dev](https://groups.google.com/a/kubernetes.io/g/dev) got mail OK |
 | Completion | n/a |
 
-[release-managers]: /release-managers.md#release-managers
+[release-managers]: https://github.com/kubernetes/website/blob/main/content/en/releases/release-managers.md


### PR DESCRIPTION


#### What type of PR is this:


/kind documentation


#### What this PR does / why we need it:
- Fix release-managers.md references (moved to k/website in 2021)
- Fix post-rc0-release-tasks.md -> post-release-branch-creation.md
- Fix ephemeral containers KEP link (reorganized to numbered dir)
- Fix k8s.gcr.io -> registry.k8s.io URL in go.md
- Fix patch-release.md references (moved to k/website)
- Fix branch-manager handbook path in patch-release-team.md
- Fix release.x.y -> release-x.y and build-verison typos

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None