### PR TITLE
Update v1.37 release links with bug triage and CI signal boards

### DIFF
--- a/releases/release-1.37/links.md
+++ b/releases/release-1.37/links.md
@@ -12,11 +12,11 @@ Each header below (and their hidden ID tagging) creates the `rel.k8s.io/v137` na
 
 ## <a id="bugtriage"></a> Bug Triage
 
-_To be updated_
+[GitHub Bug Triage Project Board for v1.37](https://github.com/orgs/kubernetes/projects/80/views/30)
 
 ## <a id="cisignal"></a> CI Signal
 
-_To be updated_
+[GitHub CI Signal Project Board for v1.37 Issue Tracking](https://github.com/orgs/kubernetes/projects/68/views/42)
 
 ## <a id="retro"></a> Release Retrospective
 


### PR DESCRIPTION
#### What type of PR is this?

Adds the Kubernetes v1.37 Bug Triage and CI Signal project board links to the release links page.
/kind documentation

#### What this PR does / why we need it:

These links replace the placeholder entries to point to the correct tracking boards.

#### Which issue(s) this PR fixes:

Ref: https://github.com/kubernetes/sig-release/issues/3015