### PR TITLE
Update outdated content and fix typos in release-engineering docs

### DIFF
--- a/release-engineering/README.md
+++ b/release-engineering/README.md
@@ -136,7 +136,7 @@ We do not bypass the “at least one reviewer” rule, so please wait for a revi
 ### For Newcomers
 At Release Engineering meetings, we like to give newcomers a happy and warm welcome. We also give space for newcomers to introduce themselves and their motivations/interests for joining. However, if you prefer not to speak during your first meeting we'll respect that. 
 
-As of Autumn 2020 we're developing a Buddy Program to improve our onboarding. Here's how it will work:
+We have a Buddy Program to improve our onboarding. Here's how it works:
 
 - Release Managers follow up with newcomers to go over the details of this page and empower them to ask questions about our work and processes.
 - Newcomers can request a Buddy (a Release Manager), who will also be shadowed/supported by up to two Release Manager Associates.
@@ -180,7 +180,6 @@ that any final cherry-pick content is merged ahead of that last release.
    - Document the different triage per repo/image.
      - kubernetes/kubernetes
        - UNLESS there are CVEs (then we must address)
-       - Every update requires an update to bazel rules_go
      - kubernetes/release
        - images/k8s-cloud-builder
        - images/build/cross (kube-cross)

--- a/release-engineering/handbooks/k8s-release-cut.md
+++ b/release-engineering/handbooks/k8s-release-cut.md
@@ -39,10 +39,10 @@ A step by step guide for cutting Kubernetes patch releases. At a high-level:
 - Update tools (~15m)
 - Run `krel stage` (~1h 15m - up to 2h)
 - Run `krel release` (~15m)
-- Run `krel stage --no-mock` (~1h 15m - up to 2h)
+- Run `krel stage --nomock` (~1h 15m - up to 2h)
 - Run `kpromo pr` & merge PR
 - Wait for image promo prow job (~1h)
-- Run `krel release --no-mock` (~15m)
+- Run `krel release --nomock` (~15m)
 - Send announcements (~30m)
 
 
@@ -386,7 +386,7 @@ You might wanna ping @release-managers on Slack to speed this process up.
 **The PR has no dependencies outside of approvals / review.**
 
 > [!CAUTION]
-In case a blocking test goes red during the release cut, you should keep the PR held and reach a consesus with @release-managers that the promo can continue.
+In case a blocking test goes red during the release cut, you should keep the PR held and reach a consensus with @release-managers that the promo can continue.
 e.g. if a test went red for infra flakyness "Node not ready" it's probably ok to continue, but it's always better to double check.
 
 > [Example PR](https://github.com/kubernetes/k8s.io/pull/3024).
@@ -460,12 +460,9 @@ dev@kubernetes.io, kubernetes-announce@googlegroups.com
 
 #### Legacy Sendgrid method:
 
-> [!TIP]
-username == email` & `password == normalx2`.
-
 ```
 cd ~/release
-export SENDGRID_API_KEY=<API_KEY previously shared>
+export SENDGRID_API_KEY=<API_KEY>
 
 krel announce send --tag v1.xx.yy-alpha|beta|rc-z --name "First Last" --email "your-email@gmail.com" --nomock
 ```
@@ -552,7 +549,7 @@ The release step will also be extended, but not substantially longer in time.
 
 See [here](post-release-branch-creation.md) for the complete list of post branch creation release tasks.
 
-Such list resides in a different document to mainain this one in a bite-sized SRE style format.
+Such list resides in a different document to maintain this one in a bite-sized SRE style format.
 
 > [!WARNING]
 You will not be able to cut an rc.1 or any other cut against the new branch until the post branch creation tasks (post rc.0) are complete.
@@ -581,11 +578,11 @@ git submodule update --init --recursive
 
 
 # from in the k/website repo
-git checkout -b schedule-updates-nov-2024
+git checkout -b schedule-updates-<month>-<year>
 schedule-builder -uc ./data/releases/schedule.yaml -e ./data/releases/eol.yaml
 git add .
 git commit -m "updating release schedule"
-git push -u origin schedule-updates-oct-2024
+git push -u origin schedule-updates-<month>-<year>
 ```
 
 ## Cleanup

--- a/release-engineering/handbooks/post-release-branch-creation.md
+++ b/release-engineering/handbooks/post-release-branch-creation.md
@@ -110,7 +110,7 @@ Follow the guidelines below very carefully during the update process.
 
 - Do not remove old jobs while adding new jobs in this phase, just do not. Handle it before or after the post branch creation tasks, or let release engineering take care of this.
 - Do not segregate PRs, just separate auto-generated files from manually updated ones in two (or more) clearly documented commits.
-- Be super careful about `releng/test_config.yaml` epecially when commenting out `stable4`
+- Be super careful about `releng/test_config.yaml` especially when commenting out `stable4`
 - Do not hesitate to remove broken jobs, but let the interested SIG(s) know about it so they can re-add it.
 
 Updating the release branch jobs in `kubernetes/test-infra` for the new release version involves some steps, it is unpredictable work and requires manual intervention as not every job is generated.
@@ -209,7 +209,7 @@ Bumping the stable version to the n+1 version of Kubernetes is done only when th
 
      # Update after the stable marker has been updated to stable.0
      - name: "Kubernetes version (next candidate.0)"
-      version: v1.35.0
+       version: v1.35.0
        refPaths:
          - path: images/build/cross/variants.yaml
            match: "KUBERNETES_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)'"

--- a/release-engineering/role-handbooks/branch-manager.md
+++ b/release-engineering/role-handbooks/branch-manager.md
@@ -68,23 +68,23 @@ construction.**
 
 ### Conventions
 
-In this handbook, we will make several references to Kubernetes releases, milestones, and [semantic versioning](http://semver.org/).
+In this handbook, we will make several references to Kubernetes releases, milestones, and [semantic versioning](https://semver.org/).
 
 For the purposes of this handbook, we'll assume that:
 
-- the current release in development is Kubernetes 1.18
-- the previous release is Kubernetes 1.17
-- the next release is Kubernetes 1.19
-- the release no longer in support is Kubernetes 1.14
+- the current release in development is Kubernetes 1.33
+- the previous release is Kubernetes 1.32
+- the next release is Kubernetes 1.34
+- the release no longer in support is Kubernetes 1.29
 
 To simplify certain instructions, we will make the following connections:
 
 | Text | SemVer | Reference Release |
 |---|---|---|
-| "current release", "current milestone", "in development" | `x.y` | Kubernetes 1.18 |
-| "previous release", "previous milestone" | `x.y-1` | Kubernetes 1.17 |
-| "next release", "next milestone" | `x.y+1` | Kubernetes 1.19 |
-| "release no longer in support" | `x.y-4` | Kubernetes 1.14 |
+| "current release", "current milestone", "in development" | `x.y` | Kubernetes 1.33 |
+| "previous release", "previous milestone" | `x.y-1` | Kubernetes 1.32 |
+| "next release", "next milestone" | `x.y+1` | Kubernetes 1.34 |
+| "release no longer in support" | `x.y-4` | Kubernetes 1.29 |
 
 **As an editor of this content, Branch Managers should periodically update these conventions and the examples contained within this handbook.**
 
@@ -336,7 +336,7 @@ corresponding help (`-h`) output.
 
 ### Beta Releases
 
-Before run the `official release step` please refer to the [Image Promotion documentation][image-promotion].
+Before running the `official release step` please refer to the [Image Promotion documentation][image-promotion].
 
 To stage a new beta release, simply run `krel stage --type=beta`. The same
 applies to `krel release --build-version=… --type=beta`.
@@ -345,9 +345,9 @@ applies to `krel release --build-version=… --type=beta`.
 
 Builds against a `release-x.y` branch are implicitly the next RC (release candidate). `krel` automatically finds and increments the current build number.
 
-**Note: If this is the first release (`rc.0`), there are additional tasks to complete. Please review them _COMPLETELY_ in the [Branch Creation section](#branch-creation), _before_ continuing.**
+**Note: If this is the first release (`rc.0`), there are additional tasks to complete. Please review them _COMPLETELY_ in the [Release Branch Creation section](#release-branch-creation), _before_ continuing.**
 
-Before run the `official release step` please refer to the [Image Promotion documentation][image-promotion].
+Before running the `official release step` please refer to the [Image Promotion documentation][image-promotion].
 
 To stage a new RC release, simply run `krel stage --type=rc --branch=release-x.y`. The same
 applies to `krel release --build-version=… --type=rc --branch=release-x.y`.
@@ -381,7 +381,7 @@ Otherwise we might have a mix of PRs against master, some have been merged in co
 
 ### Official Releases
 
-Before run the `official release step` please refer to the [Image Promotion documentation][image-promotion].
+Before running the `official release step` please refer to the [Image Promotion documentation][image-promotion].
 
 To stage a new official release, simply run `krel stage --type=official
 --branch=release-x.y`. The same applies to `krel release --build-version=…
@@ -518,7 +518,7 @@ As Branch Manager, coordinate with the Release Lead on checking the exact config
 
 #### Tide
 
-Tide automates merges and is configured via a [config.yaml][config.yaml] file. Tide identifies PRs that are mergeable using GitHub queries that correspond to the configuration. Here is an example of what the query config for `kubernetes/kubernetes` looks like without additional constraints related to the release cycle:
+Tide automates merges and is configured via a [config.yaml](https://github.com/kubernetes/test-infra/blob/master/config/prow/config.yaml) file. Tide identifies PRs that are mergeable using GitHub queries that correspond to the configuration. Here is an example of what the query config for `kubernetes/kubernetes` looks like without additional constraints related to the release cycle:
 
 ```yaml
   - repos:
@@ -674,7 +674,7 @@ The [publishing-bot](https://github.com/kubernetes/publishing-bot) is responsibl
 
 The bot also syncs the Kubernetes version tags to the published repos, prefixed with `kubernetes-`. For example, if you check out the `kubernetes-1.16.0` tag in client-go, the code you get is exactly the same as if you check out the `v1.16.0` tag in Kubernetes, and change the directory to `staging/src/k8s.io/client-go`.
 
-[client-go](https://github.com/kubernetes/client-go) follows [semver](http://semver.org/) and has its own release process. This release process and the publishing-bot are maintained by SIG API Machinery. In case of any questions related to the published staging repos, please ask someone listed in the following [OWNERS](https://git.k8s.io/publishing-bot/OWNERS) file.
+[client-go](https://github.com/kubernetes/client-go) follows [semver](https://semver.org/) and has its own release process. This release process and the publishing-bot are maintained by SIG API Machinery. In case of any questions related to the published staging repos, please ask someone listed in the following [OWNERS](https://git.k8s.io/publishing-bot/OWNERS) file.
 
 The bot runs every four hours, so it might take sometime for a new tag to appear on a published repository.
 

--- a/release-engineering/role-handbooks/patch-release-team.md
+++ b/release-engineering/role-handbooks/patch-release-team.md
@@ -596,7 +596,7 @@ corresponding command line help (`-h`) outputs.
 | Official email notify test | ```krel announce send --tag vX.Y.Z``` |
 | Check mail arrives, list has expected commits? | manual/visual |
 | Package creation (needs its own improved workflow; work starting on that) | Ping [Build Admins](https://github.com/kubernetes/website/blob/main/content/en/releases/release-managers.md) by name on Slack for package building |
-| Package testing (needs improvement) | Visually validate [yum repo](https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64/repodata/primary.xml) and [apt repo](https://packages.cloud.google.com/apt/dists/kubernetes-xenial/main/binary-amd64/Packages) have entries for "1.13.3" in package NVRs (Name-Version-Release) |
+| Package testing (needs improvement) | Visually validate [yum repo](https://pkgs.k8s.io/core:/stable:/v1.x/rpm/repodata/) and [apt repo](https://pkgs.k8s.io/core:/stable:/v1.x/deb/Packages) have entries for the release version in package NVRs (Name-Version-Release) |
 | Official email notify | ```krel announce send --tag v1.13.3 --nomock``` |
 | Check mail arrives | manual/visual check that [k-announce](https://groups.google.com/forum/#!forum/kubernetes-announce) and [k-dev](https://groups.google.com/a/kubernetes.io/g/dev) got mail OK |
 | Completion | n/a |

--- a/release-engineering/versioning.md
+++ b/release-engineering/versioning.md
@@ -1,6 +1,6 @@
 # Kubernetes Release Versioning
 
-Reference: [Semantic Versioning](http://semver.org)
+Reference: [Semantic Versioning](https://semver.org)
 
 Legend:
 
@@ -29,7 +29,7 @@ Legend:
 - X.Y.0 (Branch: release-X.Y)
   - Final release, cut from the release-X.Y branch cut two weeks prior.
   - X.Y.1-rc.0 will be tagged at the same commit on the same branch.
-  - X.Y.0 occur 3 to 4 months after X.(Y-1).0.
+  - X.Y.0 occur approximately 4 months after X.(Y-1).0.
 - X.Y.Z, Z > 0 (Branch: release-X.Y)
   - [Patch releases](#patch-releases) are released as we cherrypick commits into
     the release-X.Y branch, (which is at X.Y.Z-beta.W,) as needed.
@@ -62,7 +62,7 @@ group/version, but there are no current plans to do so.
   additional +aaaa build suffix added; X.Y.Z-beta.W.C+bbbb is C commits after
   X.Y.Z-beta.W, with an additional +bbbb build suffix added. Furthermore, builds
   that are built off of a dirty build tree, (during development, with things in
-  the tree that are not checked it,) it will be appended with -dirty.
+  the tree that are not checked in,) it will be appended with -dirty.
 
 ### Supported releases and component skew
 
@@ -76,21 +76,22 @@ minor release; we often include critical bug fixes in
 possible.
 
 Different components are expected to be compatible across different amounts of
-skew, all relative to the master version. Nodes may lag masters components by
-up to two minor versions but should be at a version no newer than the master; a
+skew, all relative to the master version. Nodes may lag master components by
+up to three minor versions but should be at a version no newer than the master; a
 client should be skewed no more than one minor version from the master, but may
-lead the master by up to one minor version. For example, a v1.3 master should
-work with v1.1, v1.2, and v1.3 nodes, and should work with v1.2, v1.3, and v1.4
-clients.
+lead the master by up to one minor version. For example, a v1.31 master should
+work with v1.28, v1.29, v1.30, and v1.31 nodes, and should work with v1.30, v1.31,
+and v1.32 clients.
 
 Furthermore, we expect to "support" three minor releases at a time. "Support"
 means we expect users to be running that version in production, though we may
-not port fixes back before the latest minor version. For example, when v1.3
-comes out, v1.0 will no longer be supported: basically, that means that the
-reasonable response to the question "my v1.0 cluster isn't working," is, "you
+not port fixes back before the latest minor version. For example, when v1.31
+comes out, v1.27 will no longer be supported: basically, that means that the
+reasonable response to the question "my v1.27 cluster isn't working," is, "you
 should probably upgrade it, (and probably should have some time ago)". With
-minor releases happening approximately every three months, that means a minor
-release is supported for approximately nine months.
+minor releases happening approximately every four months (three releases per
+year), that means a minor release is supported for approximately fourteen
+months.
 
 ## Patch releases
 


### PR DESCRIPTION


#### What type of PR is this:


/kind documentation


#### What this PR does / why we need it:
- Update version skew policy from n-2 to n-3 (changed in K8s 1.28)
- Update support window from ~9 months to ~14 months (changed in 1.19)
- Update release cadence to ~4 months (3 releases/year since 1.22)
- Update example versions in branch-manager handbook (1.18 -> 1.33)
- Remove outdated Bazel rules_go reference (dropped in 1.26)
- Remove Sendgrid credential hint from k8s-release-cut.md
- Update packages.cloud.google.com URLs to pkgs.k8s.io
- Fix http://semver.org -> https://semver.org
- Fix --no-mock -> --nomock (actual krel flag)
- Fix branch-creation anchor, config.yaml link, grammar
- Fix typos: checked it/in, epecially, mainain, consesus
- Fix YAML indentation in post-release-branch-creation.md
- Make schedule-builder branch name placeholder generic
- Update Buddy Program text (remove "as of Autumn 2020")
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None