### PR TITLE
chore: update release template with changes from 1.37 release

### DIFF
--- a/release-team/role-handbooks/communications/templates/release-blog.md
+++ b/release-team/role-handbooks/communications/templates/release-blog.md
@@ -56,9 +56,10 @@ The release announcement is held to the [Kubernetes style guide](https://kuberne
 
 * Sentence case headings, and an explicit `{#anchor}` on every feature heading so release notes and social posts can deep-link it.
 * Start case for graduation phases (Alpha, Beta, Stable, Generally Available); italics and lowercase for a feature or concept on first mention (`_gang scheduling_`).
-* Use U.S. English. Wrap source lines at around 80 characters, but never break a line inside `[...]` or `(...)` — a split link renders as literal text.
+* Use U.S. English. 
+* Wrap source lines at around 80 characters, but never break a line inside `[...]` or `(...)` 
 * Write as if the release has already happened: pre-release behavior goes in the past tense.
-* Per-section technical review: make sure to receive a review from KEP authors and owning SIG's leads.
+* Make sure to receive a review from KEP authors and/or owning SIG's leads for new features or behavior in this upcoming cycle.
 
 ## Latest Release Blogs as Reference
 * [Kubernetes v1.37: Garhwal](https://kubernetes.io/blog/2026/08/26/kubernetes-v1-37-release/)

--- a/release-team/role-handbooks/communications/templates/release-blog.md
+++ b/release-team/role-handbooks/communications/templates/release-blog.md
@@ -3,212 +3,325 @@ This outline can be used as reference for writing up the release blog. The follo
 
 * Introduction to release
     * The first paragraph of the release blog announcement introduces the release, its focus, and its importance.
-* Release Highlights (Enhancements)
+* Spotlight on key updates
+    * Three to five picks, one per graduation phase where possible, each heading prefixed with the phase (`Stable:`, `Beta:`, `Alpha:`).
     * Order release features by impact, maturity, vision.
     * This section lists out the key features (even if they are not being recommended to be used in production or are alphas).
         * When we describe something in the alpha state, we are highlighting what is going on (in/to) the community.
         * Release cycles are so short, just because it is alpha right now, it will be stable soon. Position it as “this is what is coming.”
-    * Include additional features and what's next section following the key release features.
-        * This is the vision and brand new thing you can do in-production right now.
     * Everything else is included in the release notes.
-* Changes in stable, beta, alpha
-    * List major changes not covered in themes
-    * Call out important API deprecations and removals
-    * When possible, link upstream docs or KEP docs (past blogs link k/enhancement issues)
+* Changes in Stable, Beta, Alpha
+    * One section per phase, one `###` per feature, `####` for sub-features under a grouping heading (for example, DRA or Workload-aware Scheduling).
+    * Name grouping headings consistently: `<Family> features graduating to <Phase>` (or `<Family>: Features graduating to <Phase>`) for graduations, and `<Family>: Alpha features to look out for` for Alpha.
+    * When possible, link upstream docs or KEP docs. Use `https://www.kubernetes.dev/resources/keps/XXXX/` for the KEP itself, and deep-link the KEP README on GitHub when citing a specific section (for example, `.../README.md#graduation-criteria`).
+    * State the feature gate and whether it is on or off by default, for every feature.
+* Other notable changes
+    * Changes that matter to users but don't belong to a single graduation, such as a default flipping or a subproject retirement.
+* Graduations, deprecations, and removals
+    * Full list of graduations to Stable.
+    * Call out important API deprecations and removals, and reconcile them against the mid-cycle Deprecations and Removals blog.
 * Known Issues
     * Optional section to call out specific known issues and workarounds, if applicable.
 * Release notes
     * Release notes are always included in the blog announcement.
 * Availability of release
     * Link to where the release can be downloaded on GitHub.
-    * Include interactive tutorials on the current release or how to get started with Kubernetes when relevant.
-* Release Team
+    * Include tutorials on the current release or how to get started with Kubernetes when relevant.
+* Release team
     * Mention job of release team
     * Important to highlight company contributions in a way that is respectful to the entire community – including a copy of the release team in relation to the project and their work
     * Mention efforts of community
     * Mention the growth of the community
     * List of contributors to the spec should go in the 5 Day blog series
-* Project Velocity
+* Project velocity
     * Growth since the last release
     * Number of companies involved in the release
     * Other relevant velocity numbers from DevStats
-* Event Updates
+* Event updates
     * Relevant KubeCon dates and information
     * Conferences where the release will be discussed
 * Upcoming release webinar
     * CNCF hosts a release webinar 30 days after the release is available. Webinar is conducted by the release team and discusses the current release. Include information on the webinar in the release announcement blog to encourage attendance.
-* Get Involved
+* Get involved
     * SIGs
-    * Community Meeting
-    * Where to host questions (or answer questions) 
-    * Advocates
-    * Twitter
-    * Slack
+    * New Contributor Orientation
+    * Where to host questions (or answer questions)
+    * Slack, Discuss, Stack Overflow
+    * Bluesky, LinkedIn, X
     * Kubernetes blog
 
+## Style
+
+The release announcement is held to the [Kubernetes style guide](https://kubernetes.io/docs/contribute/style/style-guide/).
+
+* Sentence case headings, and an explicit `{#anchor}` on every feature heading so release notes and social posts can deep-link it.
+* Start case for graduation phases (Alpha, Beta, Stable, Generally Available); italics and lowercase for a feature or concept on first mention (`_gang scheduling_`).
+* Use U.S. English. Wrap source lines at around 80 characters, but never break a line inside `[...]` or `(...)` — a split link renders as literal text.
+* Write as if the release has already happened: pre-release behavior goes in the past tense.
+* Per-section technical review: make sure to receive a review from KEP authors and owning SIG's leads.
+
 ## Latest Release Blogs as Reference
-* [Kubernetes 1.32: Penelope](https://kubernetes.io/blog/2024/12/11/kubernetes-v1-32-release/)
-* [Kubernetes 1.31: Elli](https://kubernetes.io/blog/2024/08/13/kubernetes-v1-31-release/)
-* [Kubernetes 1.30: Uwubernetes](https://kubernetes.io/blog/2024/04/17/kubernetes-v1-30-release/)
-* [Kubernetes 1.27: Chill Vibes](https://kubernetes.io/blog/2023/04/11/kubernetes-v1-27-release/)
-* [Kubernetes 1.26: Electrifying](https://kubernetes.io/blog/2022/12/09/kubernetes-v1-26-release/)
-* [Kubernetes 1.25: Combiner](https://kubernetes.io/blog/2022/08/23/kubernetes-v1-25-release/)
+* [Kubernetes v1.37: Garhwal](https://kubernetes.io/blog/2026/08/26/kubernetes-v1-37-release/)
+* [Kubernetes v1.36: ハル (Haru)](https://kubernetes.io/blog/2026/04/22/kubernetes-v1-36-release/)
+* [Kubernetes v1.35](https://kubernetes.io/blog/2025/12/17/kubernetes-v1-35-release/)
+* [Kubernetes v1.34: Of Wind & Will](https://kubernetes.io/blog/2025/08/27/kubernetes-v1-34-release/)
+* [Kubernetes v1.33: Octarine](https://kubernetes.io/blog/2025/04/23/kubernetes-v1-33-release/)
 
 ## Release Blog Template
 
-The template should give you some boilerplate. However, each release has its own story to tell, there will be always something special around and exactly this flavour must be brought and individualized into the relase blog. Don't be just a copy cat.
+The template should give you some boilerplate. However, each release has its own story to tell, there will be always something special around and exactly this flavour must be brought and individualized into the release blog. Don't be just a copy cat.
+
+Open the announcement as a draft placeholder PR against `main` in `kubernetes/website`. Keep `draft: true` and set no `date` — a follow-up PR sets the date and drops the draft flag when the release ships.
 
 ```md
 ---
 layout: blog
-title: 'Kubernetes v1.XX: <Release Name>'
-date: 202n-mm-dd
-slug: kubernetes-v1-XX-release-announcement
+title: "Kubernetes v1.XX: <Release Name>"
+draft: true # replaced with `date: YYYY-MM-DD` in the publishing PR
+evergreen: true
+slug: kubernetes-v1-XX-release
 author: >
   [Kubernetes v1.XX Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.XX/release-team.md)
 release_announcement:
   minor_version: "1.XX"
   themes:
-    - "Release CodeName 1"
----
+    - "<Release Name>"
 ---
 
-**Editors:** [Comms teams members]
+**Editors:** <comma-separated list of Comms team member names>
 
-Similar to previous releases, the release of Kubernetes v1.XX introduces new stable, beta, and alpha features. The consistent delivery of high-quality releases underscores the strength of our development cycle and the vibrant support from our community.
+Similar to previous releases, the release of [Kubernetes v1.XX](/releases/1.XX/) introduces new Stable, Beta, and Alpha features. The consistent delivery of high-quality releases underscores the strength of our development cycle and the vibrant support from our community.
 
 This release consists of X enhancements.
-Of those enhancements, X have graduated to Stable, X are entering Beta, 
-and X have graduated to Alpha.
+Of those enhancements, X have graduated to Stable, X have graduated to Beta,
+X are entering Alpha, and X are deprecations or removals.
 
 ## Release theme and logo
-<Logo image size is recommended to be no more than 2160px>
-{{< figure src="/images/blog/YYYY-MM-DD-kubernetes-1.XX-release/k8s-1.XX.png" alt="Kubernetes v1.XX <release theme> logo" class="release-logo" >}}
 
+<!-- Place the logo in this post's page bundle; SVG is strongly preferred. Recommended size is no
+     more than 2160px. Commit a PNG of the same basename (k8s-v1.XX.png) next to the SVG for
+     social/preview cards. -->
 
-## Release highlights
+{{< figure src="k8s-v1.XX.svg" alt="Kubernetes v1.XX <release theme> logo, <description of what the image shows>" class="release-logo" >}}
 
-<MESSAGE ABOUT THE HIGHLIGHTS BELOW AND WHY THEY WERE CHOSEN>
+<THE STORY BEHIND THE RELEASE NAME AND THE LOGO, AND CREDIT FOR THE LOGO ARTIST. IF YOU NEED A FOOTNOTE, USE INLINE `<sup>1</sup>` IN THE BODY AND `<sub>1. ...</sub>` AT THE END OF THE SECTION — MARKDOWN FOOTNOTES ARE NOT ENABLED FOR BLOG POSTS.>
 
-### <THEME 1>
+## Spotlight on key updates
 
-### <THEME 2>
+Kubernetes v1.XX is packed with new features and improvements. Here are a few select updates the [Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.XX/release-team.md) would like to highlight!
 
-### <THEME 3>
+### Stable: <feature name> {#spotlight-stable-feature}
 
-### <THEME 4>
+<1-2 PARAGRAPH DESCRIPTION OF THE CHANGE, WRITTEN FOR USERS WHO HAVE NOT READ THE KEP>
 
-### <THEME 5>
+This work was done as part of [KEP #XXXX](https://www.kubernetes.dev/resources/keps/XXXX/) led by [SIG XXXX](https://www.kubernetes.dev/community/community-groups/sigs/xxxx/).
+
+### Beta: <feature name> {#spotlight-beta-feature}
+
+<1-2 PARAGRAPH DESCRIPTION OF CHANGE>
+
+This feature is on by default; you can disable it with the `SomeFeatureGate` feature gate.
+
+This work was done as part of [KEP #XXXX](https://www.kubernetes.dev/resources/keps/XXXX/) led by [SIG XXXX](https://www.kubernetes.dev/community/community-groups/sigs/xxxx/).
+
+### Alpha: <feature name> {#spotlight-alpha-feature}
+
+<1-2 PARAGRAPH DESCRIPTION OF CHANGE>
+
+This is an opt-in, off-by-default Alpha feature. To try it out, enable the `SomeFeatureGate` feature gate.
+
+This work was done as part of [KEP #XXXX](https://www.kubernetes.dev/resources/keps/XXXX/) led by [SIG XXXX](https://www.kubernetes.dev/community/community-groups/sigs/xxxx/).
 
 ## Features graduating to Stable
 
-_This is a selection of some of the improvements that are now stable following the v1.XX release._
+<!-- This section is a prose selection of highlights. The full enumerated list of promotions belongs
+     only under "Graduations to Stable" further down — do not paste that list's intro here. -->
 
-### <FEATURE TITLE>
+_This is a selection of some of the improvements that are now Generally Available following the v1.XX release._
 
-<1-2 PARAGRAPH DESCRIPTION OF CHANGE>
-
-This work was done as part of [KEP #XXXX](https://github.com/kubernetes/enhancements/issues/XXXX) led by [SIG XXXX](https://github.com/kubernetes/community/tree/master/sig-XXXXX).
-
-## New features in Beta
-
-_This is a selection of some of the improvements that are now beta following the v1.XX release._
-
-### <FEATURE TITLE>
+### <feature title> {#feature-title}
 
 <1-2 PARAGRAPH DESCRIPTION OF CHANGE>
 
-This work was done as part of [KEP #XXXX](https://github.com/kubernetes/enhancements/issues/XXXX) led by [SIG XXXX](https://github.com/kubernetes/community/tree/master/sig-XXXXX).
+This work was done as part of [KEP #XXXX](https://www.kubernetes.dev/resources/keps/XXXX/) led by [SIG XXXX](https://www.kubernetes.dev/community/community-groups/sigs/xxxx/).
 
+### <grouping title, for a family of related features> {#grouping-title}
+
+<INTRO SENTENCE FOR THE GROUP>
+
+#### <sub-feature title> {#sub-feature-title}
+
+<1-2 PARAGRAPH DESCRIPTION OF CHANGE>
+
+This work was done as part of [KEP #XXXX](https://www.kubernetes.dev/resources/keps/XXXX/) led by [SIG XXXX](https://www.kubernetes.dev/community/community-groups/sigs/xxxx/).
+
+## Features graduating to Beta
+
+_This is a selection of some of the improvements that are now Beta following the v1.XX release._
+
+### <feature title> {#feature-title}
+
+<1-2 PARAGRAPH DESCRIPTION OF CHANGE>
+
+This feature is behind the `SomeFeatureGate` feature gate (**on** by default).
+
+This work was done as part of [KEP #XXXX](https://www.kubernetes.dev/resources/keps/XXXX/) led by [SIG XXXX](https://www.kubernetes.dev/community/community-groups/sigs/xxxx/).
+
+### <family>: Features graduating to Beta {#family-beta}
+
+<INTRO SENTENCE FOR THE GROUP>
+
+#### <sub-feature title> {#sub-feature-title}
+
+<1-2 PARAGRAPH DESCRIPTION OF CHANGE>
+
+This work was done as part of [KEP #XXXX](https://www.kubernetes.dev/resources/keps/XXXX/) led by [SIG XXXX](https://www.kubernetes.dev/community/community-groups/sigs/xxxx/).
 
 ## New features in Alpha
 
-_This is a selection of some of the improvements that are now alpha following the v1.XX release._
-    
-### <FEATURE TITLE>
+_This is a selection of some of the improvements that are now Alpha following the v1.XX release._
+
+### <feature title> {#feature-title}
 
 <1-2 PARAGRAPH DESCRIPTION OF CHANGE>
 
-This work was done as part of [KEP #XXXX](https://github.com/kubernetes/enhancements/issues/XXXX) led by [SIG XXXX](https://github.com/kubernetes/community/tree/master/sig-XXXXX).
+This is an opt-in, off-by-default Alpha feature. To try it out, enable the `SomeFeatureGate` feature gate.
 
+This work was done as part of [KEP #XXXX](https://www.kubernetes.dev/resources/keps/XXXX/) led by [SIG XXXX](https://www.kubernetes.dev/community/community-groups/sigs/xxxx/).
 
-## Graduations, deprecations, and removals in 1.XX
+### <family>: Alpha features to look out for {#family-alpha}
 
-### Graduations to stable
+<INTRO SENTENCE FOR THE GROUP>
 
-This lists all the features that graduated to stable (also known as _general availability_). For a full list of updates including new features and graduations from alpha to beta, see the release notes.
+#### <sub-feature title> {#sub-feature-title}
 
-This release includes a total of X enhancements promoted to stable:
-* [KEP TITLE](https://github.com/kubernetes/enhancements/issues/XXXXXX)
+<1-2 PARAGRAPH DESCRIPTION OF CHANGE>
 
-### Deprecations and removals 
+This work was done as part of [KEP #XXXX](https://www.kubernetes.dev/resources/keps/XXXX/) led by [SIG XXXX](https://www.kubernetes.dev/community/community-groups/sigs/xxxx/).
 
-As Kubernetes develops and matures, features may be deprecated, removed, or replaced with better ones for the project's overall health. 
+## Other notable changes
+
+_Changes that matter to users but are not a graduation: a default flipping, a subproject retirement, a performance improvement._
+
+### <change title> {#change-title}
+
+<1-2 PARAGRAPH DESCRIPTION OF CHANGE>
+
+## Graduations, deprecations, and removals in v1.XX
+
+### Graduations to Stable
+
+This lists all the features that graduated to Stable (also known as general availability). For a full list of updates including new features and graduations from Alpha to Beta, see the release notes.
+
+This release includes a total of X enhancements promoted to Stable:
+
+* [KEP TITLE](https://www.kubernetes.dev/resources/keps/XXXX/)
+
+## Deprecations, removals, and community updates
+
+As Kubernetes develops and matures, features may be deprecated, removed, or replaced with better ones for the project's overall health.
 See the Kubernetes [deprecation and removal policy](/docs/reference/using-api/deprecation-policy/) for more details on this process.
-Many of these deprecations and removals were announced in the [Deprecations and Removals blog](LINK TO MID-CYCLE BLOG)
+Many of these deprecations and removals were announced in the [Deprecations and Removals blog](LINK TO THE MID-CYCLE SNEAK PEEK / DEPRECATIONS AND REMOVALS BLOG).
 
+### <deprecation title> {#deprecation-title}
 
-### Release notes
+<1-2 PARAGRAPH DESCRIPTION, INCLUDING WHAT USERS SHOULD MIGRATE TO AND BY WHEN>
 
-Check out the full details of the Kubernetes 1.XX release in our [release notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.XX.md).
+To learn more about this deprecation, refer to [KEP #XXXX](https://www.kubernetes.dev/resources/keps/XXXX/).
 
-### Availability
+<IF THE DEPRECATION HAS NO KEP, CITE THE ORIGINAL ISSUE INSTEAD:>
 
-Kubernetes v1.XX is available for download on [GitHub](https://github.com/kubernetes/kubernetes/releases/tag/v1.XX.0) or on the [Kubernetes download page](/releases/download/). 
+See [kubernetes/kubernetes#XXXXXX](https://github.com/kubernetes/kubernetes/issues/XXXXXX) for the original issue and discussion.
 
-To get started with Kubernetes, check out these [interactive tutorials](/docs/tutorials/) or run local Kubernetes clusters using [minikube](https://minikube.sigs.k8s.io/).
-You can also easily install v1.XX using [kubeadm](/docs/setup/independent/create-cluster-kubeadm/). 
+### Ongoing major change: <change planned for a future release> {#future-change}
 
-### Release Team
+<ANYTHING THAT LANDS IN A LATER RELEASE GETS ITS OWN HEADING WITH "FUTURE" OR "ONGOING" IN IT, SO READERS DON'T ASSUME IT APPLIES TO v1.XX>
+
+## Release notes
+
+Check out the full details of the Kubernetes v1.XX release in our [release notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.XX.md).
+
+## Availability
+
+[Kubernetes v1.XX](/releases/1.XX/) is available for download from
+the [Kubernetes download page](/releases/download/) or directly from [GitHub](https://github.com/kubernetes/kubernetes/releases/tag/v1.XX.0).
+
+To get started with Kubernetes, check out [these tutorials](/docs/tutorials/) or run local Kubernetes clusters using [minikube](https://minikube.sigs.k8s.io/).
+You can also easily install v1.XX using [kubeadm](/docs/setup/production-environment/tools/kubeadm/install-kubeadm/).
+
+## Release team
 
 <FIND AN INDIVIDUAL TEXT, EACH RELEASE TEAM HAS ITS OWN STORY, TELL IT! BELOW IS AN EXAMPLE FROM PAST RELEASES>
 
-Kubernetes is only possible with the support, commitment, and hard work of its community. 
-Each release team is made up of dedicated community volunteers who work together to build the many pieces that make up the Kubernetes releases you rely on. 
+Kubernetes is only possible with the support, commitment, and hard work of its community.
+Each release team is made up of dedicated community volunteers who work together to build the many pieces that make up the Kubernetes releases you rely on.
 This requires the specialized skills of people from all corners of our community, from the code itself to its documentation and project management.
 
-We would like to thank the entire [release team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.XX/release-team.md) for the hours spent hard at work to deliver the Kubernetes v1.31 release to our community. 
-The Release Team's membership ranges from first-time shadows to returning team leads with experience forged over several release cycles. 
-A very special thanks goes out our release lead, RELEASE LEAD, for supporting us through a successful release cycle, advocating for us, making sure that we could all contribute in the best way possible, and challenging us to improve the release process.
+We would like to thank the entire [release team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.XX/release-team.md) for the hours spent hard at work to deliver the Kubernetes v1.XX release to our community.
+The Release Team's membership ranges from first-time shadows to returning team leads with experience forged over several release cycles.
+A very special thanks goes out to our release lead, RELEASE LEAD, for supporting us through a successful release cycle, advocating for us, making sure that we could all contribute in the best way possible, and challenging us to improve the release process.
 
-### Project Velocity
+## Project velocity
 
-<CHECKOUT THE DEVSTATS AND HIGHLIGHT SOME INTRESTING NUMBERS https://k8s.devstats.cncf.io/d/12/dashboards?orgId=1&refresh=15m, INCLUDE ANY INTERESTED DATA YOU FIND FOR THE CYCLE>
+<CHECKOUT THE DEVSTATS AND HIGHLIGHT SOME INTERESTING NUMBERS https://k8s.devstats.cncf.io/d/12/dashboards?orgId=1&refresh=15m, INCLUDE ANY INTERESTING DATA YOU FIND FOR THE CYCLE>
 
-The CNCF K8s [DevStats](https://k8s.devstats.cncf.io/d/11/companies-contributing-in-repository-groups?orgId=1&var-period=m&var-repogroup_name=All) project aggregates a number of interesting data points related to the velocity of Kubernetes and various sub-projects. 
+The CNCF K8s [DevStats](https://k8s.devstats.cncf.io/d/11/companies-contributing-in-repository-groups?orgId=1&var-period=m&var-repogroup_name=All) project aggregates a number of interesting data points related to the velocity of Kubernetes and various sub-projects.
 This includes everything from individual contributions to the number of companies that are contributing and is an illustration of the depth and breadth of effort that goes into evolving this ecosystem.
 
-In the v1.XX release cycle, which ran for X weeks (START DATE to RELEASE DATE), we saw contributions to Kubernetes from X different companies and X individuals.
+During the v1.XX release cycle, which spanned X weeks from START DATE to RELEASE DATE, Kubernetes received contributions from as many as X different companies and X,XXX individuals.
 
-Source for this data: 
-- [Companies contributing to Kubernetes](https://k8s.devstats.cncf.io/d/11/companies-contributing-in-repository-groups?orgId=1&from=1715032800000&to=1723586399000&var-period=d28&var-repogroup_name=Kubernetes&var-repo_name=kubernetes%2Fkubernetes)
-- [Overall ecosystem contributions](https://k8s.devstats.cncf.io/d/11/companies-contributing-in-repository-groups?orgId=1&from=1715032800000&to=1723586399000&var-period=d28&var-repogroup_name=All&var-repo_name=kubernetes%2Fkubernetes)
+<PIN BOTH SOURCE LINKS TO THE CYCLE'S START AND END TIMESTAMPS. `from` AND `to` ARE UNIX EPOCH TIME IN MILLISECONDS — NOT SECONDS (for example, `1779058800000`). NEVER LEAVE `to=now`, OR THE DASHBOARD WILL STOP MATCHING THE NUMBERS IN THIS PARAGRAPH. REFRESH THE NUMBERS RIGHT BEFORE MERGE — THEY MOVE DURING REVIEW.>
+
+<CHECK THE TWO SOURCE LINKS ACTUALLY DIFFER: THE FIRST USES `var-repogroup_name=Kubernetes`, THE SECOND USES `var-repogroup_name=All`. MAKE SURE NEITHER URL PICKED UP STRAY WHITESPACE (`%20`) WHEN COPIED OUT OF THE DASHBOARD.>
+
+Source for this data:
+- [Companies contributing to Kubernetes](https://k8s.devstats.cncf.io/d/11/companies-contributing-in-repository-groups?orgId=1&from=START_MS&to=END_MS&var-period=d28&var-repogroup_name=Kubernetes&var-repo_name=kubernetes%2Fkubernetes)
+- [Overall ecosystem contributions](https://k8s.devstats.cncf.io/d/11/companies-contributing-in-repository-groups?orgId=1&from=START_MS&to=END_MS&var-period=d28&var-repogroup_name=All&var-repo_name=kubernetes%2Fkubernetes)
 
 By contribution we mean when someone makes a commit, code review, comment, creates an issue or PR, reviews a PR (including blogs and documentation) or comments on issues and PRs.
 
-If you are interested in contributing see our [getting started](https://www.kubernetes.dev/docs/guide/#getting-started) page. 
+If you are interested in contributing, see our [getting started](https://www.kubernetes.dev/docs/guide/#getting-started) page.
 
-### Event Update
-Explore the upcoming Kubernetes events, featuring KubeCon, KCD, and other notable conferences worldwide.
+## Event updates
 
-<THERE WILL BE ALWAYS A KUBECON/CLOUDNATIVECON, PULL EVENTS FROM https://community.cncf.io/events/#/list, GIVE THE LATEST INFORMATION>
+<PULL EVENTS FROM https://community2.cncf.io/events/#/list, GIVE THE LATEST INFORMATION. LIST KUBECONS FIRST, THEN KCDs UNDER A `###` HEADING PER MONTH.>
 
-### Upcoming Release Webinar
+Explore the upcoming KubeCons worldwide:
 
-<RELEASE WEBINARE WILL TAKE PLACE NORMALLY 30 DAYS AFTER RELEASE, ALIGN WITH CNCF TO HIGHLIGHT THE WEBINAR>
+- [KubeCon + CloudNativeCon <REGION>](LINK):
+  Month D–D, YYYY, in City, Country
 
-### Get Involved
-<THIS COMMUNITY LIVES BY ITS GREAT COMMUNITY, GET THEM INVOLVED!>
-The simplest way to get involved with Kubernetes is by joining one of the many [Special Interest Groups](https://github.com/kubernetes/community/blob/master/sig-list.md) (SIGs) that align with your interests. 
-Have something you’d like to broadcast to the Kubernetes community? 
-Share your voice at our weekly [community meeting](https://github.com/kubernetes/community/tree/master/communication), and through the channels below. 
-Thank you for your continued feedback and support.
+Explore the upcoming Kubernetes Community Days (KCDs) taking place for the rest of YYYY:
 
-- Follow us on Bluesky [@Kubernetesio](https://bsky.app/profile/kubernetes.io) for the latest updates
+### Month YYYY
+
+- [KCD <CITY>](LINK):
+  Month D, YYYY, in City, Country
+
+You can find the latest event details at the [CNCF Events Page](https://community2.cncf.io/events/#/list).
+
+## Upcoming release webinar
+
+Join members of the Kubernetes v1.XX Release Team on **DAY, DATE at TIME (UTC)** to learn about the release highlights of this release. For more information and registration, visit the [event page on the CNCF Online Programs site](LINK).
+
+<RELEASE WEBINAR NORMALLY TAKES PLACE 30 DAYS AFTER THE RELEASE; ALIGN WITH CNCF TO HIGHLIGHT IT>
+
+## Get involved
+
+The simplest way to get involved with Kubernetes is by joining one of the many [Special Interest Groups](https://www.kubernetes.dev/community/community-groups/sigs/) (SIGs) that align with your interests.
+
+If you don't know where to start, join our monthly [New Contributor Orientation](https://www.kubernetes.dev/docs/orientation/), where we teach the community how the project is structured and guide you through your first contribution.
+
+Have something you'd like to broadcast to the Kubernetes community? Share your voice through the channels below. Thank you for your continued feedback and support.
+
+- Read more on how to become a [Kubernetes Contributor](https://www.kubernetes.dev/docs/guide/)
+- Read more about what's happening with Kubernetes on our [blog](https://kubernetes.io/blog/)
+- Join us on [Slack](https://slack.k8s.io/)
+- Follow us on [Bluesky](https://bsky.app/profile/kubernetes.io)
+- Follow us on [LinkedIn](https://www.linkedin.com/company/kubernetes/)
+- Follow us on [X](https://x.com/kubernetesio)
 - Join the community discussion on [Discuss](https://discuss.kubernetes.io/)
-- Join the community on [Slack](http://slack.k8s.io/)
-- Post questions (or answer questions) on [Stack Overflow](http://stackoverflow.com/questions/tagged/kubernetes)
-- Share your Kubernetes [story](https://docs.google.com/a/linuxfoundation.org/forms/d/e/1FAIpQLScuI7Ye3VQHQTwBASrgkjQDSS5TP0g3AXfFhwSM9YpHgxRKFA/viewform)
-- Read more about what’s happening with Kubernetes on the [blog](https://kubernetes.io/blog/)
+- Post questions (or answer questions) on [Stack Overflow](https://stackoverflow.com/questions/tagged/kubernetes)
+- Share your [Kubernetes End User Story](https://www.cncf.io/case-studies/)
 - Learn more about the [Kubernetes Release Team](https://github.com/kubernetes/sig-release/tree/master/release-team)
 ```


### PR DESCRIPTION
Aligns the release blog template with the suggestions from: https://github.com/kubernetes/website/pull/56990

cc. @SwathiR03 @kubernetes/release-team @kubernetes/release-team-comms 