### PR TITLE
Revise blog date instructions in feature blog messages

### DIFF
--- a/release-team/role-handbooks/communications/templates/feature-blog-messages.md
+++ b/release-team/role-handbooks/communications/templates/feature-blog-messages.md
@@ -57,7 +57,7 @@ For easier tracking, please let us know whether you’d like to opt in or opt ou
 > 
 
 > [!Note]
-> In your placeholder PR, use `XX` characters for the blog `date` in the front matter and file name. We will work with you on updating the PR with the publication date once we have a final number of feature blogs for this release.
+> In your placeholder PR, use the current scheduled overall release date for the blog `date` and add a `draft:true` to the front matter. We will work with you on updating the PR with the publication date once we have a final number of feature blogs for this release.
 ```
 
 With this one, you'd need to update the following placeholders:
@@ -84,7 +84,7 @@ This is a gentle reminder for the feature blog deadline mentioned above, which i
 > - You can find more in the [release document](LINK)
 
 > [!Note]
-> In your placeholder PR, use `XX` characters for the blog `date` in the front matter and file name. We will work with you on updating the PR with the publication date once we have a final number of feature blogs for this release.
+> In your placeholder PR, use the current scheduled overall release date for the blog `date` and add a `draft:true` to the front matter. We will work with you on updating the PR with the publication date once we have a final number of feature blogs for this release.
 ```
 
 With this one, you'd need to update the following placeholders:


### PR DESCRIPTION
#### What type of PR is this:

/kind cleanup

#### What this PR does / why we need it:

Updated instructions for placeholder PRs to use the current scheduled release date and add draft status. Blog guidelines are calling to omit the publication date completely, but I aligned to other notes on this page

Noted by @danwinship:  https://github.com/kubernetes/website/pull/56422#discussion_r3551748820
