### PR TITLE
fix: cosign verification and exclude deleted files from krel release notes validation

### DIFF
--- a/.github/workflows/krel-release-notes-validate.yaml
+++ b/.github/workflows/krel-release-notes-validate.yaml
@@ -88,7 +88,7 @@ jobs:
           KREL_PATH: ${{ steps.install-krel.outputs.krel-path }}
         run: |
           # Get a list of changed YAML files based on git diff
-          CHANGED_FILES=$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.sha }} -- releases/ | grep -E '\.ya?ml$' || true)
+          CHANGED_FILES=$(git diff --diff-filter=d --name-only ${{ github.event.pull_request.base.sha }} ${{ github.sha }} -- releases/ | grep -E '\.ya?ml$' || true)
 
           if [ -n "$CHANGED_FILES" ]; then
             echo "### YAML Validation Results :mag:" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/krel-release-notes-validate.yaml
+++ b/.github/workflows/krel-release-notes-validate.yaml
@@ -41,7 +41,7 @@ jobs:
         with:
           go-version: '1.23'
           check-latest: true
-      - uses: sigstore/cosign-installer@dc72c7d5c4d10cd6bcb8cf6e3fd625a9e5e537da # v3.7.0
+      - uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
         with:
           use-sudo: false
       - id: install-krel
@@ -62,13 +62,25 @@ jobs:
               exit 1
           fi
           
-          KREL_CERT="https://github.com/kubernetes/release/releases/download/$KREL_VERSION/$ARTIFACT_NAME.pem"
-          KREL_SIG="https://github.com/kubernetes/release/releases/download/$KREL_VERSION/$ARTIFACT_NAME.sig"
-          
+          RELEASE_URL="https://github.com/kubernetes/release/releases/download/$KREL_VERSION"
+          COSIGN_IDENTITY="https://github.com/kubernetes/release/.github/workflows/release.yml@refs/tags/$KREL_VERSION"
+          COSIGN_ISSUER="https://token.actions.githubusercontent.com"
+
           echo "Using cosign to verify signature of krel version $KREL_VERSION"
-          if ! cosign verify-blob --certificate "$KREL_CERT" --signature "$KREL_SIG" \
-              --certificate-identity "https://github.com/kubernetes/release/.github/workflows/release.yml@refs/tags/$KREL_VERSION" \
-              --certificate-oidc-issuer "https://token.actions.githubusercontent.com" krel; then
+          # Try new bundle format first (.sigstore.json), fall back to legacy .sig/.pem
+          # Use curl -f to fail on HTTP 404 (GitHub returns HTML for missing assets)
+          if curl -sfL "$RELEASE_URL/$ARTIFACT_NAME.sigstore.json" -o "$ARTIFACT_NAME.sigstore.json" && \
+              cosign verify-blob --bundle "$ARTIFACT_NAME.sigstore.json" \
+              --certificate-identity "$COSIGN_IDENTITY" \
+              --certificate-oidc-issuer "$COSIGN_ISSUER" krel; then
+              echo "Signature verified using sigstore bundle"
+          elif cosign verify-blob \
+              --certificate "$RELEASE_URL/$ARTIFACT_NAME.pem" \
+              --signature "$RELEASE_URL/$ARTIFACT_NAME.sig" \
+              --certificate-identity "$COSIGN_IDENTITY" \
+              --certificate-oidc-issuer "$COSIGN_ISSUER" krel; then
+              echo "Signature verified using legacy .sig/.pem"
+          else
               echo "Signature verification failed for krel version: '$KREL_VERSION'"
               exit 1
           fi

--- a/.github/workflows/krel-release-notes-validate.yaml
+++ b/.github/workflows/krel-release-notes-validate.yaml
@@ -54,46 +54,46 @@ jobs:
           KREL_VERSION=$(curl -s https://api.github.com/repos/kubernetes/release/releases/latest | grep '"tag_name":' | cut -d'"' -f4)
           ARTIFACT_NAME=krel-amd64-linux
           TEMP_DIR=$(mktemp -d)
-          cd "$TEMP_DIR"
-          
-          echo "Downloading latest krel version $KREL_VERSION..."
-          if ! curl -sL "https://github.com/kubernetes/release/releases/download/$KREL_VERSION/$ARTIFACT_NAME" -o krel; then
+          cd "${TEMP_DIR}"
+
+          echo "Downloading latest krel version ${KREL_VERSION}..."
+          if ! curl -sL "https://github.com/kubernetes/release/releases/download/${KREL_VERSION}/${ARTIFACT_NAME}" -o krel; then
               echo "Failed to download krel"
               exit 1
           fi
-          
-          RELEASE_URL="https://github.com/kubernetes/release/releases/download/$KREL_VERSION"
-          COSIGN_IDENTITY="https://github.com/kubernetes/release/.github/workflows/release.yml@refs/tags/$KREL_VERSION"
+
+          RELEASE_URL="https://github.com/kubernetes/release/releases/download/${KREL_VERSION}"
+          COSIGN_IDENTITY="https://github.com/kubernetes/release/.github/workflows/release.yml@refs/tags/${KREL_VERSION}"
           COSIGN_ISSUER="https://token.actions.githubusercontent.com"
 
-          echo "Using cosign to verify signature of krel version $KREL_VERSION"
+          echo "Using cosign to verify signature of krel version ${KREL_VERSION}"
           # Try new bundle format first (.sigstore.json), fall back to legacy .sig/.pem
           # Use curl -f to fail on HTTP 404 (GitHub returns HTML for missing assets)
-          if curl -sfL "$RELEASE_URL/$ARTIFACT_NAME.sigstore.json" -o "$ARTIFACT_NAME.sigstore.json" && \
-              cosign verify-blob --bundle "$ARTIFACT_NAME.sigstore.json" \
-              --certificate-identity "$COSIGN_IDENTITY" \
-              --certificate-oidc-issuer "$COSIGN_ISSUER" krel; then
+          if curl -sfL "${RELEASE_URL}/${ARTIFACT_NAME}.sigstore.json" -o "${ARTIFACT_NAME}.sigstore.json" && \
+              cosign verify-blob --bundle "${ARTIFACT_NAME}.sigstore.json" \
+              --certificate-identity "${COSIGN_IDENTITY}" \
+              --certificate-oidc-issuer "${COSIGN_ISSUER}" krel; then
               echo "Signature verified using sigstore bundle"
           elif cosign verify-blob \
-              --certificate "$RELEASE_URL/$ARTIFACT_NAME.pem" \
-              --signature "$RELEASE_URL/$ARTIFACT_NAME.sig" \
-              --certificate-identity "$COSIGN_IDENTITY" \
-              --certificate-oidc-issuer "$COSIGN_ISSUER" krel; then
+              --certificate "${RELEASE_URL}/${ARTIFACT_NAME}.pem" \
+              --signature "${RELEASE_URL}/${ARTIFACT_NAME}.sig" \
+              --certificate-identity "${COSIGN_IDENTITY}" \
+              --certificate-oidc-issuer "${COSIGN_ISSUER}" krel; then
               echo "Signature verified using legacy .sig/.pem"
           else
-              echo "Signature verification failed for krel version: '$KREL_VERSION'"
+              echo "Signature verification failed for krel version: '${KREL_VERSION}'"
               exit 1
           fi
-          
+
           chmod +x krel
-          mkdir -p "$HOME/.local/bin"
-          mv krel "$HOME/.local/bin/"
+          mkdir -p "${HOME}/.local/bin"
+          mv krel "${HOME}/.local/bin/"
           cd - > /dev/null
-          rm -rf "$TEMP_DIR"
-          
-          KREL_PATH="$HOME/.local/bin/krel"
-          echo "krel-path=$KREL_PATH" >> "$GITHUB_OUTPUT"
-          echo "Krel installed at: $KREL_PATH"
+          rm -rf "${TEMP_DIR}"
+
+          KREL_PATH="${HOME}/.local/bin/krel"
+          echo "krel-path=${KREL_PATH}" >> "${GITHUB_OUTPUT}"
+          echo "Krel installed at: ${KREL_PATH}"
       - name: Run if releases YAML changes exist and validate the YAML
         id: validate_releases_yaml
         env:
@@ -102,37 +102,37 @@ jobs:
           # Get a list of changed YAML files based on git diff
           CHANGED_FILES=$(git diff --diff-filter=d --name-only ${{ github.event.pull_request.base.sha }} ${{ github.sha }} -- releases/ | grep -E '\.ya?ml$' || true)
 
-          if [ -n "$CHANGED_FILES" ]; then
-            echo "### YAML Validation Results :mag:" >> $GITHUB_STEP_SUMMARY
-            echo "Validating files against base SHA: ${{ github.event.pull_request.base.sha }}" >> $GITHUB_STEP_SUMMARY
+          if [ -n "${CHANGED_FILES}" ]; then
+            echo "### YAML Validation Results :mag:" >> "${GITHUB_STEP_SUMMARY}"
+            echo "Validating files against base SHA: ${{ github.event.pull_request.base.sha }}" >> "${GITHUB_STEP_SUMMARY}"
 
             INVALID_FILES=""
 
             while IFS= read -r file; do
-              echo "#### Validating: ${file##*/}" >> $GITHUB_STEP_SUMMARY
+              echo "#### Validating: ${file##*/}" >> "${GITHUB_STEP_SUMMARY}"
               set +e
-              VALIDATION_OUTPUT=$("${KREL_PATH}" release-notes validate --path-to-release-notes "$file" 2>&1)
+              VALIDATION_OUTPUT=$("${KREL_PATH}" release-notes validate --path-to-release-notes "${file}" 2>&1)
               exit_code=$?
               set -e
-          
-              if [ $exit_code -ne 0 ]; then
+
+              if [ "${exit_code}" -ne 0 ]; then
                   INVALID_FILES="${INVALID_FILES}- ${file##*/}\n"
-                  echo "❌ Validation failed with the following errors:" >> $GITHUB_STEP_SUMMARY
-                  echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-                  echo "$VALIDATION_OUTPUT" >> $GITHUB_STEP_SUMMARY
-                  echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+                  echo "❌ Validation failed with the following errors:" >> "${GITHUB_STEP_SUMMARY}"
+                  echo "\`\`\`" >> "${GITHUB_STEP_SUMMARY}"
+                  echo "${VALIDATION_OUTPUT}" >> "${GITHUB_STEP_SUMMARY}"
+                  echo "\`\`\`" >> "${GITHUB_STEP_SUMMARY}"
               else
-                  echo "✅ File is valid" >> $GITHUB_STEP_SUMMARY
+                  echo "✅ File is valid" >> "${GITHUB_STEP_SUMMARY}"
               fi
-            done <<< "$CHANGED_FILES"
-          
-            if [ -n "$INVALID_FILES" ]; then
-              echo -e "\n### ❌ Validation Failed" >> $GITHUB_STEP_SUMMARY
-              echo "The following files contain invalid YAML:" >> $GITHUB_STEP_SUMMARY
-              echo -e "$INVALID_FILES" >> $GITHUB_STEP_SUMMARY
+            done <<< "${CHANGED_FILES}"
+
+            if [ -n "${INVALID_FILES}" ]; then
+              echo -e "\n### ❌ Validation Failed" >> "${GITHUB_STEP_SUMMARY}"
+              echo "The following files contain invalid YAML:" >> "${GITHUB_STEP_SUMMARY}"
+              echo -e "${INVALID_FILES}" >> "${GITHUB_STEP_SUMMARY}"
               exit 1
             fi
           else
-            echo "### No YAML Changes Detected" >> $GITHUB_STEP_SUMMARY
-            echo "No YAML files were changed under /releases/*" >> $GITHUB_STEP_SUMMARY
+            echo "### No YAML Changes Detected" >> "${GITHUB_STEP_SUMMARY}"
+            echo "No YAML files were changed under /releases/*" >> "${GITHUB_STEP_SUMMARY}"
           fi


### PR DESCRIPTION
#### What type of PR is this:

/kind bug

#### What this PR does / why we need it:

1. Adds `--diff-filter=d` to the `git diff` command in the `krel-release-notes-validate` workflow to exclude deleted files from validation.

   Without this filter, the workflow fails when a PR deletes YAML files under `releases/**/release-notes/` because `krel validate` tries to read files that no longer exist on disk.

2. Updates cosign signature verification to support the new `.sigstore.json` bundle format introduced in kubernetes/release/pull/4357, while keeping backward compatibility with the legacy `.sig`/`.pem` format for older krel releases.

#### Which issue(s) this PR fixes:

Fixes kubernetes/sig-release#2999

#### Special notes for your reviewer:

- The `--diff-filter=d` flag (lowercase `d`) tells git diff to exclude deleted files from the output, while still including added, copied, modified, and renamed files.
- The cosign verification now tries `--bundle` with the `.sigstore.json` file first, falling back to `--certificate`/`--signature` with `.pem`/`.sig` if the bundle isn't available.