### PR TITLE
fix: the release team the author for the mid-cycle blog template

### DIFF
--- a/release-team/role-handbooks/communications/templates/mid-cycle-blog-sneak-peek.md
+++ b/release-team/role-handbooks/communications/templates/mid-cycle-blog-sneak-peek.md
@@ -36,8 +36,10 @@ title: 'Kubernetes v1.XX Sneak Peek'
 date: 202n-mm-dd
 slug: kubernetes-v1-XX-sneak-peek
 author: >
-  [Comms team members, ordered by first name ascending]
+  [Kubernetes v1.XX Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.XX/release-team.md)
 ---
+
+**Editors:** [Comms team members, ordered by last name ascending]
 
 As we get closer to the release date for Kubernetes v1.xx, the project develops and matures, features may be deprecated, removed, or replaced with better ones for the project's overall health. This blog outlines some of the planned changes for the Kubernetes 1.xx release, that the release team feels you should be aware of for the continued maintenance of your Kubernetes environment and keeping up to date with the latest changes. The information listed below is based on the current status of the v1.xx release and may change before the actual release date. 
 


### PR DESCRIPTION
#### What type of PR is this:

/kind cleanup

#### What this PR does / why we need it:

The last 3 release cycles have drifted from the original blog front-matter template by listing individual authors instead of linking to the Release Team page. 

This PR rolls the template back to the original convention.

**To note**: the upcoming Release Comms team must be aware of these changes.

| Post | `author:` front matter |
|---|---|
| [v1.35 Sneak Peek](https://github.com/kubernetes/website/blob/main/content/en/blog/_posts/2025/kubernetes-v1-35-sneak-peek.md) | Aakanksha Bhende, Arujjwal Negi, Chad M. Crowell, Graziano Casto, Swathi Rao |
| [v1.35 Release announcement](https://github.com/kubernetes/website/blob/main/content/en/blog/_posts/2025/kubernetes-v1-35-release/index.md) | [Kubernetes v1.35 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.35/release-team.md) |
| [v1.36 Sneak Peek](https://github.com/kubernetes/website/blob/main/content/en/blog/_posts/2026/kubernetes-v1-36-sneak-peak.md) | Chad Crowell, Kirti Goyal, Sophia Ugochukwu, Swathi Rao, Utkarsh Umre |
| [v1.36 Release announcement](https://github.com/kubernetes/website/blob/main/content/en/blog/_posts/2026/kubernetes-v1-36-release/index.md) | [Kubernetes v1.36 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.36/release-team.md) + **Editors:** Chad M. Crowell, Kirti Goyal, Sophia Ugochukwu, Swathi Rao, Utkarsh Umre |
| [v1.37 Sneak Peek](https://github.com/kubernetes/website/blob/main/content/en/blog/_posts/2026/kubernetes-v1-37-sneak-peek.md) | Arsh Sharma, Christopher Tineo, Kirti Goyal, Sophia Ugochukwu, Swathi Rao, Troy Connor *(v1.37 announcement not yet published)* |