### PR TITLE
Add release codename to Release Blog handbook

### DIFF
--- a/release-team/role-handbooks/communications/README.md
+++ b/release-team/role-handbooks/communications/README.md
@@ -108,10 +108,13 @@ The release lead will drive the content for the release theme and logo.
 - remove the `draft: true` parameter
 - ensure the date parameter is set to the release date
 - add the `release_announcement` parameter:
+- add the `themes` parameter with the release code name, if applicable
 
   ```yaml
   release_announcement:
     minor_version: "<major>.<minor>"
+    themes:
+      - "Release CodeName 1"
   ```
 - add the release logo and theme to the final release blog
 

--- a/release-team/role-handbooks/communications/templates/release-blog.md
+++ b/release-team/role-handbooks/communications/templates/release-blog.md
@@ -68,6 +68,8 @@ author: >
   [Kubernetes v1.XX Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.XX/release-team.md)
 release_announcement:
   minor_version: "1.XX"
+  themes:
+    - "Release CodeName 1"
 ---
 ---
 


### PR DESCRIPTION
#### What type of PR is this:

/kind documentation

#### What this PR does / why we need it:

Add the `themes` field under `release_announcement` in the communications role handbook and the release-blog template so that the release code name can be included in the final release blog frontmatter.

#### Which issue(s) this PR fixes:

None

#### Special Notes for the reviewers

Follow-up to #2987.
The `themes` (release codename) field was missed in that PR and is being added here.

The convention to include the codename in the release blog frontmatter was introduced by kubernetes/website#55596, which has already been merged.
This PR aligns the communications role handbook and template with that convention.

---

nit: `themes` is defined as an array because some older releases shipped with multiple codenames. For recent releases, a single entry is sufficient. The array form is kept for backward compatibility with the old release codenames.