### PR TITLE
Skip mock runs for patch releases

### DIFF
--- a/.github/ISSUE_TEMPLATE/cut-release.md
+++ b/.github/ISSUE_TEMPLATE/cut-release.md
@@ -76,7 +76,7 @@ Help? Ring @release-managers on slack!
 - [ ] Create a thread on #release-management: <!-- Paste link to slack -->
 - [ ] Screenshot unhealthy release branch testgrid boards
 - [ ] Check the health of the publishing-bot <!-- check if https://github.com/kubernetes/kubernetes/issues/56876 is closed  --> 
-- Mock Run
+- Mock Run (skip for patch releases)
   - [ ] Stage
   - [ ] Release
 - NoMock Run
@@ -108,8 +108,8 @@ Platform:      linux/amd64
 <!-- The following table can be automatically generated using krel --history  -->
 | Step | Command | Link | Start | Duration | Succeeded? |
 | --- | --- | --- | --- | --- | --- |
-| Mock stage | `krel stage [arguments]` | | | | |
-| Mock release | `krel release [arguments]` | | | | |
+| Mock stage (skip for patch releases) | `krel stage [arguments]` | | | | |
+| Mock release (skip for patch releases) | `krel release [arguments]` | | | | |
 | Stage | `krel stage [arguments]` | | | | |
 | Release | `krel release [arguments]` | | | | |
 

--- a/release-engineering/handbooks/k8s-release-cut.md
+++ b/release-engineering/handbooks/k8s-release-cut.md
@@ -33,18 +33,23 @@
     - [\[Patch only\] Update schedule on k/website](#patch-only-update-schedule-on-kwebsite)
   - [Cleanup](#cleanup)
 
-A step by step guide for cutting Kubernetes patch releases. At a high-level:
+A step by step guide for cutting Kubernetes releases. At a high-level:
 
 - Maintain GitHub release cut issue
 - Update tools (~15m)
-- Run `krel stage` (~1h 15m - up to 2h)
-- Run `krel release` (~15m)
+- Run `krel stage` (~1h 15m - up to 2h) (**skip for patch releases**)
+- Run `krel release` (~15m) (**skip for patch releases**)
 - Run `krel stage --nomock` (~1h 15m - up to 2h)
 - Run `kpromo pr` & merge PR
 - Wait for image promo prow job (~1h)
 - Run `krel release --nomock` (~15m)
 - Send announcements (~30m)
 
+> [!NOTE]
+> For patch releases (x.y.z where z > 0), mock stage and mock release are skipped.
+> The nomock pipeline has built-in safety checks (provenance verification, deterministic builds)
+> that make a separate mock run unnecessary for patches. This reduces the total release
+> cut time by approximately 45 minutes per branch.
 
 ## Prerequisites
 
@@ -250,11 +255,29 @@ Helpful templates, each one has a "completed" response too:
 ```
 :thread: Release Cut v1.xx.yy-alpha|beta|rc-z (GH Issue)
 
-:hourglass_flowing_sand: Mock Stage (logs) 
+:hourglass_flowing_sand: Mock Stage (logs)
 -> :white_check_mark:
 
 :hourglass_flowing_sand: Mock Release (logs)
 -> :white_check_mark:
+
+:hourglass_flowing_sand: No-mock Stage (logs)
+-> :white_check_mark:
+
+https://github.com/kubernetes/k8s.io/pull/xxxx
+
+Image Promotion PR (link)
+cc: @release-managers
+-> Image promotion is :white_check_mark:
+
+:hourglass_flowing_sand: No-mock Release (logs)
+-> :white_check_mark:
+```
+
+For patch releases (where mock runs are skipped), use this template instead:
+
+```
+:thread: Release Cut v1.x.y (GH Issue)
 
 :hourglass_flowing_sand: No-mock Stage (logs)
 -> :white_check_mark:
@@ -292,6 +315,9 @@ Check the health of the publishing-bot by navigating to [this issue](https://git
 If the issue is open you must stop the release process and inform #release-management on Slack.
 
 ## 5. Mock stage and Mock release
+
+> [!NOTE]
+> **Skip this step for patch releases** (x.y.z where z > 0). Proceed directly to [No-mock stage](#6-no-mock-stage).
 
 > [!WARNING]
 Before cutting `alpha.1` ideally some days before, ensure that @release-managers have performed the propedeutic tasks for the alpha cut (e.g. setting up the new OBS project)

--- a/release-engineering/role-handbooks/branch-manager.md
+++ b/release-engineering/role-handbooks/branch-manager.md
@@ -247,7 +247,8 @@ to the GCP build console. You can take a look at the
 [release-management-url]: https://app.slack.com/client/T09NY5SBT/CJH2GBF7Y
 [example-release-thread]: https://kubernetes.slack.com/archives/CJH2GBF7Y/p1600247891103600
 
-Once mock and nomock runs are complete, data about the jobs launched must be
+Once the release runs are complete (nomock only for patch releases, mock and
+nomock for all other release types), data about the jobs launched must be
 collected in the issue. These are assembled in a table and correspond to the
 `Collect metrics, links...` check mark.
 
@@ -327,7 +328,9 @@ This can be confusing. The v1.16.0-alpha.0 tag was created automatically in the 
 
 ##### Mock vs nomock
 
-Any `krel stage/release` command without the `--nomock` flag is a dry run. It is highly encouraged to dry run first before letting `krel stage/release` take any actual impact on the release process. Mock building/releasing can help you verify that you have a working setup!
+Any `krel stage/release` command without the `--nomock` flag is a dry run. For minor releases, RCs, alphas, and betas, it is highly encouraged to dry run first before letting `krel stage/release` take any actual impact on the release process. Mock building/releasing can help you verify that you have a working setup!
+
+For patch releases (x.y.z where z > 0), mock runs are skipped. The nomock pipeline includes built-in safety checks that make a separate mock run unnecessary for patches.
 
 To get more information on `krel stage/release`, please refer to their
 corresponding help (`-h`) output.
@@ -757,13 +760,13 @@ The diagram below shows the actions needed to cut a Kubernetes release
 flowchart TD
     Start(["Start"]) --> issue["Create a release cut issue on GitHub"] -->|"update along the way"| issue
     issue --> thread["Create a Slack Thread in #release-management \n and cc release-managers"] -->|"update along the way"| thread
-    thread --> build_admins["Contact Google Build Admins \n for their availability to plan when to cut the release"]
-    build_admins --> mock["Mock run (stage and release)"]
-    mock --> staging["Nomock stage"]
+    thread --> is_patch{{"Patch release?"}}
+    is_patch -->|Yes| staging["Nomock stage"]
+    is_patch -->|No| mock["Mock run (stage and release)"]
+    mock --> staging
     staging --> artifact_promotion["Image promotion"]
     artifact_promotion --> release["Nomock release"]
-    release --> publish_pkgs["Contact Google Build Admins to publish the deps/rpms"]
-    publish_pkgs --> announcement_chat["Notify Slack channel #release-management \n about the new release"]
+    release --> announcement_chat["Notify Slack channel #release-management \n about the new release"]
     announcement_chat --> announcement_email["Notify Community by Email \n using Krel"]
     announcement_email --> close["Close release cut GitHub Issue"]
     close --> done(["End"])
@@ -772,5 +775,5 @@ flowchart TD
     classDef plain fill:#ddd,stroke:#fff,stroke-width:4px,color:#000;
     classDef k8s fill:#326ce5,stroke:#fff,stroke-width:4px,color:#fff;
     class Start,done plain;
-    class issue,thread,build_admins,mock,staging,artifact_promotion,release,publish_pkgs,announcement_chat,announcement_email,close k8s;
+    class issue,thread,is_patch,mock,staging,artifact_promotion,release,announcement_chat,announcement_email,close k8s;
 ```

--- a/release-engineering/role-handbooks/patch-release-team.md
+++ b/release-engineering/role-handbooks/patch-release-team.md
@@ -506,25 +506,13 @@ The freeze serves several purposes:
 1.  It allows slow test jobs like "serial", which has a period of many hours,
     to run several times at `HEAD` to ensure they pass consistently.
 
-On the day before the planned release, run a mock build with `krel stage/release`
-to make sure the tooling is ready as per the [Branch Manager
-Handbook](/release-engineering/role-handbooks/branch-manager.md).
-Also give the Google Debs/RPMs build staff notification that their
-help will be needed the next day.  Once you've done the mock build, you can
-also do a mock release and notify, sending the release notification email
-to yourself to visual confirm its content:
+Mock builds are no longer required for patch releases. The nomock pipeline
+includes built-in safety checks (provenance verification, deterministic builds)
+that make a separate mock run unnecessary. Proceed directly with
+the `--nomock` stage and release on the day of the cut.
 
-```bash
-~$ cd src/k8s.io/release
-~$ export SENDGRID_API_KEY=<API_KEY>
-~$ krel announce send --tag v1.13.2 --nomock
-```
-
-If the mock build and release goes well and CI tests show the branch
-is healthy, run the real cut the next day by repeating the build
-and release process with the `--nomock` argument in the commands.
-Collaborate with the Google Debs/RPMs build staff to insure the
-packages are successfully published.  Then announce the release:
+If CI tests show the branch is healthy, run the release cut using the
+`--nomock` argument in the commands. Then announce the release:
 
 ```bash
 ~$ cd src/k8s.io/release
@@ -584,19 +572,12 @@ corresponding command line help (`-h`) outputs.
 | --- |--- |
 | Make sure you have latest release tooling | ```cd ~/go/src/k8s.io/release && git pull``` |
 | Configure branch | n/a |
-| Mock build staging | `krel stage --type=official --branch=release-x.y` |
-| Mock build staging success? | Visually confirm yes |
-| Mock release | `krel release --type=official --branch=release-x.y --build-version=…` (get the build-version from the Google Cloud console output of `krel stage`) |
-| Mock release success? | Visually confirm yes |
-| Mock email notify test | ```krel announce send --tag v1.13.3-beta.1``` |
-| Check mail arrives, list has expected commits? | manual/visual |
 | Official build staging | `krel stage --nomock --type=official --branch=release-x.y` |
 | Official build staging success? | Visually confirm yes |
 | Official release | `krel release --nomock --type=official --branch=release-x.y --build-version=…` |
 | Official email notify test | ```krel announce send --tag vX.Y.Z``` |
 | Check mail arrives, list has expected commits? | manual/visual |
-| Package creation (needs its own improved workflow; work starting on that) | Ping [Build Admins](https://github.com/kubernetes/website/blob/main/content/en/releases/release-managers.md) by name on Slack for package building |
-| Package testing (needs improvement) | Visually validate [yum repo](https://pkgs.k8s.io/core:/stable:/v1.x/rpm/repodata/) and [apt repo](https://pkgs.k8s.io/core:/stable:/v1.x/deb/Packages) have entries for the release version in package NVRs (Name-Version-Release) |
+| Package testing | Visually validate [yum repo](https://pkgs.k8s.io/core:/stable:/v1.x/rpm/repodata/) and [apt repo](https://pkgs.k8s.io/core:/stable:/v1.x/deb/Packages) have entries for the release version in package NVRs (Name-Version-Release) |
 | Official email notify | ```krel announce send --tag v1.13.3 --nomock``` |
 | Check mail arrives | manual/visual check that [k-announce](https://groups.google.com/forum/#!forum/kubernetes-announce) and [k-dev](https://groups.google.com/a/kubernetes.io/g/dev) got mail OK |
 | Completion | n/a |


### PR DESCRIPTION
#### What type of PR is this:

/kind documentation

#### What this PR does / why we need it:

Updates release engineering docs to skip mock stage and mock release for patch releases (x.y.z where z > 0). Mock runs remain mandatory for minor releases, RCs, alphas, and betas. The nomock pipeline already includes built-in safety checks (provenance verification, deterministic builds) that make a separate mock run unnecessary for patches, reducing release cut time by ~45 minutes per branch. Also removes outdated Google Build Admins references, as package building is now handled by the release engineering team directly.

#### Which issue(s) this PR fixes:

Fixes kubernetes/sig-release#2980

#### Special notes for your reviewer:

Changes across four files: the main release cut handbook, the patch release team handbook, the branch manager handbook (including the Mermaid diagram), and the release cut issue template.