### PR TITLE
Add v1.37 branch management learnings to release-engineering handbook

### DIFF
--- a/release-engineering/handbooks/branch-creation.md
+++ b/release-engineering/handbooks/branch-creation.md
@@ -32,7 +32,7 @@ Open a new issue using [this template](https://github.com/kubernetes/sig-release
 
 ### Remove EOL version jobs from test-infra (optional)
 
-Consider removing jobs for versions that are going EOL. This is sometimes done before adding new jobs to avoid overwhelming the Prow cluster.
+Consider removing jobs for versions that are going EOL. **This is not a priority for the post branch creation tasks**, prioritize adding the new release's jobs (see below) first; EOL job removal can happen later and does not need to precede or block that work.
 
 Removing EOL jobs involves different steps, including deleting old configs from `config/jobs/kubernetes/sig-release/release-branch-jobs/` e.g. 1.29 EOL jobs removed in [this PR](https://github.com/kubernetes/test-infra/pull/34672).
 There could also be some other jobs living outside `config/jobs/kubernetes/sig-release/release-branch-jobs` that also needs to be removed.
@@ -53,7 +53,7 @@ You should also remove the unused EOL jobs from the `kubekins-e2e-v2/variants.ya
 ```
 
 > [!NOTE]
-This step may alternatively be performed as part of a patch release process. It's mandatory to consult with the release engineering team regarding the timing of this step.
+This step may alternatively be performed as part of a patch release process, or deferred until after the rest of the post branch creation tasks are done. It's mandatory to consult with the release engineering team regarding the timing of this step.
 
 ### Update milestone applier rules and check milestone requirements
 

--- a/release-engineering/handbooks/release-cuts.md
+++ b/release-engineering/handbooks/release-cuts.md
@@ -84,6 +84,9 @@ You can find the complete list of release signal team members at this link (subs
 Ensure that there are no patch releases in progress, coordinating with @release-managers.
 These are typically scheduled on different days of the week, so there is usually no need to plan around them, but since they can sometimes overlap with other release activities, it's good to double-check.
 
+> [!NOTE]
+Before starting the cut, check whether a Go version update is in progress or planned, by looking for an open tracking issue in `kubernetes/release` (see [Signaling intent](go-updates.md#signaling-intent)) and coordinating with @kubernetes/release-engineering. Starting a cut while a Go update is mid-flight can cause job failures.
+
 ### Install latest software (every time)
 
 Begin by updating to the latest package versions. This helps reduce failure points in the build process. The following packages are needed:
@@ -305,6 +308,9 @@ krel testgridshot --branch 1.xx
 Post the comment generated in the **GitHub issue**.
 
 This comment contains a current snapshot of the test results for the target branch, if there is any error you should stop the release process and inform #release-management on Slack. Before proceeding the failing tests need to be either fixed or marked as non-release blocking.
+
+> [!IMPORTANT]
+> The default `krel testgridshot` targets `master`, which is only correct up to and including `rc.0`. For `rc.1` and later, and for stable/patch releases, the release branch already exists, so pass `--branch 1.xx` to screenshot testgrid **on the release branch** instead of master.
 
 ## 4. Check publishing-bot status
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this:
/kind documentation
<!--
Add one of the following kinds:
/kind cleanup
/kind documentation
/kind feature
/kind design
-->

#### What this PR does / why we need it:
Add v1.37 branch management learnings to release-engineering handbook

#### Which issue(s) this PR fixes:
Handbook updates part of https://github.com/kubernetes/sig-release/issues/3026
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #
or
None
-->

#### Special notes for your reviewer:
@xmudrii I'm not entirely sure about all of these, please feel free to suggest changes if the additions are not accurate