### PR TITLE
Add release announcement field to the Communications handbook

### DIFF
--- a/release-team/role-handbooks/communications/README.md
+++ b/release-team/role-handbooks/communications/README.md
@@ -107,6 +107,12 @@ The release lead will drive the content for the release theme and logo.
 3. In a second PR opened (ideally) a week before the release day, the Comms Lead will:
 - remove the `draft: true` parameter
 - ensure the date parameter is set to the release date
+- add the `release_announcement` parameter:
+
+  ```yaml
+  release_announcement:
+    minor_version: "<major>.<minor>"
+  ```
 - add the release logo and theme to the final release blog
 
 > [!IMPORTANT]  

--- a/release-team/role-handbooks/communications/templates/release-blog.md
+++ b/release-team/role-handbooks/communications/templates/release-blog.md
@@ -61,11 +61,13 @@ The template should give you some boilerplate. However, each release has its own
 ```md
 ---
 layout: blog
-title: 'Kubernetes 1.XX: <Release Name>'
+title: 'Kubernetes v1.XX: <Release Name>'
 date: 202n-mm-dd
-slug: kubernetes-1-XX-release-announcement
+slug: kubernetes-v1-XX-release-announcement
 author: >
   [Kubernetes v1.XX Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.XX/release-team.md)
+release_announcement:
+  minor_version: "1.XX"
 ---
 ---
 


### PR DESCRIPTION
#### What type of PR is this:

/kind documentation

#### What this PR does / why we need it:

Add documentation for the `release_announcement` field in the release blog frontmatter to the Communications handbook.

This field is being introduced in kubernetes/website#54885 to support the automated release series page generation. The release series pages (e.g., /releases/1.35/) will automatically link to the corresponding release announcement blog post using this frontmatter field.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

The release series pages (e.g., https://kubernetes.io/releases/1.35/) are now auto-generated from existing data (kubernetes/website#54041). To automatically display a link to the release blog on these pages, PR (kubernetes/website#54885) is trying to add support for the `release_announcement` field in the blog frontmatter.

As suggested in [kubernetes/website#54885](https://github.com/kubernetes/website/pull/54885#issuecomment-4179102131), this PR updates the handbook so future Comms leads know to add this field.